### PR TITLE
fix(tui): Preserve status indicator during streaming commits

### DIFF
--- a/codex-rs/tui/docs.md
+++ b/codex-rs/tui/docs.md
@@ -177,6 +177,20 @@ The app uses a tokio-based event loop that multiplexes:
 
 State updates flow through `app_event_sender.rs` channels.
 
+**Status Indicator Lifecycle:**
+
+The "Working (Xs)" status indicator in the bottom pane is controlled exclusively by conversational turn boundaries:
+
+- **Shown**: When `TaskStarted` event arrives, `on_task_started()` calls `set_task_running(true)`
+- **Hidden**: When `TaskComplete` event arrives, `on_task_complete()` calls `set_task_running(false)`
+
+**Invariant**: Streaming operations (e.g., `on_commit_tick()`) must NOT call `hide_status_indicator()`. The status indicator should remain visible throughout the entire conversational turn, including during:
+- Streaming text deltas being committed to history
+- Subagent completions (when parent turn is still active)
+- Tool call executions
+
+This ensures users see continuous "Working" feedback until the agent's conversational turn fully completes.
+
 **Interrupt Queueing and Approval Handling:**
 
 Most event types (exec begin/end, MCP calls, elicitation) are queued during active streaming and flushed when streaming completes via `InterruptManager`. However, **approval requests are handled immediately** (not deferred):

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -948,7 +948,11 @@ impl ChatWidget {
         if let Some(controller) = self.stream_controller.as_mut() {
             let (cell, is_idle) = controller.on_commit_tick();
             if let Some(cell) = cell {
-                self.bottom_pane.hide_status_indicator();
+                // NOTE: Do NOT hide the status indicator here. The "Working (Xs)"
+                // message should remain visible until the conversational turn fully
+                // completes (when TaskComplete event arrives and set_task_running(false)
+                // is called). Hiding it during streaming commits causes the indicator
+                // to disappear prematurely while the agent is still processing.
                 self.add_boxed_history(cell);
             }
             if is_idle {

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -881,7 +881,13 @@ fn streaming_final_answer_keeps_task_running_state() {
     chat.on_commit_tick();
 
     assert!(chat.bottom_pane.is_task_running());
-    assert!(chat.bottom_pane.status_widget().is_none());
+    // The status indicator ("Working (Xs)") should remain visible during streaming
+    // until the conversational turn fully completes (TaskComplete event).
+    // Previously this was incorrectly hidden during on_commit_tick.
+    assert!(
+        chat.bottom_pane.status_widget().is_some(),
+        "status indicator should remain visible during streaming until task completes"
+    );
 
     chat.bottom_pane
         .set_composer_text("queued submission".to_string());


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Fixed bug where the "Working (Xs)" status indicator disappeared prematurely while the agent was still processing
- Removed erroneous `hide_status_indicator()` call from `on_commit_tick()` method in chatwidget.rs
- Added documentation in docs.md explaining the Status Indicator Lifecycle invariant

## Root Cause

The `on_commit_tick()` method was calling `hide_status_indicator()` whenever streaming content was committed to history. This caused the status indicator to disappear mid-turn, such as when a spawned subagent completed streaming but the parent conversational turn was still active.

## Fix

The status indicator lifecycle should be controlled exclusively by conversational turn boundaries:
- **Shown**: When `TaskStarted` event arrives (`set_task_running(true)`)
- **Hidden**: When `TaskComplete` event arrives (`set_task_running(false)`)

Streaming operations should NOT affect status indicator visibility.

## Test Plan
- [x] Updated existing test `streaming_final_answer_keeps_task_running_state` to verify correct behavior
- [x] Verified test fails with old code (TDD red phase)
- [x] Verified test passes with fix (TDD green phase)
- [x] All 557 TUI tests pass
- [x] Clippy passes with no warnings

Share Nori with your team: https://www.npmjs.com/package/nori-ai