### PR TITLE
Add interactive example for selection component

### DIFF
--- a/tui-components/Cargo.toml
+++ b/tui-components/Cargo.toml
@@ -19,6 +19,10 @@ path = "tests/key_hint_snapshots.rs"
 name = "shimmer"
 path = "tests/shimmer_snapshots.rs"
 
+[[example]]
+name = "selection"
+path = "tests/selection_snapshots.rs"
+
 [dependencies]
 ratatui = { version = "0.29", features = ["unstable-widget-ref"] }
 crossterm = { version = "0.28", features = ["bracketed-paste"] }

--- a/tui-components/README.md
+++ b/tui-components/README.md
@@ -85,23 +85,51 @@ Bash syntax highlighting using tree-sitter. Converts bash scripts into styled Ra
 
 ## Examples
 
-### TextArea Example
+Interactive examples are available for several components. Each example demonstrates multiple configurations side-by-side:
 
-An interactive example demonstrating the TextArea widget is available:
+### TextArea Example
 
 ```bash
 cargo run --example textarea
 ```
 
-This example displays four TextArea configurations simultaneously:
+Displays four TextArea configurations simultaneously:
 - Default with placeholder text
 - Custom styling with colored text
 - Pre-filled multiline content
 - Narrow width demonstrating text wrapping
 
-All TextAreas receive the same keyboard input, allowing you to compare behaviors across configurations. Press `Esc` or `Ctrl+C` to exit.
+### Selection Example
 
-For other components, comprehensive usage examples are included in the rustdoc.
+```bash
+cargo run --example selection
+```
+
+Demonstrates the SelectionList widget with four configurations:
+- Basic selection with title and footer
+- Selection with search filtering enabled
+- Selection with subtitle
+- Long list (12 items) showing scrolling behavior
+
+### KeyHint Example
+
+```bash
+cargo run --example key_hint
+```
+
+Shows platform-aware keyboard shortcut formatting for various key combinations.
+
+### Shimmer Example
+
+```bash
+cargo run --example shimmer
+```
+
+Animated text effects with different color palettes and animation modes.
+
+---
+
+All examples receive keyboard input simultaneously for easy comparison. Press `Esc` or `Ctrl+C` to exit. For additional usage examples, see the rustdoc.
 
 ## Documentation
 

