### PR TITLE
feat(release): Add Android target support for Termux

### DIFF
--- a/.github/workflows/nori-release.yml
+++ b/.github/workflows/nori-release.yml
@@ -29,16 +29,16 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to test build (e.g., 0.2.0) - dry run only'
+        description: "Version to test build (e.g., 0.2.0) - dry run only"
         required: true
         type: string
       dry_run:
-        description: 'Dry run mode (builds but does not publish)'
+        description: "Dry run mode (builds but does not publish)"
         required: false
         default: true
         type: boolean
       skip_tests:
-        description: 'Skip running tests (for faster build testing)'
+        description: "Skip running tests (for faster build testing)"
         required: false
         default: false
         type: boolean
@@ -200,6 +200,14 @@ jobs:
           - os: macos-14
             target: x86_64-apple-darwin
             artifact-name: darwin-x86_64
+          - os: ubuntu-24.04
+            target: aarch64-linux-android
+            artifact-name: android-arm64
+            use-ndk: true
+          - os: ubuntu-24.04
+            target: x86_64-linux-android
+            artifact-name: android-x86_64
+            use-ndk: true
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
@@ -224,6 +232,27 @@ jobs:
         with:
           toolchain: "1.90.0"
           targets: ${{ matrix.target }}
+
+      - name: Setup Android NDK
+        if: matrix.use-ndk == true
+        uses: android-actions/setup-android@v3
+        with:
+          packages: "ndk;26.1.10909125"
+
+      - name: Configure Android linker
+        if: matrix.use-ndk == true
+        run: |
+          mkdir -p ~/.cargo
+          NDK_HOST_TAG="linux-x86_64"
+          NDK_TOOLCHAIN="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$NDK_HOST_TAG/bin"
+          cat >> ~/.cargo/config.toml << EOF
+          [target.aarch64-linux-android]
+          linker = "$NDK_TOOLCHAIN/aarch64-linux-android30-clang"
+
+          [target.x86_64-linux-android]
+          linker = "$NDK_TOOLCHAIN/x86_64-linux-android30-clang"
+          EOF
+          cat ~/.cargo/config.toml
 
       - name: Build release binaries
         working-directory: codex-rs
@@ -279,8 +308,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -331,8 +360,9 @@ jobs:
           mkdir -p "$STAGING_DIR/bin"
           mkdir -p "$STAGING_DIR/vendor"
 
-          # Copy the CLI launcher
+          # Copy the CLI launcher and platform module
           cp codex-cli/bin/nori.js "$STAGING_DIR/bin/"
