### PR TITLE
fix(ci): Use musl targets for Linux builds to fix glibc compatibility

### DIFF
--- a/.github/workflows/nori-release.yml
+++ b/.github/workflows/nori-release.yml
@@ -130,6 +130,8 @@ jobs:
     needs: validate
     if: ${{ needs.validate.outputs.skip_tests != 'true' }}
     runs-on: ubuntu-24.04
+    env:
+      MUSL_TARGET: x86_64-unknown-linux-musl
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -141,33 +143,39 @@ jobs:
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android || true
           df -h
 
+      - name: Install musl tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.90.0"
+          targets: ${{ env.MUSL_TARGET }}
           components: clippy
 
       - name: cargo check
         working-directory: codex-rs
-        run: cargo check --all-targets
+        run: cargo check --target ${{ env.MUSL_TARGET }} --all-targets
 
       - name: cargo clippy
         working-directory: codex-rs
-        run: cargo clippy --all-targets # needs all features to avoid unused import/var/etc errors
+        run: cargo clippy --target ${{ env.MUSL_TARGET }} --all-targets # needs all features to avoid unused import/var/etc errors
 
       - name: cargo build
         working-directory: codex-rs
-        run: cargo build -p codex-cli && cargo build -p mock-acp-agent
+        run: cargo build --target ${{ env.MUSL_TARGET }} -p codex-cli && cargo build --target ${{ env.MUSL_TARGET }} -p mock-acp-agent
 
       - name: cargo test
         working-directory: codex-rs
         run: |
-          cargo test --package tui-pty-e2e
-          cargo test --package codex-acp
-          cargo test --package codex-tui
-          cargo test --package codex-cli
-          cargo test --package codex-protocol
-          cargo test --package codex-core
+          cargo test --target ${{ env.MUSL_TARGET }} --package tui-pty-e2e
+          cargo test --target ${{ env.MUSL_TARGET }} --package codex-acp
+          cargo test --target ${{ env.MUSL_TARGET }} --package codex-tui
+          cargo test --target ${{ env.MUSL_TARGET }} --package codex-cli
+          cargo test --target ${{ env.MUSL_TARGET }} --package codex-protocol
+          cargo test --target ${{ env.MUSL_TARGET }} --package codex-core
 
   # ============================================================================
   # BUILD NATIVE BINARIES
@@ -181,10 +189,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             artifact-name: linux-x86_64
           - os: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             artifact-name: linux-arm64
           - os: macos-14
             target: aarch64-apple-darwin
@@ -204,6 +212,12 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
           df -h
+
+      - name: Install musl tools (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             name: Linux checks
           - runner: macos-14
             target: aarch64-apple-darwin
@@ -40,7 +40,7 @@ jobs:
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo apt-get update
-          sudo apt-get install coreutils
+          sudo apt-get install -y coreutils musl-tools
           docker system prune -af || true
 
       - uses: dtolnay/rust-toolchain@1.90


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Switch Linux build targets from `*-linux-gnu` to `*-linux-musl` to produce statically-linked binaries
- Add `musl-tools` installation to all Linux build steps in CI
- Fixes GLIBC_2.39 compatibility error when running on systems with older glibc

**Root cause:** Ubuntu 24.04 has glibc 2.39, but dynamically-linked binaries require that same version at runtime. Users on older distros (e.g., Ubuntu 22.04 with glibc 2.35) cannot run the binaries.

**Solution:** musl targets statically link the C library, eliminating glibc version dependencies.

## Test Plan
- [x] Verify CI builds pass for all platforms
- [x] Test dry-run release workflow: `gh workflow run nori-release.yml -f version=0.2.0 -f dry_run=true`
- [x] Verify built binary works on Ubuntu 22.04 or similar older distro

Share Nori with your team: https://www.npmjs.com/package/nori-ai