--- a/tui-components/tests/docs.md
+++ b/tui-components/tests/docs.md
@@ -1,0 +1,105 @@
+# Noridoc: TUI Components Tests
+
+Path: @/tui-components/tests
+
+### Overview
+
+- Snapshot tests for all TUI components using the `insta` crate
+- Interactive examples demonstrating component behavior, co-located with tests
+- Visual regression testing with text-based snapshots
+
+### How it fits into the larger codebase
+
+- Tests live in dedicated `tests/` directory, separate from `src/` implementation code
+- Each `*_snapshots.rs` file contains both snapshot tests AND a runnable interactive example
+- Interactive examples are registered in `@/tui-components/Cargo.toml` as `[[example]]` entries
+- Snapshots are stored in `tests/snapshots/` subdirectory, managed by `insta` crate
+- Examples use the same ratatui/crossterm APIs as production code, serving as integration tests
+- Components being tested are imported from `@/tui-components/src/`
+
+### Core Implementation
+
+**Dual-Purpose Test Files**
+- Each `*_snapshots.rs` file has two distinct sections separated by `#[cfg(test)]` guards:
+  - Interactive example code (no guard, always compiled)
+  - Test code (behind `#[cfg(test)]`, only compiled during testing)
+- Examples include: `textarea`, `key_hint`, `shimmer`, `selection`
+
+**Interactive Example Pattern**
+- Entry point: `main()` function follows standard pattern:
+  1. `color_eyre::install()?` - Error handling setup
+  2. `ratatui::init()` - Terminal initialization
+  3. `app.run(&mut terminal)` - Event loop
+  4. `ratatui::restore()` - Terminal cleanup
+- `App` struct: Holds multiple widget configurations to demonstrate different features side-by-side
+- `App::new()`: Constructs example configurations (basic, styled, with options, etc.)
+- `App::run()`: Event loop handling keyboard input (Esc/Ctrl+C to exit, distributes input to widgets)
+- `App::draw()`: Renders all widget configurations with labels using ratatui Layout system
+- All widgets receive input simultaneously - no focus management needed for examples
+
+**Snapshot Testing Pattern**
+- Helper functions like `render_to_string()` or `render_list_to_string()` convert widgets to text
+- Each test renders a widget configuration and compares against saved snapshot
+- Snapshots capture exact terminal output including Unicode, colors, borders
+- Uses `assert_snapshot!()` macro from `insta` crate
+
+**Selection Component Example** (`selection_snapshots.rs`)
+- `ExampleData`: Simple struct demonstrating generic data type for `SelectionList<T>`
+- Four `SelectionList` configurations demonstrated:
+  1. Basic selection with title and footer
+  2. Selection with search enabled
+  3. Selection with subtitle
+  4. Long list (12 items) demonstrating scrolling behavior (MAX_POPUP_ROWS=8)
+- Status line shows last selection event from any list
+- Snapshot tests cover: basic render, with search, with subtitle, long list scrolling
+
+**TextArea Example** (`textarea_snapshots.rs`)
+- Four TextArea configurations: default with placeholder, custom styling, pre-filled content, narrow width for wrapping
+- All textareas receive same input to compare behaviors
+
+**Shimmer Example** (`shimmer_snapshots.rs`)
+- Demonstrates animation patterns: fixed 30 FPS vs on-keypress animation
+- Multiple color palettes: basic, blue, green
+- Unicode text handling
+
+**KeyHint Example** (`key_hint_snapshots.rs`)
+- Demonstrates platform-aware keyboard shortcut display
+- Shows plain keys, control keys, alt keys, shift keys, arrow keys
+
+### Things to Know
+
+**Co-location Strategy**
+- Tests and examples are intentionally co-located in same file
+- Avoids duplication of setup code and widget configuration logic
+- Examples serve as both documentation AND integration tests
+- All examples are runnable via `cargo run --example <name>`
+
+**No Focus Management in Examples**
+- Interactive examples distribute keyboard input to ALL widgets simultaneously
+- Simplifies example code - no need for focus tracking state
+- Works well for demonstration purposes where seeing all variants respond is useful
+- Production usage would typically have focus management
+
+**Snapshot File Organization**
+- Snapshots stored in `tests/snapshots/` directory
+- Named pattern: `<test_module_name>__<test_function_name>.snap`
+- `insta` crate handles snapshot creation/comparison automatically
+- Review snapshots with `cargo insta review` after changes
+
+**Testing Anti-Pattern Avoided**
+- Tests verify actual widget rendering output, not mocked behavior
+- Each test exercises real component code path through `render()` methods
+- Snapshot approach catches visual regressions that unit tests might miss
+
+**MAX_POPUP_ROWS Constant**
+- Selection component limits visible items to 8 rows (MAX_POPUP_ROWS)
+- Long list example (12 items) demonstrates scrolling behavior
+- Scrolling automatically tracks current selection
+
+**Event Handling**
+- Examples use crossterm's `Event::Key` for keyboard input
+- Standard exit pattern: `Esc` or `Ctrl+C` to quit
+- Components return event enums (e.g., `SelectionListEvent::Selected`, `SelectionListEvent::Cancelled`)
+- Selection example tracks and displays last event in status line
+
+Created and maintained by Nori.

--- a/tui-components/tests/selection_snapshots.rs
+++ b/tui-components/tests/selection_snapshots.rs
@@ -1,10 +1,26 @@
 //! Snapshot tests for selection components
 
-use insta::assert_snapshot;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use tui_components::render::Renderable;
 use tui_components::selection::selection_option_row;