+          cp codex-cli/bin/platform.js "$STAGING_DIR/bin/"
 
           # Copy vendor binaries
           cp -r vendor/* "$STAGING_DIR/vendor/"
@@ -416,8 +446,8 @@ jobs:
     runs-on: ubuntu-24.04
     environment: npm-publish
     permissions:
-      contents: read      # Required to checkout code
-      id-token: write     # Required for OIDC Trusted Publishing
+      contents: read # Required to checkout code
+      id-token: write # Required for OIDC Trusted Publishing
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -427,8 +457,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Download npm package
         uses: actions/download-artifact@v4

--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -5,6 +5,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { getTargetTriple } from "./platform.js";
 
 // __dirname equivalent in ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -12,48 +13,7 @@ const __dirname = path.dirname(__filename);
 
 const { platform, arch } = process;
 
-let targetTriple = null;
-switch (platform) {
-  case "linux":
-  case "android":
-    switch (arch) {
-      case "x64":
-        targetTriple = "x86_64-unknown-linux-musl";
-        break;
-      case "arm64":
-        targetTriple = "aarch64-unknown-linux-musl";
-        break;
-      default:
-        break;
-    }
-    break;
-  case "darwin":
-    switch (arch) {
-      case "x64":
-        targetTriple = "x86_64-apple-darwin";
-        break;
-      case "arm64":
-        targetTriple = "aarch64-apple-darwin";
-        break;
-      default:
-        break;
-    }
-    break;
-  case "win32":
-    switch (arch) {
-      case "x64":
-        targetTriple = "x86_64-pc-windows-msvc";
-        break;
-      case "arm64":
-        targetTriple = "aarch64-pc-windows-msvc";
-        break;
-      default:
-        break;
-    }
-    break;
-  default:
-    break;
-}
+const targetTriple = getTargetTriple(platform, arch);
 
 if (!targetTriple) {
   throw new Error(`Unsupported platform: ${platform} (${arch})`);

--- a/codex-cli/bin/nori.js
+++ b/codex-cli/bin/nori.js
@@ -5,6 +5,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { getTargetTriple } from "./platform.js";
 
 // __dirname equivalent in ESM
 const __filename = fileURLToPath(import.meta.url);
@@ -12,48 +13,7 @@ const __dirname = path.dirname(__filename);
 
 const { platform, arch } = process;
 
-let targetTriple = null;
-switch (platform) {
-  case "linux":
-  case "android":
-    switch (arch) {
-      case "x64":
-        targetTriple = "x86_64-unknown-linux-musl";
-        break;
-      case "arm64":
-        targetTriple = "aarch64-unknown-linux-musl";
-        break;
-      default:
-        break;
-    }
-    break;
-  case "darwin":
-    switch (arch) {
-      case "x64":
-        targetTriple = "x86_64-apple-darwin";
-        break;
-      case "arm64":
-        targetTriple = "aarch64-apple-darwin";
-        break;
-      default:
-        break;
-    }
-    break;
-  case "win32":
-    switch (arch) {
-      case "x64":
-        targetTriple = "x86_64-pc-windows-msvc";
-        break;
-      case "arm64":
-        targetTriple = "aarch64-pc-windows-msvc";
-        break;
-      default:
-        break;
-    }
-    break;
-  default:
-    break;
-}
+const targetTriple = getTargetTriple(platform, arch);
 
 if (!targetTriple) {
   throw new Error(`Unsupported platform: ${platform} (${arch})`);

--- a/codex-cli/bin/platform.js
+++ b/codex-cli/bin/platform.js
@@ -1,0 +1,48 @@
+/**
+ * Get the Rust target triple for the given platform and architecture.
+ * @param {string} platform - Node.js process.platform value
+ * @param {string} arch - Node.js process.arch value
+ * @returns {string|null} - Rust target triple or null if unsupported
+ */
+export function getTargetTriple(platform, arch) {
+  switch (platform) {
+    case "android":
+      switch (arch) {
+        case "x64":
+          return "x86_64-linux-android";
+        case "arm64":
+          return "aarch64-linux-android";
+        default:
+          return null;
+      }
+    case "linux":
+      switch (arch) {
+        case "x64":
+          return "x86_64-unknown-linux-musl";
+        case "arm64":
+          return "aarch64-unknown-linux-musl";
+        default:
+          return null;
+      }
+    case "darwin":
+      switch (arch) {
+        case "x64":
+          return "x86_64-apple-darwin";
+        case "arm64":
+          return "aarch64-apple-darwin";
+        default:
+          return null;
+      }
+    case "win32":
+      switch (arch) {
+        case "x64":
+          return "x86_64-pc-windows-msvc";
+        case "arm64":
+          return "aarch64-pc-windows-msvc";
+        default:
+          return null;
+      }
+    default:
+      return null;
+  }
+}

