### PR TITLE
refactor: Replace tui-textarea with internal tui-components implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,7 +945,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tui-components",
- "tui-textarea",
  "tuicore",
  "unicode-width 0.2.0",
  "which",
@@ -1797,17 +1796,6 @@ dependencies = [
  "tree-sitter-highlight",
  "unicode-segmentation",
  "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "tui-textarea"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
-dependencies = [
- "crossterm",
- "ratatui",
- "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ tokio-stream = "0.1"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tui-textarea = "0.7"
 async-trait = "0.1"
 async-stream = "0.3"
 which = "7.0"

--- a/docs.md
+++ b/docs.md
@@ -65,10 +65,9 @@ Alt+A overlays agent selector (60% width, 40% height centered)
 - tokio (full features): Async runtime for subprocess management and concurrent I/O
 - tokio-util: Provides CancellationToken for cooperative cancellation
 - crossterm 0.28.1 (event-stream feature): Terminal manipulation and async event handling
-- tui-textarea 0.7: Multi-line text input widget
 - serde + serde_json: JSONL parsing
 - color-eyre: Error reporting
-- tui-components (path dependency): Reusable TUI components library, provides Shimmer loading animation widget
+- tui-components (path dependency): Reusable TUI components library, provides Shimmer loading animation widget and TextArea input widget
 
 ### Things to Know
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,9 +3,8 @@
 use crate::backends;
 use crate::backends::AgentBackend;
 use crate::conversation::ConversationEvent;
-use ratatui::style::Style;
 use ratatui::widgets::ListState;
-use tui_textarea::TextArea;
+use tui_components::textarea::{TextArea, TextAreaConfig};
 
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
 pub enum AppMode {
@@ -102,7 +101,7 @@ pub struct Model {
     pub list_state: ListState,
     pub agents: Vec<String>,
     pub backend_availability: Vec<bool>,
-    pub textarea: TextArea<'static>,
+    pub textarea: TextArea,
     pub response_events: Vec<ConversationEvent>,
     pub selected_agent_index: Option<usize>,
     pub session_id: Option<String>,
@@ -220,7 +219,7 @@ impl Model {
             Message::KeyPress(key) => {
                 // Only handle text input when overlay is NOT open
                 if !self.show_agent_router {
-                    self.textarea.input(key);
+                    self.textarea.handle_key(key);
                     // Clear Ctrl-C timer when user types (resets the double-press window)
                     self.last_ctrl_c_time = None;
                     // Clear any error/hint messages when user starts typing
@@ -230,7 +229,7 @@ impl Model {
 
             Message::SubmitInput => {
                 // Capture user message and transition to streaming mode
-                let user_text = self.textarea.lines().join("\n");
+                let user_text = self.textarea.text().to_string();
                 if !user_text.trim().is_empty() {
                     // Clear textarea immediately after capturing text
                     self.textarea = create_textarea();
@@ -408,9 +407,10 @@ impl Model {
                 {
                     // Replace textarea content with selected command
                     self.textarea = {
-                        let mut textarea = TextArea::from([format!("/{selected_cmd}")]);
-                        textarea.set_cursor_line_style(Style::default());
-                        textarea.move_cursor(tui_textarea::CursorMove::End);
+                        let mut textarea = TextArea::new(TextAreaConfig::default());
+                        let text = format!("/{selected_cmd}");
+                        textarea.set_text(&text);
+                        textarea.set_cursor(text.len());
                         textarea
                     };
                 }
@@ -430,8 +430,6 @@ impl Model {
     }
 }
 
-fn create_textarea() -> TextArea<'static> {
-    let mut textarea = TextArea::default();
-    textarea.set_cursor_line_style(Style::default());
-    textarea
+fn create_textarea() -> TextArea {
+    TextArea::new(TextAreaConfig::default())
 }

--- a/src/docs.md
+++ b/src/docs.md
@@ -40,7 +40,7 @@ pub mod ui;           // Rendering functions for each mode
 - SubmitInput handler (@/src/main.rs:113-188): For regular prompts (non-slash-commands), renders UserMessage to scrollback BEFORE backend availability check, captures textarea content, clears textarea immediately (before streaming begins), adds UserMessage to history, transitions to Streaming mode
 - CancelStream handler: Calls token.cancel(), transitions to Selection mode, appends StreamCancelled event to history (textarea already cleared by SubmitInput)
 - ClearTextarea handler: Implements two-stage Ctrl-C keyboard interrupt - first press clears textarea and shows hint, second press within 2-second timeout signals quit by clearing timestamp (detected in main loop via Some → None transition)
-- `create_textarea()` helper (@/src/app.rs:359-363): Factory function that creates TextArea instances with consistent styling - sets `cursor_line_style` to `Style::default()` to remove the default underline from the cursor line while preserving cursor visibility
+- `create_textarea()` helper (@/src/app.rs:433-435): Factory function that creates TextArea instances with default configuration using `TextArea::new(TextAreaConfig::default())`
 
 **UI Rendering** (@/src/ui.rs):
 - `render()`: Routes to appropriate fullscreen renderer based on state flags - install prompt takes priority (blocking action), then agent router, then normal chat view
@@ -189,7 +189,9 @@ Cancellation Path
 
 **Component Library Integration** (@/Cargo.toml, @/src/ui.rs, @/src/app.rs, @/src/main.rs):
 - nori-cli depends on tui-components as a path dependency (./tui-components)
-- **Conditional rendering approach**: `use_codex_components: bool` flag in Model (defaults to true) controls whether to use Shimmer component or legacy spinner
+- **TextArea component**: Uses `tui_components::textarea::TextArea` for multi-line text input - replaced external `tui-textarea` crate to consolidate dependencies within tui-components library
+- **TextArea API**: Created via `TextArea::new(TextAreaConfig::default())`, handles key events via `.handle_key(key)`, exposes text via `.text()` returning `&str`, supports `.is_empty()` check, and cursor positioning via `.set_cursor(pos)`
+- **Shimmer component**: Conditional rendering approach using `use_codex_components: bool` flag in Model (defaults to true) to toggle between Shimmer component and legacy spinner
 - **Shimmer component path** (when `use_codex_components = true`): Shimmer instantiated on-demand during render (`Shimmer::new()`) with time-based animation using `Instant::now()` internally - no Model state tracking required
 - **Legacy spinner path** (when `use_codex_components = false`): Uses frame-based animation with `loading_frame: usize` counter in Model, incremented on each render tick in main.rs event loop (lines 374-377), cycles through Braille spinner frames using modulo
 - **Frame increment gating** (@/src/main.rs:374-377): Frame counter only increments when `current_mode == AppMode::Streaming && !use_codex_components`, ensuring frame counter doesn't advance when using Shimmer
@@ -202,18 +204,16 @@ Cancellation Path
 - All UI modes (chat, agent selection, install prompt) use Constraint::Min() for flexible sections that adapt to available viewport height
 - Text wrapping enabled on install prompt message to handle varying viewport widths without manual text size management
 
-**TextArea Styling Pattern** (@/src/app.rs, @/src/main.rs):
-- All TextArea instances created with `cursor_line_style` set to `Style::default()` to remove underline from cursor line
-- The tui-textarea library applies underline styling to the cursor line by default - this pattern removes that styling while keeping cursor itself visible (reversed colors)
-- TextArea creation happens in 6 places: Model::default() initialization, 4 locations in Model::update() (SubmitInput, two ClearTextarea branches, AutocompleteSelect), and 1 location in main.rs (slash command execution)
-- `create_textarea()` helper function in @/src/app.rs:359-363 provides DRY pattern for consistent styling across most creation sites
-- AutocompleteSelect (@/src/app.rs:336-341) and slash command clearing (@/src/main.rs:167-171) use inline styling because they need additional operations (TextArea::from() with content, move_cursor()) that don't fit the helper pattern
-- All inline creations follow same pattern: create TextArea, call `set_cursor_line_style(Style::default())`, perform other operations
-- This is a pure UI/styling change with no functional impact on text editing, cursor movement, or input handling
+**TextArea Creation Pattern** (@/src/app.rs, @/src/main.rs):
+- All TextArea instances created via `TextArea::new(TextAreaConfig::default())` from tui-components library
+- TextArea creation happens in multiple locations: Model::default() initialization, Model::update() handlers (SubmitInput, ClearTextarea, AutocompleteSelect), and main.rs (slash command execution)
+- `create_textarea()` helper function in @/src/app.rs:433-435 provides DRY pattern for consistent creation with default configuration
+- AutocompleteSelect handler creates TextArea with initial text content and positions cursor at end of text using `.set_cursor(text.len())`
+- All TextArea instances use default configuration which provides standard text editing behavior, cursor handling, and styling
 
 **Key Event Handling**:
 - KeyEvent passed to textarea via Message::KeyPress only when `show_agent_router` is false
-- textarea.input() handles cursor movement, text editing, newlines internally
+- textarea.handle_key(key) processes keyboard input for cursor movement, text editing, and newlines internally
 - Ctrl-C is checked FIRST in handle_key_simple (@/src/main.rs:320-326) - takes priority over all other key handling including overlays and install prompts
 - Alt+A globally toggles agent router overlay - handled before mode-specific logic in @/src/main.rs:117-121
 - 'q' quits from Selection/Streaming modes but types 'q' character when in Input mode

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,7 +144,7 @@ async fn run_app(terminal: &mut ratatui::Terminal<CrosstermBackend<TerminalWrite
                     }
                     Message::SubmitInput => {
                         // Extract prompt from textarea
-                        let prompt = model.textarea.lines().join("\n");
+                        let prompt = model.textarea.text().to_string();
                         if !prompt.trim().is_empty() {
                             // Check if this is a slash command
                             if let Some(command_name) = parse_slash_command(&prompt) {
@@ -176,11 +176,9 @@ async fn run_app(terminal: &mut ratatui::Terminal<CrosstermBackend<TerminalWrite
                                         }
 
                                         // Clear textarea after successful command
-                                        model.textarea = {
-                                            let mut textarea = tui_textarea::TextArea::default();
-                                            textarea.set_cursor_line_style(ratatui::style::Style::default());
-                                            textarea
-                                        };
+                                        model.textarea = tui_components::textarea::TextArea::new(
+                                            tui_components::textarea::TextAreaConfig::default()
+                                        );
                                     }
                                     Err(err) => {
                                         // Command execution failed - show error
@@ -332,7 +330,7 @@ async fn run_app(terminal: &mut ratatui::Terminal<CrosstermBackend<TerminalWrite
                         // Update model (which updates textarea)
                         model.update(msg);
                         // Update autocomplete state based on new textarea content
-                        let input = model.textarea.lines().join("\n");
+                        let input = model.textarea.text().to_string();
                         update_autocomplete_state(&mut model, &input, &command_registry);
                         // Send state updates
                         let _ = mode_tx.send(model.current_mode);
@@ -343,7 +341,7 @@ async fn run_app(terminal: &mut ratatui::Terminal<CrosstermBackend<TerminalWrite
                     }
                     Message::InputChanged => {
                         // Explicitly update autocomplete state (called after other updates)
-                        let input = model.textarea.lines().join("\n");
+                        let input = model.textarea.text().to_string();
                         update_autocomplete_state(&mut model, &input, &command_registry);
                         let _ = autocomplete_tx.send(model.show_autocomplete);
                     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5,7 +5,7 @@ use ratatui::{
     style::{Color, Modifier, Style},
     widgets::{Block, Borders, List, ListItem, Paragraph},
 };
-use tui_textarea::TextArea;
+use tui_components::textarea::TextArea;
 use unicode_width::UnicodeWidthStr;
 
 pub fn calculate_textarea_height(textarea: &TextArea, available_width: u16) -> u16 {
@@ -16,7 +16,14 @@ pub fn calculate_textarea_height(textarea: &TextArea, available_width: u16) -> u
     let available_width = available_width.max(1); // Prevent division by zero
 
     let mut total_lines = 0u16;
-    for line in textarea.lines() {
+    let text = textarea.text();
+    let lines: Vec<&str> = if text.is_empty() {
+        vec![""]
+    } else {
+        text.lines().collect()
+    };
+
+    for line in lines {
         let line_width = line.width() as u16;
         // Calculate how many wrapped lines this will take
         let wrapped_lines = if line_width == 0 {

--- a/tests/ctrl_c_handling_test.rs
+++ b/tests/ctrl_c_handling_test.rs
@@ -9,7 +9,7 @@ fn test_first_ctrl_c_clears_textarea_and_shows_hint() {
     model.update(Message::ClearTextarea);
 
     // Textarea should be cleared
-    assert!(model.textarea.lines()[0].is_empty());
+    assert!(model.textarea.is_empty());
 
     // Timestamp should be set
     assert!(model.last_ctrl_c_time.is_some());
@@ -56,7 +56,7 @@ fn test_ctrl_c_after_timeout_clears_textarea_again() {
     model.update(Message::ClearTextarea);
 
     // Textarea should be cleared
-    assert!(model.textarea.lines()[0].is_empty());
+    assert!(model.textarea.is_empty());
 
     // Timestamp should be updated (not None)
     assert!(model.last_ctrl_c_time.is_some());

--- a/tests/docs.md
+++ b/tests/docs.md
@@ -19,9 +19,9 @@ Test suite for the agent-router-tui application, covering state machine transiti
 
 **Ctrl-C Handling Tests** (@/tests/ctrl_c_handling_test.rs):
 - `test_first_ctrl_c_clears_textarea_and_shows_hint()`: Verifies first Ctrl-C press behavior
-  - Adds text to textarea
+  - Adds text to textarea via .insert_str()
   - Sends ClearTextarea message
-  - Asserts textarea is cleared
+  - Asserts textarea is cleared via .is_empty()
   - Asserts last_ctrl_c_time is set to Some(Instant)
   - Asserts error_message contains "Press Ctrl-C again to exit" hint
 - `test_second_ctrl_c_within_timeout_clears_timestamp()`: Verifies second Ctrl-C within 2-second window
@@ -32,39 +32,39 @@ Test suite for the agent-router-tui application, covering state machine transiti
 - `test_ctrl_c_after_timeout_clears_textarea_again()`: Verifies timeout expiration behavior
   - Sends first ClearTextarea
   - Manually sets timestamp to 3 seconds in the past (simulates timeout)
-  - Adds new text to textarea
+  - Adds new text to textarea via .insert_str()
   - Sends ClearTextarea again
-  - Asserts textarea cleared again
+  - Asserts textarea cleared again via .is_empty()
   - Asserts new timestamp is set (more recent than old one)
   - Asserts hint shown again (behaves as first press)
 
 **Textarea Clearing Tests** (@/tests/textarea_clearing_test.rs):
 - `test_textarea_clears_immediately_on_submit()`: Verifies textarea is cleared immediately when SubmitInput message is processed
-  - User types a message into textarea
+  - User types a message into textarea via .insert_str()
   - Sends SubmitInput message
-  - Asserts textarea is empty after SubmitInput (not waiting for stream to complete)
+  - Asserts textarea is empty via .is_empty() after SubmitInput (not waiting for stream to complete)
   - Asserts mode transitions to Streaming
 - `test_empty_input_does_not_submit()`: Verifies empty textarea does not trigger submission
   - Sends SubmitInput with empty textarea
-  - Asserts mode stays in Selection
+  - Asserts mode stays in Selection via .is_empty()
   - Asserts no events added to response_events
 - `test_whitespace_only_input_does_not_submit()`: Verifies whitespace-only input does not trigger submission
-  - Types only whitespace into textarea
+  - Types only whitespace into textarea via .insert_str()
   - Sends SubmitInput
   - Asserts mode stays in Selection
 - `test_textarea_stays_clear_during_streaming()`: Verifies textarea remains empty during streaming
-  - Submits message (clears textarea)
+  - Submits message via .insert_str() and SubmitInput (clears textarea)
   - Sends StreamEvent message
-  - Asserts textarea still empty
+  - Asserts textarea still empty via .is_empty()
 - `test_textarea_stays_clear_after_stream_complete()`: Verifies textarea remains empty after stream completes
-  - Submits message (clears textarea)
+  - Submits message via .insert_str() and SubmitInput (clears textarea)
   - Sends StreamComplete message
-  - Asserts textarea still empty and mode is Selection
+  - Asserts textarea still empty via .is_empty() and mode is Selection
 - `test_textarea_stays_clear_after_cancel()`: Verifies textarea remains empty after stream cancellation
-  - Submits message (clears textarea)
+  - Submits message via .insert_str() and SubmitInput (clears textarea)
   - Sets up CancellationToken
   - Sends CancelStream message
-  - Asserts textarea still empty (not restored to original content)
+  - Asserts textarea still empty via .is_empty() (not restored to original content)
 
 **State Machine Tests** (@/tests/state_machine_test.rs):
 - `test_state_transitions()`: Verifies overlay and mode transitions
@@ -77,11 +77,12 @@ Test suite for the agent-router-tui application, covering state machine transiti
 - `test_toggle_agent_router_overlay()`: Verifies ToggleAgentRouter message toggles `show_agent_router` boolean
 - `test_submit_input_adds_user_message_to_history()`: Verifies SubmitInput captures textarea content and adds UserMessage to response_events before spawning agent
 - `test_cancel_stream_during_streaming()`: Verifies CancelStream message handling
-  - Submits a message via SubmitInput (which clears textarea and sets up streaming state)
+  - Submits a message via .insert_str() and SubmitInput (which clears textarea and sets up streaming state)
   - Sets up CancellationToken for the stream
   - Sends CancelStream message
   - Asserts token.is_cancelled() is true
   - Verifies mode transitions to Selection, token cleared from model
+  - Verifies textarea is empty via .is_empty()
   - Verifies StreamCancelled event added to response_events
 
 **Subprocess Tests** (@/tests/subprocess_test.rs):
@@ -93,6 +94,21 @@ Test suite for the agent-router-tui application, covering state machine transiti
   - Creates CancellationToken and passes to spawn_stream()
   - Consumes stream and verifies at least one event received
   - Tests stream completion without cancellation
+
+**Dynamic TextArea Height Tests** (@/tests/dynamic_textarea_height_test.rs):
+- `test_single_line_returns_minimum_height()`: Verifies single line of text returns minimum height
+  - Creates TextArea via TextArea::new(TextAreaConfig::default())
+  - Inserts text via .insert_str()
+  - Asserts calculated height matches minimum
+- `test_multiline_returns_correct_height()`: Verifies multiple lines return correct height
+  - Creates TextArea and inserts multiple lines via .insert_str() with embedded newlines
+  - Asserts height accounts for all lines
+- `test_long_line_accounts_for_wrapping()`: Verifies long lines account for text wrapping
+  - Creates TextArea and inserts long string via .insert_str() with &str reference
+  - Asserts height accounts for wrapped lines based on terminal width
+- `test_height_respects_maximum_bound()`: Verifies maximum height constraint
+  - Creates TextArea and inserts many lines via .insert_str() with loop
+  - Asserts height respects maximum bound regardless of content
 
 **Conversation Rendering Tests** (@/tests/conversation_rendering_test.rs):
 - `test_parse_assistant_message_event()`: Verifies parsing of Claude CLI assistant message format
@@ -125,6 +141,14 @@ Test suite for the agent-router-tui application, covering state machine transiti
 - Subprocess tests use MockBackend to avoid external dependencies on claude/codex CLIs
 - No integration tests with real backends because they require API authentication
 - Rendering tests verify both parsing and styling independently for each event type
+
+**TextArea Testing Pattern**:
+- Tests use tui_components::textarea::TextArea instead of external tui-textarea crate
+- TextArea creation: `TextArea::new(TextAreaConfig::default())` in all tests
+- Text insertion: `.insert_str()` method for adding text content (takes string or &str reference)
+- Empty check: `.is_empty()` method replaces `.lines()[0].is_empty()` pattern
+- Text access: `.text()` returns `&str` instead of `.lines()` returning array
+- Newlines: Embedded in strings passed to `.insert_str()` instead of separate `.insert_newline()` calls
 
 **MockBackend Implementation**:
 - Uses `printf` command to output hardcoded JSONL strings in actual Claude CLI format

--- a/tests/dynamic_textarea_height_test.rs
+++ b/tests/dynamic_textarea_height_test.rs
@@ -1,9 +1,9 @@
 use nori_cli::ui::calculate_textarea_height;
-use tui_textarea::TextArea;
+use tui_components::textarea::{TextArea, TextAreaConfig};
 
 #[test]
 fn test_single_line_returns_minimum_height() {
-    let mut textarea = TextArea::default();
+    let mut textarea = TextArea::new(TextAreaConfig::default());
     textarea.insert_str("hello");
 
     let height = calculate_textarea_height(&textarea, 80);
@@ -14,11 +14,11 @@ fn test_single_line_returns_minimum_height() {
 
 #[test]
 fn test_multiline_returns_correct_height() {
-    let mut textarea = TextArea::default();
+    let mut textarea = TextArea::new(TextAreaConfig::default());
     textarea.insert_str("line 1");
-    textarea.insert_newline();
+    textarea.insert_str("\n");
     textarea.insert_str("line 2");
-    textarea.insert_newline();
+    textarea.insert_str("\n");
     textarea.insert_str("line 3");
 
     let height = calculate_textarea_height(&textarea, 80);
@@ -29,10 +29,10 @@ fn test_multiline_returns_correct_height() {
 
 #[test]
 fn test_long_line_accounts_for_wrapping() {
-    let mut textarea = TextArea::default();
+    let mut textarea = TextArea::new(TextAreaConfig::default());
     // Create a 250-character line (will wrap at width 80)
     // 250 / 80 = 4 wrapped lines (rounded up from 3.125)
-    textarea.insert_str("a".repeat(250));
+    textarea.insert_str(&"a".repeat(250));
 
     let height = calculate_textarea_height(&textarea, 80);
 
@@ -45,13 +45,13 @@ fn test_long_line_accounts_for_wrapping() {
 
 #[test]
 fn test_height_respects_maximum_bound() {
-    let mut textarea = TextArea::default();
+    let mut textarea = TextArea::new(TextAreaConfig::default());
     // Create 20 lines
     for i in 0..20 {
         if i > 0 {
-            textarea.insert_newline();
+            textarea.insert_str("\n");
         }
-        textarea.insert_str(format!("line {i}"));
+        textarea.insert_str(&format!("line {i}"));
     }
 
     let height = calculate_textarea_height(&textarea, 80);

--- a/tests/state_machine_test.rs
+++ b/tests/state_machine_test.rs
@@ -165,7 +165,7 @@ fn test_cancel_stream_during_streaming() {
     model.update(Message::SubmitInput);
 
     // Verify textarea was cleared and mode changed
-    assert!(model.textarea.lines()[0].is_empty());
+    assert!(model.textarea.is_empty());
     assert_eq!(model.current_mode, AppMode::Streaming);
 
     // Set up cancellation token for the stream
@@ -178,7 +178,7 @@ fn test_cancel_stream_during_streaming() {
     // Verify state transitions correctly
     assert_eq!(model.current_mode, AppMode::Selection);
     assert!(model.current_stream_token.is_none());
-    assert!(model.textarea.lines()[0].is_empty());
+    assert!(model.textarea.is_empty());
     assert!(token.is_cancelled());
 
     // Verify cancellation status message was added to history

--- a/tests/textarea_clearing_test.rs
+++ b/tests/textarea_clearing_test.rs
@@ -7,14 +7,14 @@ fn test_textarea_clears_immediately_on_submit() {
 
     // User types a message
     model.textarea.insert_str("test message");
-    assert!(!model.textarea.lines()[0].is_empty());
+    assert!(!model.textarea.is_empty());
 
     // User submits
     model.update(Message::SubmitInput);
 
     // Textarea should be cleared immediately
     assert!(
-        model.textarea.lines()[0].is_empty(),
+        model.textarea.is_empty(),
         "Textarea should be empty after SubmitInput"
     );
 
@@ -27,7 +27,7 @@ fn test_empty_input_does_not_submit() {
     let mut model = Model::default();
 
     // Start with empty textarea
-    assert!(model.textarea.lines()[0].is_empty());
+    assert!(model.textarea.is_empty());
 
     // Try to submit
     model.update(Message::SubmitInput);
@@ -63,7 +63,7 @@ fn test_textarea_stays_clear_during_streaming() {
     // Submit a message
     model.textarea.insert_str("test");
     model.update(Message::SubmitInput);
-    assert!(model.textarea.lines()[0].is_empty());
+    assert!(model.textarea.is_empty());
 
     // Receive stream events
     model.update(Message::StreamEvent(ConversationEvent::AssistantMessage {
@@ -72,7 +72,7 @@ fn test_textarea_stays_clear_during_streaming() {
 
     // Textarea should still be empty
     assert!(
-        model.textarea.lines()[0].is_empty(),
+        model.textarea.is_empty(),
         "Textarea should remain empty during streaming"
     );
 }
@@ -84,14 +84,14 @@ fn test_textarea_stays_clear_after_stream_complete() {
     // Submit and clear
     model.textarea.insert_str("test");
     model.update(Message::SubmitInput);
-    assert!(model.textarea.lines()[0].is_empty());
+    assert!(model.textarea.is_empty());
 
     // Stream completes
     model.update(Message::StreamComplete);
 
     // Textarea should still be empty
     assert!(
-        model.textarea.lines()[0].is_empty(),
+        model.textarea.is_empty(),
         "Textarea should remain empty after StreamComplete"
     );
 
@@ -108,7 +108,7 @@ fn test_textarea_stays_clear_after_cancel() {
     // Submit and clear
     model.textarea.insert_str("test message");
     model.update(Message::SubmitInput);
-    assert!(model.textarea.lines()[0].is_empty());
+    assert!(model.textarea.is_empty());
 
     // Set up cancellation token for streaming
     model.current_stream_token = Some(CancellationToken::new());
@@ -118,7 +118,7 @@ fn test_textarea_stays_clear_after_cancel() {
 
     // Textarea should still be empty (not restored)
     assert!(
-        model.textarea.lines()[0].is_empty(),
+        model.textarea.is_empty(),
         "Textarea should remain empty after cancellation"
     );
 


### PR DESCRIPTION
## Summary

- Replaced external `tui-textarea` crate with internal `tui_components::textarea` implementation
- Updated all API calls to use new TextArea interface (.text(), .handle_key(), .is_empty())
- Consolidated dependencies within tui-components library for better component consistency

## Test Plan

- [x] All 87 tests pass
- [x] Cargo clippy clean (no warnings)
- [x] Cargo fmt applied
- [x] Manual verification of TextArea functionality
- [x] Documentation updated for new API

🤖 Generated with [Claude Code](https://claude.com/claude-code)