+
+// Imports for the interactive example
+use color_eyre::Result;
+use crossterm::event::{self, Event, KeyCode as EventKeyCode, KeyModifiers};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style},
+    widgets::Paragraph,
+};
+use tui_components::selection::{
+    SelectionItem, SelectionList, SelectionListConfig, SelectionListEvent, standard_popup_hint_line,
+};
+
+// Test imports
+#[cfg(test)]
+use insta::assert_snapshot;
 
 fn render_to_string(renderable: &dyn Renderable, width: u16) -> String {
     let height = renderable.desired_height(width);
@@ -78,16 +94,270 @@ fn selection_row_unicode_content() {
 
 // SelectionList widget tests
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use tui_components::selection::{
-    SelectionItem, SelectionList, SelectionListConfig, SelectionListEvent, standard_popup_hint_line,
-};
+#[cfg(test)]
+use crossterm::event::{KeyCode, KeyEvent};
 
+// Helper function to render SelectionList to string for snapshot testing
+#[cfg(test)]
+fn render_list_to_string<T: Clone>(list: &SelectionList<T>, width: u16) -> String {
+    let height = list.desired_height(width);
+    let area = Rect::new(0, 0, width, height);
+    let mut buf = Buffer::empty(area);
+    list.render(area, &mut buf);
+
+    let lines: Vec<String> = (0..area.height)
+        .map(|row| {
+            let mut line = String::new();
+            for col in 0..area.width {
+                let symbol = buf[(area.x + col, area.y + row)].symbol();
+                if symbol.is_empty() {
+                    line.push(' ');
+                } else {
+                    line.push_str(symbol);
+                }
+            }
+            line
+        })
+        .collect();
+    lines.join("\n")
+}
+
+// Interactive example application
+struct App {
+    lists: Vec<(String, SelectionList<ExampleData>)>,
+    last_event: String,
+}
+
+#[derive(Clone)]
+struct ExampleData {
+    name: String,
+}
+
+impl App {
+    fn new() -> Self {
+        let mut lists = Vec::new();
+
+        // 1. Basic selection with title and footer
+        let config = SelectionListConfig::new()
+            .with_title("Basic Selection")
+            .with_footer_hint(standard_popup_hint_line());
+        let items = vec![
+            SelectionItem {
+                data: ExampleData {
+                    name: "Option A".to_string(),
+                },
+                name: "Option A".to_string(),
+                description: Some("First option".to_string()),
+                selected_description: None,
+                is_current: true,
+                display_shortcut: None,
+                search_value: Some("option a".to_string()),
+            },
+            SelectionItem {
+                data: ExampleData {
+                    name: "Option B".to_string(),
+                },
+                name: "Option B".to_string(),
+                description: Some("Second option".to_string()),
+                selected_description: None,
+                is_current: false,
+                display_shortcut: None,
+                search_value: Some("option b".to_string()),
+            },
+        ];
+        lists.push((
+            "Basic".to_string(),
+            SelectionList::new(config, items, Box::new(())),
+        ));
+
+        // 2. With search enabled
+        let config = SelectionListConfig::new()
+            .with_title("With Search")
+            .with_search(Some("Type to filter...".to_string()))
+            .with_footer_hint(standard_popup_hint_line());
+        let items = vec![
+            SelectionItem {
+                data: ExampleData {
+                    name: "Apple".to_string(),
+                },
+                name: "Apple".to_string(),
+                description: Some("A fruit".to_string()),
+                selected_description: None,
+                is_current: false,
+                display_shortcut: None,
+                search_value: Some("apple fruit".to_string()),
+            },
+            SelectionItem {
+                data: ExampleData {
+                    name: "Banana".to_string(),
+                },
+                name: "Banana".to_string(),
+                description: Some("Another fruit".to_string()),
+                selected_description: None,
+                is_current: false,
+                display_shortcut: None,
+                search_value: Some("banana fruit".to_string()),
+            },
+            SelectionItem {
+                data: ExampleData {
+                    name: "Carrot".to_string(),
+                },
+                name: "Carrot".to_string(),
+                description: Some("A vegetable".to_string()),
+                selected_description: None,
+                is_current: false,
+                display_shortcut: None,
+                search_value: Some("carrot vegetable".to_string()),
+            },
+        ];
+        lists.push((
+            "Searchable".to_string(),
+            SelectionList::new(config, items, Box::new(())),
+        ));
+
+        // 3. With subtitle
+        let config = SelectionListConfig::new()
+            .with_title("With Subtitle")
+            .with_subtitle("This is a helpful subtitle")
+            .with_footer_hint(standard_popup_hint_line());
+        let items = vec![SelectionItem {
+            data: ExampleData {
+                name: "First".to_string(),
+            },
+            name: "First".to_string(),
+            description: Some("First item".to_string()),
+            selected_description: None,
+            is_current: false,
+            display_shortcut: None,
+            search_value: Some("first".to_string()),
+        }];
+        lists.push((
+            "Subtitle".to_string(),
+            SelectionList::new(config, items, Box::new(())),
+        ));
+
+        // 4. Long list for scrolling
+        let config = SelectionListConfig::new()
+            .with_title("Scrolling List")
+            .with_footer_hint(standard_popup_hint_line());
+        let mut items = Vec::new();
+        for i in 0..12 {
+            items.push(SelectionItem {
+                data: ExampleData {
+                    name: format!("Item {}", i + 1),
+                },
+                name: format!("Item {}", i + 1),
+                description: Some(format!("Description {}", i + 1)),
+                selected_description: None,
+                is_current: i == 0,
+                display_shortcut: None,
+                search_value: Some(format!("item {}", i + 1)),
+            });
+        }
+        lists.push((
+            "Long List".to_string(),
+            SelectionList::new(config, items, Box::new(())),
+        ));
+
+        Self {
+            lists,
+            last_event: "Press keys to interact...".to_string(),
+        }
+    }
+
+    fn run(&mut self, terminal: &mut ratatui::DefaultTerminal) -> Result<()> {
+        loop {
+            terminal.draw(|frame| self.draw(frame))?;
+
+            if let Event::Key(key) = event::read()? {
+                // Exit on Esc or Ctrl+C
+                if key.code == EventKeyCode::Esc
+                    || (key.code == EventKeyCode::Char('c')
+                        && key.modifiers.contains(KeyModifiers::CONTROL))
+                {
+                    break;
+                }
+
+                // Distribute input to all SelectionLists
+                for (label, list) in &mut self.lists {
+                    let event = list.handle_key_event(key);
+                    match event {
+                        SelectionListEvent::Selected(idx) => {
+                            self.last_event = format!("[{}] Selected item at index {}", label, idx);
+                        }
+                        SelectionListEvent::Cancelled => {
+                            self.last_event = format!("[{}] Cancelled", label);
+                        }
+                        SelectionListEvent::None => {}
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn draw(&mut self, frame: &mut Frame) {
+        let main_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(2), // Status line
+                Constraint::Min(0),    // Lists
+            ])
+            .split(frame.area());
+
+        // Render status line
+        let status = Paragraph::new(format!("Last event: {}", self.last_event))
+            .style(Style::default().fg(Color::Cyan));
+        frame.render_widget(status, main_layout[0]);
+
+        // Calculate heights for each list
+        let num_lists = self.lists.len();
+        let constraints = vec![Constraint::Min(0); num_lists];
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(constraints)
+            .split(main_layout[1]);
+
+        // Render each SelectionList with its label
+        for (i, (label, list)) in self.lists.iter_mut().enumerate() {
+            if i < chunks.len() {
+                let area = chunks[i];
+
+                // Split area: 1 line for label, rest for list
+                let inner_layout = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Length(1), Constraint::Min(0)])
+                    .split(area);
+
+                // Render label
+                let label_text = Paragraph::new(format!("[ {} ]", label))
+                    .style(Style::default().fg(Color::Yellow));
+                frame.render_widget(label_text, inner_layout[0]);
+
+                // Render list
+                list.render(inner_layout[1], frame.buffer_mut());
+            }
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    let mut terminal = ratatui::init();
+    let mut app = App::new();
+    let result = app.run(&mut terminal);
+    ratatui::restore();
+    result
+}
+
+#[cfg(test)]
 #[derive(Clone)]
 struct TestData {
     id: u32,
 }
 
+#[cfg(test)]
 fn make_test_items() -> Vec<SelectionItem<TestData>> {
     vec![
         SelectionItem {
@@ -202,6 +472,63 @@ fn selection_list_search_filtering() {
     list.set_search_query("".to_string());
     // When clearing search, the first matching item with is_current might be selected
     assert!(list.selected_index().is_some()); // Just verify something is selected
+}
+
+#[test]
+fn test_selection_list_basic_render() {
+    let config = SelectionListConfig::new()
+        .with_title("Select Approval Mode")
+        .with_footer_hint(standard_popup_hint_line());
+    let items = make_test_items();
+    let list = SelectionList::new(config, items, Box::new(()));
+    let output = render_list_to_string(&list, 48);
+    assert_snapshot!(output);
+}
+
+#[test]
+fn test_selection_list_with_search_render() {
+    let config = SelectionListConfig::new()
+        .with_title("Select Approval Mode")
+        .with_search(Some("Type to search...".to_string()))
+        .with_footer_hint(standard_popup_hint_line());
+    let items = make_test_items();
+    let list = SelectionList::new(config, items, Box::new(()));
+    let output = render_list_to_string(&list, 48);
+    assert_snapshot!(output);
+}
+
+#[test]
+fn test_selection_list_with_subtitle_render() {
+    let config = SelectionListConfig::new()
+        .with_title("Select Approval Mode")
+        .with_subtitle("Switch between Codex approval presets")
+        .with_footer_hint(standard_popup_hint_line());
+    let items = make_test_items();
+    let list = SelectionList::new(config, items, Box::new(()));
+    let output = render_list_to_string(&list, 48);
+    assert_snapshot!(output);
+}
+
+#[test]
+fn test_selection_list_long_list_render() {
+    let config = SelectionListConfig::new()
+        .with_title("Select Option")
+        .with_footer_hint(standard_popup_hint_line());
+    let mut items = Vec::new();
+    for i in 0..12 {
+        items.push(SelectionItem {
+            data: TestData { id: i },
+            name: format!("Option {}", i + 1),
+            description: Some(format!("Description for option {}", i + 1)),
+            selected_description: None,
+            is_current: i == 0,
+            display_shortcut: None,
+            search_value: Some(format!("option {}", i + 1)),
+        });
+    }
+    let list = SelectionList::new(config, items, Box::new(()));
+    let output = render_list_to_string(&list, 48);
+    assert_snapshot!(output);
 }
 
 #[test]

--- a/tui-components/tests/snapshots/selection_snapshots__selection_list_basic_render.snap
+++ b/tui-components/tests/snapshots/selection_snapshots__selection_list_basic_render.snap
@@ -1,0 +1,12 @@
+---
+source: tui-components/tests/selection_snapshots.rs
+assertion_line: 239
+expression: output
+---
+                                                
+  Select Approval Mode                          
+                                                
+› 1. Read Only (current)  Codex can read files  
+  2. Full Access          Codex can edit files  
+                                                
+  Press enter to confirm or esc to go back

--- a/tui-components/tests/snapshots/selection_snapshots__selection_list_long_list_render.snap
+++ b/tui-components/tests/snapshots/selection_snapshots__selection_list_long_list_render.snap
@@ -1,0 +1,26 @@
+---
+source: tui-components/tests/selection_snapshots.rs
+assertion_line: 285
+expression: output
+---
+                                                
+  Select Option                                 
+                                                
+› 1. Option 1 (current)  Description for        
+                         option 1               
+  2. Option 2            Description for        
+                         option 2               
+  3. Option 3            Description for        
+                         option 3               
+  4. Option 4            Description for        
+                         option 4               
+  5. Option 5            Description for        
+                         option 5               
+  6. Option 6            Description for        
+                         option 6               
+  7. Option 7            Description for        
+                         option 7               
+  8. Option 8            Description for        
+                         option 8               
+                                                
+  Press enter to confirm or esc to go back

--- a/tui-components/tests/snapshots/selection_snapshots__selection_list_with_search_render.snap
+++ b/tui-components/tests/snapshots/selection_snapshots__selection_list_with_search_render.snap
@@ -1,0 +1,13 @@
+---
+source: tui-components/tests/selection_snapshots.rs
+assertion_line: 251
+expression: output
+---
+                                                
+  Select Approval Mode                          
+                                                
+  Type to search...                             
+› Read Only (current)  Codex can read files     
+  Full Access          Codex can edit files     
+                                                
+  Press enter to confirm or esc to go back

--- a/tui-components/tests/snapshots/selection_snapshots__selection_list_with_subtitle_render.snap
+++ b/tui-components/tests/snapshots/selection_snapshots__selection_list_with_subtitle_render.snap
@@ -1,0 +1,13 @@
+---
+source: tui-components/tests/selection_snapshots.rs
+assertion_line: 263
+expression: output
+---
+                                                
+  Select Approval Mode                          
+  Switch between Codex approval presets         
+                                                
+› 1. Read Only (current)  Codex can read files  
+  2. Full Access          Codex can edit files  
+                                                
+  Press enter to confirm or esc to go back


### PR DESCRIPTION
## Summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- Added interactive example for the selection component, following the established pattern of co-located examples in `tests/*_snapshots.rs` files
- Four `SelectionList` configurations demonstrated side-by-side: basic, with search, with subtitle, and long list (scrolling)
- Status line at top shows last selection event from any list
- All lists receive keyboard input simultaneously (no focus management)
- Added 4 new snapshot tests for visual regression testing of `SelectionList` rendering

## Test Plan

- [x] All 101 tests pass (including 4 new snapshot tests)
- [x] Example builds successfully with `cargo build --example selection`
- [x] Example runs with `cargo run --example selection` demonstrating:
  - Keyboard navigation (Up/Down arrows)
  - Search filtering (type in searchable list)
  - Selection events (Enter key shows event in status line)
  - Scrolling behavior (long list with 12 items, MAX_POPUP_ROWS=8)
  - Exit with Esc or Ctrl+C
- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings with `cargo clippy -p tui-components`
- [x] Documentation updated in `tests/docs.md` and `README.md`

Share Claude Code with your team: https://claude.com/claude-code