### PR TITLE
fix: eliminate race condition in event handler state tracking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,9 @@ async fn run_app(terminal: &mut DefaultTerminal) -> Result<()> {
     let mut model = Model::default();
     let (tx, mut rx) = mpsc::unbounded_channel::<Message>();
 
+    // Create mode channel for syncing state with event handler
+    let (mode_tx, mut mode_rx) = mpsc::unbounded_channel::<AppMode>();
+
     // Spawn event handling task
     let event_tx = tx.clone();
     tokio::spawn(async move {
@@ -44,16 +47,12 @@ async fn run_app(terminal: &mut DefaultTerminal) -> Result<()> {
         let mut current_mode = AppMode::Selection;
         loop {
             tokio::select! {
+                // Receive mode updates from main loop (single source of truth)
+                Some(mode) = mode_rx.recv() => {
+                    current_mode = mode;
+                }
                 Some(Ok(event)) = reader.next() => {
                     if let Some(msg) = handle_event_simple(current_mode, event) {
-                        // Update local mode tracking based on the message we're sending
-                        match &msg {
-                            Message::SelectItem => current_mode = AppMode::Input,
-                            Message::ExitInputMode | Message::StreamComplete => current_mode = AppMode::Selection,
-                            Message::SubmitInput => current_mode = AppMode::Streaming,
-                            Message::Error(_) => {}, // Stay in current mode (should be Streaming)
-                            _ => {}
-                        }
                         let _ = event_tx.send(msg);
                     }
                 }
@@ -78,6 +77,8 @@ async fn run_app(terminal: &mut DefaultTerminal) -> Result<()> {
                             let backend = get_backend(&model);
                             let stream_tx = tx.clone();
                             model.update(msg);
+                            // Send updated mode to event handler
+                            let _ = mode_tx.send(model.current_mode);
 
                             tokio::spawn(async move {
                                 if let Err(e) = spawn_and_stream(backend, prompt, stream_tx).await {
@@ -87,7 +88,11 @@ async fn run_app(terminal: &mut DefaultTerminal) -> Result<()> {
                             });
                         }
                     }
-                    _ => model.update(msg),
+                    _ => {
+                        model.update(msg);
+                        // Send updated mode to event handler after every state change
+                        let _ = mode_tx.send(model.current_mode);
+                    }
                 }
             }
 

--- a/tests/state_machine_test.rs
+++ b/tests/state_machine_test.rs
@@ -37,3 +37,31 @@ fn test_stream_chunk_accumulation() {
     assert_eq!(model.response_text[0], "Hello ");
     assert_eq!(model.response_text[1], "World");
 }
+
+#[test]
+fn test_post_stream_state_handling() {
+    let mut model = Model::default();
+
+    // Simulate complete user flow
+    model.update(Message::SelectItem);
+    assert_eq!(model.current_mode, AppMode::Input);
+
+    model.update(Message::SubmitInput);
+    assert_eq!(model.current_mode, AppMode::Streaming);
+
+    // Simulate receiving stream chunks
+    model.update(Message::StreamChunk("test response".to_string()));
+
+    // Stream completes - should return to Selection
+    model.update(Message::StreamComplete);
+    assert_eq!(model.current_mode, AppMode::Selection);
+
+    // Verify we can interact again - this verifies the state machine
+    // The actual bug is in the event handler, not the Model
+    model.update(Message::NextItem);
+    assert_eq!(model.current_mode, AppMode::Selection);
+
+    // Verify we can select again
+    model.update(Message::SelectItem);
+    assert_eq!(model.current_mode, AppMode::Input);
+}


### PR DESCRIPTION
## Summary

Fixed a race condition where the event handler task maintained its own local copy of `current_mode` that would become desynchronized with the actual Model state.

- Event handler now receives mode updates via dedicated channel from main loop
- Establishes `Model.current_mode` as single source of truth
- Prevents key events from being filtered based on stale state

## What Was Broken

After submitting a prompt and receiving a streamed response:
- User would return to the Selection screen
- Arrow keys and other input would not work
- Only 'q' for quit would respond

## Root Cause

The event handler's local `current_mode` variable would update immediately when messages were sent, but the actual `Model.current_mode` wouldn't update until the message was processed in the main loop. This race condition meant the event handler was filtering key events based on outdated state.

## The Fix

Created a bidirectional communication pattern:
- Added `mode_tx`/`mode_rx` channel for mode synchronization
- Main loop sends current mode to event handler after each state change
- Event handler updates its local mode only from the channel
- No more local state inference from messages

## Test Plan

- [x] Added `test_post_stream_state_handling` test to verify state transitions
- [x] All existing tests pass (5 tests)
- [x] Manual testing: Selected agent → submitted prompt → stream completed → verified arrow keys work correctly
- [x] Cargo fmt and clippy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>