### PR TITLE
feat(tui): Display actual model name in approval overlay

### DIFF
--- a/codex-rs/tui/docs.md
+++ b/codex-rs/tui/docs.md
@@ -202,6 +202,18 @@ Most event types (exec begin/end, MCP calls, elicitation) are queued during acti
 - The `InterruptManager` still contains `ExecApproval` and `ApplyPatchApproval` variants for completeness, but these methods are marked `#[allow(dead_code)]`
 - `on_task_complete()` calls `flush_interrupt_queue()` for any remaining queued items
 
+**Approval Overlay Model Display Name:**
+
+The approval overlay displays the current agent's display name (e.g., "Claude", "Gemini") instead of a hardcoded name in options like "No, and tell Claude what to do differently". The display name flows through:
+
+1. `ChatWidget` initialization resolves the display name via `nori::agent_picker::get_agent_info(model)`, falling back to the raw model name if not found
+2. `BottomPaneParams.model_display_name` carries the name to `BottomPane`
+3. `BottomPane.set_model_display_name()` allows dynamic updates when agent switches
+4. `ApprovalOverlay::new()` receives the display name and passes it to `exec_options()` / `patch_options()`
+5. If the display name is empty, "the agent" is used as fallback
+
+Updates occur via `set_pending_agent()` (when user selects new agent) and `set_model()` (when model changes), ensuring the approval dialog always reflects the active agent.
+
 **Pending ExecCell Tracking:**
 
 The `PendingExecCellTracker` (`chatwidget/pending_exec_cells.rs`) prevents duplicate ACP tool call messages in the chat history. The problem it solves:

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1021,6 +1021,9 @@ impl App {
                 error,
             } => {
                 if success {
+                    // Update the approval dialog display name to reflect the new model
+                    self.chat_widget
+                        .update_model_display_name(display_name.clone());
                     self.chat_widget
                         .add_info_message(format!("Model switched to: {display_name}"), None);
                 } else {

--- a/codex-rs/tui/src/bottom_pane/approval_overlay.rs
+++ b/codex-rs/tui/src/bottom_pane/approval_overlay.rs
@@ -67,10 +67,15 @@ pub(crate) struct ApprovalOverlay {
     options: Vec<ApprovalOption>,
     current_complete: bool,
     done: bool,
+    model_display_name: String,
 }
 
 impl ApprovalOverlay {
-    pub fn new(request: ApprovalRequest, app_event_tx: AppEventSender) -> Self {
+    pub fn new(
+        request: ApprovalRequest,
+        app_event_tx: AppEventSender,
+        model_display_name: String,
+    ) -> Self {
         let mut view = Self {
             current_request: None,
             current_variant: None,
@@ -80,6 +85,7 @@ impl ApprovalOverlay {
             options: Vec::new(),
             current_complete: false,
             done: false,
+            model_display_name,
         };
         view.set_current(request);
         view
@@ -94,7 +100,7 @@ impl ApprovalOverlay {
         let ApprovalRequestState { variant, header } = ApprovalRequestState::from(request);
         self.current_variant = Some(variant.clone());
         self.current_complete = false;
-        let (options, params) = Self::build_options(variant, header);
+        let (options, params) = Self::build_options(variant, header, &self.model_display_name);
         self.options = options;
         self.list = ListSelectionView::new(params, self.app_event_tx.clone());
     }
@@ -102,14 +108,15 @@ impl ApprovalOverlay {
     fn build_options(
         variant: ApprovalVariant,
         header: Box<dyn Renderable>,
+        model_display_name: &str,
     ) -> (Vec<ApprovalOption>, SelectionViewParams) {
         let (options, title) = match &variant {
             ApprovalVariant::Exec { .. } => (
-                exec_options(),
+                exec_options(model_display_name),
                 "Would you like to run the following command?".to_string(),
             ),
             ApprovalVariant::ApplyPatch { .. } => (
-                patch_options(),
+                patch_options(model_display_name),
                 "Would you like to make the following edits?".to_string(),
             ),
             ApprovalVariant::McpElicitation { server_name, .. } => (
@@ -463,7 +470,12 @@ impl ApprovalOption {
     }
 }
 
-fn exec_options() -> Vec<ApprovalOption> {
+fn exec_options(model_display_name: &str) -> Vec<ApprovalOption> {
+    let display_name = if model_display_name.is_empty() {
+        "the agent"
+    } else {
+        model_display_name
+    };
     vec![
         ApprovalOption {
             label: "Yes, proceed".to_string(),
@@ -478,7 +490,7 @@ fn exec_options() -> Vec<ApprovalOption> {
             additional_shortcuts: vec![key_hint::plain(KeyCode::Char('a'))],
         },
         ApprovalOption {
-            label: "No, and tell Codex what to do differently".to_string(),
+            label: format!("No, and tell {display_name} what to do differently"),
             decision: ApprovalDecision::Review(ReviewDecision::Abort),
             display_shortcut: Some(key_hint::plain(KeyCode::Esc)),
             additional_shortcuts: vec![key_hint::plain(KeyCode::Char('n'))],
@@ -486,7 +498,12 @@ fn exec_options() -> Vec<ApprovalOption> {
     ]
 }
 
-fn patch_options() -> Vec<ApprovalOption> {
+fn patch_options(model_display_name: &str) -> Vec<ApprovalOption> {
+    let display_name = if model_display_name.is_empty() {
+        "the agent"
+    } else {
+        model_display_name
+    };
     vec![
         ApprovalOption {
             label: "Yes, proceed".to_string(),
@@ -495,7 +512,7 @@ fn patch_options() -> Vec<ApprovalOption> {
             additional_shortcuts: vec![key_hint::plain(KeyCode::Char('y'))],
         },
         ApprovalOption {
-            label: "No, and tell Codex what to do differently".to_string(),
+            label: format!("No, and tell {display_name} what to do differently"),
             decision: ApprovalDecision::Review(ReviewDecision::Abort),
             display_shortcut: Some(key_hint::plain(KeyCode::Esc)),
             additional_shortcuts: vec![key_hint::plain(KeyCode::Char('n'))],
@@ -546,7 +563,7 @@ mod tests {
     fn ctrl_c_aborts_and_clears_queue() {
         let (tx, _rx) = unbounded_channel::<AppEvent>();
         let tx = AppEventSender::new(tx);
-        let mut view = ApprovalOverlay::new(make_exec_request(), tx);
+        let mut view = ApprovalOverlay::new(make_exec_request(), tx, String::new());
         view.enqueue_request(make_exec_request());
         assert_eq!(CancellationEvent::Handled, view.on_ctrl_c());
         assert!(view.queue.is_empty());
@@ -557,7 +574,7 @@ mod tests {
     fn shortcut_triggers_selection() {
         let (tx, mut rx) = unbounded_channel::<AppEvent>();
         let tx = AppEventSender::new(tx);
-        let mut view = ApprovalOverlay::new(make_exec_request(), tx);
+        let mut view = ApprovalOverlay::new(make_exec_request(), tx, String::new());
         assert!(!view.is_complete());
         view.handle_key_event(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
         // We expect at least one CodexOp message in the queue.
@@ -583,7 +600,7 @@ mod tests {
             risk: None,
         };
 
-        let view = ApprovalOverlay::new(exec_request, tx);
+        let view = ApprovalOverlay::new(exec_request, tx, String::new());
         let mut buf = Buffer::empty(Rect::new(0, 0, 80, view.desired_height(80)));
         view.render(Rect::new(0, 0, 80, view.desired_height(80)), &mut buf);
 
@@ -633,7 +650,7 @@ mod tests {
     fn enter_sets_last_selected_index_without_dismissing() {
         let (tx_raw, mut rx) = unbounded_channel::<AppEvent>();
         let tx = AppEventSender::new(tx_raw);
-        let mut view = ApprovalOverlay::new(make_exec_request(), tx);
+        let mut view = ApprovalOverlay::new(make_exec_request(), tx, String::new());
         view.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         view.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
 
@@ -650,5 +667,100 @@ mod tests {
             }
         }
         assert_eq!(decision, Some(ReviewDecision::ApprovedForSession));
+    }
+
+    #[test]
+    fn exec_approval_shows_model_name_in_deny_option() {
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx);
+        let exec_request = ApprovalRequest::Exec {
+            id: "test".into(),
+            command: vec!["echo".into(), "test".into()],
+            reason: None,
+            risk: None,
+        };
+
+        let view = ApprovalOverlay::new(exec_request, tx, "Claude".to_string());
+        let mut buf = Buffer::empty(Rect::new(0, 0, 80, view.desired_height(80)));
+        view.render(Rect::new(0, 0, 80, view.desired_height(80)), &mut buf);
+
+        let rendered: Vec<String> = (0..buf.area.height)
+            .map(|row| {
+                (0..buf.area.width)
+                    .map(|col| buf[(col, row)].symbol().to_string())
+                    .collect()
+            })
+            .collect();
+
+        assert!(
+            rendered.iter().any(|line| line.contains("tell Claude")),
+            "expected deny option to include model name 'Claude', got {rendered:?}"
+        );
+        assert!(
+            !rendered.iter().any(|line| line.contains("tell Codex")),
+            "should not contain hardcoded 'Codex', got {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn patch_approval_shows_model_name_in_deny_option() {
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx);
+        let patch_request = ApprovalRequest::ApplyPatch {
+            id: "test".into(),
+            reason: None,
+            cwd: PathBuf::from("/tmp"),
+            changes: HashMap::new(),
+        };
+
+        let view = ApprovalOverlay::new(patch_request, tx, "Gemini".to_string());
+        let mut buf = Buffer::empty(Rect::new(0, 0, 80, view.desired_height(80)));
+        view.render(Rect::new(0, 0, 80, view.desired_height(80)), &mut buf);
+
+        let rendered: Vec<String> = (0..buf.area.height)
+            .map(|row| {
+                (0..buf.area.width)
+                    .map(|col| buf[(col, row)].symbol().to_string())
+                    .collect()
+            })
+            .collect();
+
+        assert!(
+            rendered.iter().any(|line| line.contains("tell Gemini")),
+            "expected deny option to include model name 'Gemini', got {rendered:?}"
+        );
+        assert!(
+            !rendered.iter().any(|line| line.contains("tell Codex")),
+            "should not contain hardcoded 'Codex', got {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn approval_overlay_uses_fallback_for_empty_model_name() {
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx);
+        let exec_request = ApprovalRequest::Exec {
+            id: "test".into(),
+            command: vec!["echo".into(), "test".into()],
+            reason: None,
+            risk: None,
+        };
+
+        let view = ApprovalOverlay::new(exec_request, tx, "".to_string());
+        let mut buf = Buffer::empty(Rect::new(0, 0, 80, view.desired_height(80)));
+        view.render(Rect::new(0, 0, 80, view.desired_height(80)), &mut buf);
+
+        let rendered: Vec<String> = (0..buf.area.height)
+            .map(|row| {
+                (0..buf.area.width)
+                    .map(|col| buf[(col, row)].symbol().to_string())
+                    .collect()
+            })
+            .collect();
+
+        assert!(
+            rendered.iter().any(|line| line.contains("tell the agent")),
+            "expected deny option to use fallback 'the agent' for empty model name, got {rendered:?}"
+        );
     }
 }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -80,6 +80,8 @@ pub(crate) struct BottomPane {
     /// Queued user messages to show above the composer while a turn is running.
     queued_user_messages: QueuedUserMessages,
     context_window_percent: Option<i64>,
+    /// Display name of the current model/agent for use in approval dialogs.
+    model_display_name: String,
 }
 
 pub(crate) struct BottomPaneParams {
@@ -90,6 +92,7 @@ pub(crate) struct BottomPaneParams {
     pub(crate) placeholder_text: String,
     pub(crate) disable_paste_burst: bool,
     pub(crate) animations_enabled: bool,
+    pub(crate) model_display_name: String,
 }
 
 impl BottomPane {
@@ -102,6 +105,7 @@ impl BottomPane {
             placeholder_text,
             disable_paste_burst,
             animations_enabled,
+            model_display_name,
         } = params;
         let mut composer = ChatComposer::new(
             has_input_focus,
@@ -137,6 +141,7 @@ impl BottomPane {
             esc_backtrack_hint: false,
             animations_enabled,
             context_window_percent: None,
+            model_display_name,
         }
     }
 
@@ -373,6 +378,11 @@ impl BottomPane {
         self.request_redraw();
     }
 
+    /// Update the model display name used in approval dialogs.
+    pub(crate) fn set_model_display_name(&mut self, name: String) {
+        self.model_display_name = name;
+    }
+
     /// Show a generic list selection view with the provided items.
     pub(crate) fn show_selection_view(&mut self, params: list_selection_view::SelectionViewParams) {
         let view = list_selection_view::ListSelectionView::new(params, self.app_event_tx.clone());
@@ -431,7 +441,11 @@ impl BottomPane {
         };
 
         // Otherwise create a new approval modal overlay.
-        let modal = ApprovalOverlay::new(request, self.app_event_tx.clone());
+        let modal = ApprovalOverlay::new(
+            request,
+            self.app_event_tx.clone(),
+            self.model_display_name.clone(),
+        );
         self.pause_status_timer_for_modal();
         self.push_view(Box::new(modal));
     }
@@ -593,6 +607,7 @@ mod tests {
             placeholder_text: "Ask Codex to do anything".to_string(),
             disable_paste_burst: false,
             animations_enabled: true,
+            model_display_name: String::new(),
         });
         pane.push_approval_request(exec_request());
         assert_eq!(CancellationEvent::Handled, pane.on_ctrl_c());
@@ -614,6 +629,7 @@ mod tests {
             placeholder_text: "Ask Codex to do anything".to_string(),
             disable_paste_burst: false,
             animations_enabled: true,
+            model_display_name: String::new(),
         });
 
         // Create an approval modal (active view).
@@ -646,6 +662,7 @@ mod tests {
             placeholder_text: "Ask Codex to do anything".to_string(),
             disable_paste_burst: false,
             animations_enabled: true,
+            model_display_name: String::new(),
         });
 
         // Start a running task so the status indicator is active above the composer.
@@ -712,6 +729,7 @@ mod tests {
             placeholder_text: "Ask Codex to do anything".to_string(),
             disable_paste_burst: false,
             animations_enabled: true,
+            model_display_name: String::new(),
         });
 
         // Begin a task: show initial status.
@@ -738,6 +756,7 @@ mod tests {
             placeholder_text: "Ask Codex to do anything".to_string(),
             disable_paste_burst: false,
             animations_enabled: true,
+            model_display_name: String::new(),
         });
 
         // Activate spinner (status view replaces composer) with no live ring.
@@ -768,6 +787,7 @@ mod tests {
             placeholder_text: "Ask Codex to do anything".to_string(),
             disable_paste_burst: false,
             animations_enabled: true,
+            model_display_name: String::new(),
         });
 
         pane.set_task_running(true);
@@ -795,6 +815,7 @@ mod tests {
             placeholder_text: "Ask Codex to do anything".to_string(),
             disable_paste_burst: false,
             animations_enabled: true,
+            model_display_name: String::new(),
         });
 
         pane.set_task_running(true);

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1381,6 +1381,9 @@ impl ChatWidget {
                 placeholder_text: placeholder,
                 disable_paste_burst: config.disable_paste_burst,
                 animations_enabled: config.animations,
+                model_display_name: crate::nori::agent_picker::get_agent_info(&config.model)
+                    .map(|info| info.display_name)
+                    .unwrap_or_else(|| config.model.clone()),
             }),
             active_cell: None,
             config: config.clone(),
@@ -1468,6 +1471,9 @@ impl ChatWidget {
                 placeholder_text: placeholder,
                 disable_paste_burst: config.disable_paste_burst,
                 animations_enabled: config.animations,
+                model_display_name: crate::nori::agent_picker::get_agent_info(&config.model)
+                    .map(|info| info.display_name)
+                    .unwrap_or_else(|| config.model.clone()),
             }),
             active_cell: None,
             config: config.clone(),
@@ -1523,6 +1529,9 @@ impl ChatWidget {
 
     /// Set a pending agent to switch to on the next prompt submission.
     pub(crate) fn set_pending_agent(&mut self, model_name: String, display_name: String) {
+        // Update the bottom pane's model display name for approval dialogs
+        self.bottom_pane
+            .set_model_display_name(display_name.clone());
         self.pending_agent = Some(PendingAgentInfo {
             model_name,
             display_name,
@@ -3160,6 +3169,18 @@ impl ChatWidget {
     pub(crate) fn set_model(&mut self, model: &str) {
         self.session_header.set_model(model);
         self.config.model = model.to_string();
+        // Update the bottom pane's model display name for approval dialogs
+        let display_name = crate::nori::agent_picker::get_agent_info(model)
+            .map(|info| info.display_name)
+            .unwrap_or_else(|| model.to_string());
+        self.bottom_pane.set_model_display_name(display_name);
+    }
+
+    /// Update the model display name shown in approval dialogs.
+    /// Used when ACP model switch completes successfully.
+    #[cfg(feature = "unstable")]
+    pub(crate) fn update_model_display_name(&mut self, display_name: String) {
+        self.bottom_pane.set_model_display_name(display_name);
     }
 
     pub(crate) fn add_info_message(&mut self, message: String, hint: Option<String>) {

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_exec.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_exec.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/chatwidget/tests.rs
+assertion_line: 1929
 expression: terminal.backend().vt100().screen().contents()
 ---
   Would you like to run the following command?
@@ -11,6 +12,6 @@ expression: terminal.backend().vt100().screen().contents()
 
 › 1. Yes, proceed (y)
   2. Yes, and don't ask again for this command (a)
-  3. No, and tell Codex what to do differently (esc)
+  3. No, and tell the agent what to do differently (esc)
 
   Press enter to confirm or esc to cancel

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_exec_no_reason.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_exec_no_reason.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/chatwidget/tests.rs
+assertion_line: 1963
 expression: terminal.backend().vt100().screen().contents()
 ---
   Would you like to run the following command?
@@ -8,6 +9,6 @@ expression: terminal.backend().vt100().screen().contents()
 
 › 1. Yes, proceed (y)
   2. Yes, and don't ask again for this command (a)
-  3. No, and tell Codex what to do differently (esc)
+  3. No, and tell the agent what to do differently (esc)
 
   Press enter to confirm or esc to cancel

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_patch.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_patch.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/chatwidget/tests.rs
+assertion_line: 2003
 expression: terminal.backend().vt100().screen().contents()
 ---
   Would you like to make the following edits?
@@ -12,6 +13,6 @@ expression: terminal.backend().vt100().screen().contents()
     2 +world
 
 › 1. Yes, proceed (y)
-  2. No, and tell Codex what to do differently (esc)
+  2. No, and tell the agent what to do differently (esc)
 
   Press enter to confirm or esc to cancel

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__exec_approval_modal_exec.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__exec_approval_modal_exec.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/chatwidget/tests.rs
+assertion_line: 621
 expression: "format!(\"{buf:?}\")"
 ---
 Buffer {
@@ -16,7 +17,7 @@ Buffer {
         "                                                                                ",
         "› 1. Yes, proceed (y)                                                           ",
         "  2. Yes, and don't ask again for this command (a)                              ",
-        "  3. No, and tell Codex what to do differently (esc)                            ",
+        "  3. No, and tell the agent what to do differently (esc)                        ",
         "                                                                                ",
         "  Press enter to confirm or esc to cancel                                       ",
     ],
@@ -32,8 +33,8 @@ Buffer {
         x: 21, y: 9, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
         x: 48, y: 10, fg: Reset, bg: Reset, underline: Reset, modifier: DIM,
         x: 49, y: 10, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
-        x: 48, y: 11, fg: Reset, bg: Reset, underline: Reset, modifier: DIM,
-        x: 51, y: 11, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 52, y: 11, fg: Reset, bg: Reset, underline: Reset, modifier: DIM,
+        x: 55, y: 11, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
         x: 2, y: 13, fg: Reset, bg: Reset, underline: Reset, modifier: DIM,
     ]
 }

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_and_approval_modal.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_and_approval_modal.snap
@@ -1,6 +1,6 @@
 ---
 source: tui/src/chatwidget/tests.rs
-assertion_line: 1548
+assertion_line: 2176
 expression: terminal.backend()
 ---
 "                                                                                "
@@ -14,6 +14,6 @@ expression: terminal.backend()
 "                                                                                "
 "› 1. Yes, proceed (y)                                                           "
 "  2. Yes, and don't ask again for this command (a)                              "
-"  3. No, and tell Codex what to do differently (esc)                            "
+"  3. No, and tell the agent what to do differently (esc)                        "
 "                                                                                "
 "  Press enter to confirm or esc to cancel                                       "

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -341,6 +341,7 @@ fn make_chatwidget_manual() -> (
         placeholder_text: "Ask Codex to do anything".to_string(),
         disable_paste_burst: false,
         animations_enabled: cfg.animations,
+        model_display_name: String::new(),
     });
     let auth_manager = AuthManager::from_auth_for_testing(CodexAuth::from_api_key("test"));
     let widget = ChatWidget {

--- a/codex-rs/tui/src/nori/docs.md
+++ b/codex-rs/tui/src/nori/docs.md
@@ -69,6 +69,7 @@ The `discover_all_instruction_files()` function discovers ALL instruction files 
 - `agent_picker_params()` consumes `codex_acp::list_available_agents()` so `/agent` can display each `AcpAgentInfo` entry with a `SelectionAction` that sends `AppEvent::SetPendingAgent`
 - `acp_model_picker_params()` renders a fallback when the `unstable` feature is disabled
 - `PendingAgentSelection` holds the selected model/display name pair until the next prompt triggers `AppEvent::SubmitWithAgentSwitch`
+- `get_agent_info(model_name)` looks up agent metadata (display name, description) from the available agents list by model name (case-insensitive). Used by `chatwidget.rs` to resolve human-readable display names for approval dialogs.
 
 **Feedback Redirect (`feedback.rs`):**
 


### PR DESCRIPTION
## Summary

- Replace hardcoded "Codex" with the actual agent's display name in approval dialogs
- The text "No, and tell Codex what to do differently" now dynamically shows which ACP agent the user is interacting with (e.g., "No, and tell Claude what to do differently")
- Use "the agent" as fallback when model name is empty

## Test plan

- [x] Unit tests added for model name display in approval overlay
- [x] All existing tests pass
- [x] Snapshot tests updated to reflect new behavior
- [x] Verified clippy and rustfmt pass