### PR TITLE
fix(e2e): Use TIMEOUT_PRESNAPSHOT for error test snapshot timing

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -209,7 +209,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app_test_support"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -867,7 +867,7 @@ checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "codex-acp"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ansi-escape"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "ansi-to-tui",
  "ratatui",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "app_test_support",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-test-client"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "async-trait",
  "pretty_assertions",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "codex-backend-openapi-models",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "codex-chatgpt"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cloud-tasks-client"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "codex-common"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "clap",
  "codex-app-server-protocol",
@@ -1186,7 +1186,7 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy-legacy"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "allocative",
  "anyhow",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "codex-protocol",
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "codex-git"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "assert_matches",
  "once_cell",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "keyring",
  "tracing",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "clap",
  "codex-core",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "codex-lmstudio"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "codex-core",
  "reqwest",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "codex-ollama"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "assert_matches",
  "async-stream",
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -1527,14 +1527,14 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-protocol"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "codex-responses-api-proxy"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "codex-stdio-to-uds"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "codex-tui"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "lru",
  "sha1",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "base64",
  "codex-utils-cache",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "pretty_assertions",
  "serde_json",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "portable-pty 0.9.0",
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -1735,11 +1735,11 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-string"
-version = "0.0.1"
+version = "0.0.0"
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "codex-protocol",
@@ -1876,7 +1876,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core_test_support"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3841,7 +3841,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-types"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3851,7 +3851,7 @@ dependencies = [
 
 [[package]]
 name = "mcp_test_support"
-version = "0.0.1"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/codex-rs/tui-pty-e2e/tests/prompt_flow.rs
+++ b/codex-rs/tui-pty-e2e/tests/prompt_flow.rs
@@ -73,7 +73,7 @@ fn test_http_model_immediate_error_without_retries() {
         elapsed
     );
 
-    std::thread::sleep(TIMEOUT_INPUT);
+    std::thread::sleep(TIMEOUT_PRESNAPSHOT);
     assert_snapshot!(
         "http_model_immediate_error",
         normalize_for_input_snapshot(session.screen_contents())


### PR DESCRIPTION
## Summary
- Fix flaky `test_http_model_immediate_error_without_retries` test in CI

## Problem
The test was timing out in CI with an empty TUI screen, failing to capture the error message. The root cause was using `TIMEOUT_INPUT` (100ms) before taking the snapshot, which wasn't enough time for PTY I/O to settle in CI environments.

## Solution
Change `TIMEOUT_INPUT` to `TIMEOUT_PRESNAPSHOT` (1000ms) to give the output buffer sufficient time to be captured before taking the snapshot.

## Test plan
- [x] Test passes locally
- [x] CI should pass with the increased sleep duration