### PR TITLE
fix: remove duplicate imports and unused variable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use color_eyre::Result;
 use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyEventKind};
 use crossterm::execute;
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
-use crossterm::{cursor::MoveTo, execute};
 use futures::StreamExt;
 use nori_cli::app::{AppMode, InstallChoice, Message, Model};
 use nori_cli::backends::{self, AgentBackend, claude::ClaudeBackend, codex::CodexBackend};
@@ -16,9 +15,6 @@ use tokio::time::{Duration, interval};
 #[tokio::main]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-
-    // Get starting cursor position before creating viewport
-    let viewport_start_row = crossterm::cursor::position()?.1;
 
     // Setup terminal with inline viewport (8 lines at bottom for input/instructions)
     enable_raw_mode()?;


### PR DESCRIPTION
## Summary

- Remove duplicate import of `execute` macro (was imported on both line 3 and line 5)
- Remove unused `MoveTo` import leftover from commit 8d6e636
- Remove unused `viewport_start_row` variable leftover from refactoring in commit fec6099

## Root Cause

The duplicate `execute` import was introduced in commit fec6099 when adding the import on line 3, but line 5 already had it from commit 8d6e636.

The `viewport_start_row` variable was added in commit 8d6e636 for absolute cursor positioning, but its usage was removed in commit fec6099 when switching to relative positioning with `MoveToColumn`.

## Test Plan

- [x] `cargo build` compiles with 0 errors, 0 warnings
- [x] All 38 tests pass (`cargo test`)
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>