### PR TITLE
fix(ci): Correct dtolnay/rust-action to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/nori-release.yml
+++ b/.github/workflows/nori-release.yml
@@ -139,7 +139,7 @@ jobs:
           df -h
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.90.0"
           components: clippy
@@ -258,7 +258,7 @@ jobs:
           df -h
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.90.0"
           targets: ${{ matrix.target }}


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Fixed typo in nori-release.yml workflow: `dtolnay/rust-action` → `dtolnay/rust-toolchain`
- The GitHub Action `dtolnay/rust-action` does not exist; the correct name is `dtolnay/rust-toolchain`

## Test Plan
- [ ] Verify CI workflow runs successfully with the correct action name

Share Nori with your team: https://www.npmjs.com/package/nori-ai