### PR TITLE
fix(ci): Upgrade workflows to actions checkout v6

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -27,7 +27,7 @@ jobs:
             name: macOS checks
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       # Free disk space on Linux runners to prevent "No space left on device" errors
       - name: Free disk space

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -34,7 +34,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           # PAT required to push workflow file changes (GITHUB_TOKEN lacks 'workflows' permission)


### PR DESCRIPTION
Upgrade checkout action in all workflows to v6:
- rust-ci.yml: v5 → v6
- upstream-sync.yml: v4 → v6
- cargo-deny.yml already at v6