### PR TITLE
fix(test): Add missing fields in ChatWidget initializer

### DIFF
--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -379,6 +379,8 @@ fn make_chatwidget_manual() -> (
         feedback: codex_feedback::CodexFeedback::new(),
         current_rollout_path: None,
         pending_agent: None,
+        expected_model: None,
+        session_configured_received: false,
     };
     (widget, rx, op_rx)
 }


### PR DESCRIPTION
Add `expected_model` and `session_configured_received` fields to the `make_chatwidget_manual()` test helper function to fix compile error.