--- a/codex-cli/bin/platform.test.js
+++ b/codex-cli/bin/platform.test.js
@@ -1,0 +1,65 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { getTargetTriple } from "./platform.js";
+
+describe("getTargetTriple", () => {
+  describe("android platform", () => {
+    it("returns aarch64-linux-android for android arm64", () => {
+      const result = getTargetTriple("android", "arm64");
+      assert.strictEqual(result, "aarch64-linux-android");
+    });
+
+    it("returns x86_64-linux-android for android x64", () => {
+      const result = getTargetTriple("android", "x64");
+      assert.strictEqual(result, "x86_64-linux-android");
+    });
+
+    it("returns null for unsupported android arch", () => {
+      const result = getTargetTriple("android", "ia32");
+      assert.strictEqual(result, null);
+    });
+  });
+
+  describe("linux platform", () => {
+    it("returns x86_64-unknown-linux-musl for linux x64", () => {
+      const result = getTargetTriple("linux", "x64");
+      assert.strictEqual(result, "x86_64-unknown-linux-musl");
+    });
+
+    it("returns aarch64-unknown-linux-musl for linux arm64", () => {
+      const result = getTargetTriple("linux", "arm64");
+      assert.strictEqual(result, "aarch64-unknown-linux-musl");
+    });
+  });
+
+  describe("darwin platform", () => {
+    it("returns x86_64-apple-darwin for darwin x64", () => {
+      const result = getTargetTriple("darwin", "x64");
+      assert.strictEqual(result, "x86_64-apple-darwin");
+    });
+
+    it("returns aarch64-apple-darwin for darwin arm64", () => {
+      const result = getTargetTriple("darwin", "arm64");
+      assert.strictEqual(result, "aarch64-apple-darwin");
+    });
+  });
+
+  describe("win32 platform", () => {
+    it("returns x86_64-pc-windows-msvc for win32 x64", () => {
+      const result = getTargetTriple("win32", "x64");
+      assert.strictEqual(result, "x86_64-pc-windows-msvc");
+    });
+
+    it("returns aarch64-pc-windows-msvc for win32 arm64", () => {
+      const result = getTargetTriple("win32", "arm64");
+      assert.strictEqual(result, "aarch64-pc-windows-msvc");
+    });
+  });
+
+  describe("unsupported platform", () => {
+    it("returns null for unsupported platform", () => {
+      const result = getTargetTriple("freebsd", "x64");
+      assert.strictEqual(result, null);
+    });
+  });
+});

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -13,7 +13,8 @@
   },
   "os": [
     "darwin",
-    "linux"
+    "linux",
+    "android"
   ],
   "cpu": [
     "x64",

--- a/docs/release_management.md
+++ b/docs/release_management.md
@@ -1,5 +1,22 @@
 # Release Management
 
+## Supported Platforms
+
+The following platforms are supported:
+
+| Platform         | Architecture | Target Triple              |
+| ---------------- | ------------ | -------------------------- |
+| Linux            | x86_64       | x86_64-unknown-linux-musl  |
+| Linux            | arm64        | aarch64-unknown-linux-musl |
+| macOS            | x86_64       | x86_64-apple-darwin        |
+| macOS            | arm64        | aarch64-apple-darwin       |
+| Android (Termux) | arm64        | aarch64-linux-android      |
+| Android (Termux) | x86_64       | x86_64-linux-android       |
+
+Android binaries are cross-compiled using Android NDK 26.1 with API level 30 (Android 11+).
+
+## Distribution
+
 Currently, we made Codex binaries available in three places:
 
 - GitHub Releases https://github.com/openai/codex/releases/


### PR DESCRIPTION
## Summary
Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Add Android cross-compilation targets (aarch64-linux-android, x86_64-linux-android) to the release workflow
- Extract platform detection into testable platform.js module
- Fix Android platform detection (was incorrectly falling through to Linux MUSL targets)
- Update both nori.js and codex.js to use shared platform module
- Add unit tests for platform detection
- Update documentation with supported platforms table

## Technical Details

- Uses Android NDK 26.1 for cross-compilation
- Targets Android API level 30 (Android 11+)
- Codebase already has Android-specific conditionals in process-hardening and TUI crates

## Test Plan
- [x] Unit tests for platform detection (10 tests pass)
- [x] Rust tests pass (15 tests)
- [x] Prettier formatting passes
- [x] Clippy linting passes
- [ ] CI builds Android targets successfully (verify after merge)
- [ ] Manual testing on Termux (post-release)

Share Nori with your team: https://www.npmjs.com/package/nori-ai