### PR TITLE
Rename dev branch to main across CI

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -3,7 +3,7 @@ name: cargo-deny
 on:
   pull_request: {}
   push:
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   cargo-deny:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -2,7 +2,7 @@ name: rust-ci
 on:
   pull_request: {}
   push:
-    branches: [main, dev]
+    branches: [main]
 
 jobs:
   checks:

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,4 +1,4 @@
-# Automatically sync stable upstream releases into dev branch.
+# Automatically sync stable upstream releases into main branch.
 # Creates a sync branch and draft PR for each new stable release.
 #
 # Manual trigger: gh workflow run upstream-sync.yml
@@ -203,8 +203,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Count commits between dev and the tag for context
-          commit_count=$(git rev-list --count origin/dev.."$TARGET_TAG" 2>/dev/null || echo "unknown")
+          # Count commits between main and the tag for context
+          commit_count=$(git rev-list --count origin/main.."$TARGET_TAG" 2>/dev/null || echo "unknown")
 
           pr_title="Sync upstream $TARGET_TAG"
 
@@ -237,7 +237,7 @@ jobs:
           1. Review the changes for conflicts with our ACP fork work
           2. Resolve any merge conflicts:
              \`\`\`bash
-             git checkout dev
+             git checkout main
              git merge $SYNC_BRANCH --no-ff
              # Resolve conflicts if any
              \`\`\`
@@ -259,7 +259,7 @@ jobs:
           else
             gh pr create \
               --repo "${{ github.repository }}" \
-              --base dev \
+              --base main \
               --head "$SYNC_BRANCH" \
               --title "$pr_title" \
               --body "$pr_body" \

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+<!-- NORI FORK NOTICE -->
+> **Note:** This is a Nori fork of openai/codex with ACP (Agent Context Protocol) features.
+> Our `main` branch is NOT compatible with upstream `main` - it contains Nori-specific
+> modifications. Upstream sync is handled via release tags through the `upstream-sync` workflow.
+> See [nori-releases.md](./nori-releases.md) for branching details.
+
+---
+
 <p align="center"><code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
 
 <p align="center"><strong>Codex CLI</strong> is a coding agent from OpenAI that runs locally on your computer.

--- a/docs.md
+++ b/docs.md
@@ -2,6 +2,11 @@
 
 Path: @/
 
+> **Fork Notice:** This is a Nori fork of openai/codex. Our `main` branch is NOT
+> compatible with upstream `main` - it contains Nori-specific ACP features.
+> Upstream synchronization is managed via the `upstream-sync` workflow using release tags.
+> See [nori-releases.md](./nori-releases.md) for branching strategy details.
+
 ### Overview
 
 This repository contains the Codex CLI, a local coding agent from OpenAI that runs on your computer. It provides AI-assisted coding capabilities through a terminal-based interface, with support for multiple model providers, sandboxed command execution, and IDE integration. The primary implementation is in Rust (`codex-rs`), with supporting TypeScript components for Node.js distribution.

--- a/nori-releases.md
+++ b/nori-releases.md
@@ -20,6 +20,10 @@ Release Workflow (from rust-release.yml):
 
 ## Branching Strategy
 
+> **Important:** Our `main` branch is NOT compatible with upstream `main`.
+> It contains Nori-specific features (ACP, etc.) that diverge from openai/codex.
+> Upstream synchronization is handled via the `upstream-sync` workflow using release tags.
+
 ```
 upstream/main ──●──●──●──●──●──●──●──●──●──●──●──●──●──●──●──●───→
                 │        ▲              ▲              ▲
@@ -30,17 +34,16 @@ fork/upstream-sync ──────┴─────────────�
                 │                       │
                 │ merge                 │ merge
                 ▼                       ▼
-origin/dev ─────●────●────●────●────────●────●────●────────────→ (your ACP work)
+origin/main ────●────●────●────●────────●────●────●────────────→ (Nori ACP development)
 ```
 
 Branch Roles:
 
-| Branch             | Purpose                                      |
+| Branch             | Purpose                                       |
 |--------------------|-----------------------------------------------|
-| origin/main        | Stable releases of your fork                  |
-| origin/dev         | Active development (ACP features)             |
+| origin/main        | Active development (Nori ACP features)        |
 | fork/upstream-main | Tracks upstream/main exactly (already exists) |
-| fork/upstream-sync | NEW: Sync point branch for merges             |
+| fork/upstream-sync | Sync point branch for merges from upstream    |
 
 ## Automated Sync (CI)
 
@@ -55,7 +58,7 @@ upstream releases and creates draft PRs.
 2. Finds latest stable tag (X.Y.Z only, no alpha/beta)
 3. Updates `fork/upstream-sync` branch to point to the tag
 4. Creates `sync/upstream-vX.Y.Z` branch from the tag
-5. Opens a draft PR against `dev` with merge instructions
+5. Opens a draft PR against `main` with merge instructions
 
 **Manual trigger:**
 
@@ -89,9 +92,9 @@ git checkout -b sync/upstream-v0.63.0 rust-v0.63.0
 git push origin sync/upstream-v0.63.0
 ```
 
-3. Merge into dev with conflict resolution
+3. Merge into main with conflict resolution
 ```bash
-git checkout dev
+git checkout main
 git merge sync/upstream-v0.63.0 --no-ff -m "Sync upstream rust-v0.63.0"
 ```
 
@@ -99,18 +102,18 @@ git merge sync/upstream-v0.63.0 --no-ff -m "Sync upstream rust-v0.63.0"
 ```bash
 cd codex-rs && cargo test
 cargo insta review  # if snapshot tests need updating
-git push origin dev
+git push origin main
 ```
 
 ## Downstream Nori Releases
 
-For now we will maintain our own separate versioning scheme, to avoid blocking
-on the upstream releases for our release tagging.
+We maintain our own separate versioning scheme, independent of upstream releases.
 
 For example for nori-v0.2.0 or similar:
 
+```bash
 git checkout main
-git merge dev --no-ff
 git tag -a nori-v0.2.0 -m "Nori release 0.2.0"
 git push origin main --tags
+```
 


### PR DESCRIPTION
- Update rust-ci.yml and cargo-deny.yml to trigger only on main
- Update upstream-sync.yml to target main instead of dev for sync PRs
- Update nori-releases.md with new branching strategy documentation
- Add fork compatibility notices to README.md and docs.md clarifying that our main branch diverges from upstream main