### PR TITLE
feat(tui): Add in-app login authentication support

### DIFF
--- a/codex-rs/login/src/anthropic_server.rs
+++ b/codex-rs/login/src/anthropic_server.rs
@@ -1,0 +1,539 @@
+//! Anthropic OAuth login server for Claude Code authentication.
+//!
+//! This module provides OAuth browser-based authentication for Anthropic's Claude Code,
+//! similar to how `server.rs` handles OpenAI authentication.
+
+use std::io::Cursor;
+use std::io::Read;
+use std::io::Write;
+use std::io::{self};
+use std::net::SocketAddr;
+use std::net::TcpStream;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use crate::pkce::PkceCodes;
+use crate::pkce::generate_pkce;
+use base64::Engine;
+use rand::RngCore;
+use tiny_http::Header;
+use tiny_http::Request;
+use tiny_http::Response;
+use tiny_http::Server;
+use tiny_http::StatusCode;
+
+/// Anthropic OAuth issuer URL
+pub const ANTHROPIC_ISSUER: &str = "https://console.anthropic.com";
+/// Default port for the local OAuth callback server
+const DEFAULT_PORT: u16 = 1456;
+/// Anthropic OAuth client ID for Claude Code CLI
+pub const ANTHROPIC_CLIENT_ID: &str = "9d3c964e-d6f1-41b7-bff4-b29f0ce41766";
+
+/// Options for running the Anthropic login server
+#[derive(Debug, Clone)]
+pub struct AnthropicServerOptions {
+    /// Path to store authentication credentials
+    pub config_dir: PathBuf,
+    /// OAuth client ID
+    pub client_id: String,
+    /// OAuth issuer URL
+    pub issuer: String,
+    /// Port for the local callback server
+    pub port: u16,
+    /// Whether to automatically open the browser
+    pub open_browser: bool,
+}
+
+impl AnthropicServerOptions {
+    /// Create new options with defaults for Claude Code
+    pub fn new(config_dir: PathBuf) -> Self {
+        Self {
+            config_dir,
+            client_id: ANTHROPIC_CLIENT_ID.to_string(),
+            issuer: ANTHROPIC_ISSUER.to_string(),
+            port: DEFAULT_PORT,
+            open_browser: true,
+        }
+    }
+}
+
+/// Anthropic login server handle
+pub struct AnthropicLoginServer {
+    /// The OAuth authorization URL to open in browser
+    pub auth_url: String,
+    /// The actual port the server is listening on
+    pub actual_port: u16,
+    /// Handle to the server task
+    server_handle: tokio::task::JoinHandle<io::Result<()>>,
+    /// Handle to cancel the server
+    shutdown_handle: AnthropicShutdownHandle,
+}
+
+impl AnthropicLoginServer {
+    /// Block until the login flow completes
+    pub async fn block_until_done(self) -> io::Result<()> {
+        self.server_handle
+            .await
+            .map_err(|err| io::Error::other(format!("login server thread panicked: {err:?}")))?
+    }
+
+    /// Cancel the login flow
+    pub fn cancel(&self) {
+        self.shutdown_handle.shutdown();
+    }
+
+    /// Get a handle for cancelling the server
+    pub fn cancel_handle(&self) -> AnthropicShutdownHandle {
+        self.shutdown_handle.clone()
+    }
+}
+
+/// Handle to cancel the Anthropic login server
+#[derive(Clone, Debug)]
+pub struct AnthropicShutdownHandle {
+    shutdown_notify: Arc<tokio::sync::Notify>,
+}
+
+impl AnthropicShutdownHandle {
+    /// Trigger server shutdown
+    pub fn shutdown(&self) {
+        self.shutdown_notify.notify_waiters();
+    }
+}
+
+/// Run the Anthropic OAuth login server
+pub fn run_anthropic_login_server(opts: AnthropicServerOptions) -> io::Result<AnthropicLoginServer> {
+    let pkce = generate_pkce();
+    let state = generate_state();
+
+    let server = bind_server(opts.port)?;
+    let actual_port = match server.server_addr().to_ip() {
+        Some(addr) => addr.port(),
+        None => {
+            return Err(io::Error::new(
+                io::ErrorKind::AddrInUse,
+                "Unable to determine the server port",
+            ));
+        }
+    };
+    let server = Arc::new(server);
+
+    let redirect_uri = format!("http://localhost:{actual_port}/callback");
+    let auth_url = build_authorize_url(&opts.issuer, &opts.client_id, &redirect_uri, &pkce, &state);
+
+    if opts.open_browser {
+        let _ = webbrowser::open(&auth_url);
+    }
+
+    // Map blocking reads from server.recv() to an async channel
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Request>(16);
+    let _server_handle = {
+        let server = server.clone();
+        thread::spawn(move || -> io::Result<()> {
+            while let Ok(request) = server.recv() {
+                tx.blocking_send(request).map_err(|e| {
+                    eprintln!("Failed to send request to channel: {e}");
+                    io::Error::other("Failed to send request to channel")
+                })?;
+            }
+            Ok(())
+        })
+    };
+
+    let shutdown_notify = Arc::new(tokio::sync::Notify::new());
+    let server_handle = {
+        let shutdown_notify = shutdown_notify.clone();
+        let server = server;
+        tokio::spawn(async move {
+            let result = loop {
+                tokio::select! {
+                    _ = shutdown_notify.notified() => {
+                        break Err(io::Error::other("Login was not completed"));
+                    }
+                    maybe_req = rx.recv() => {
+                        let Some(req) = maybe_req else {
+                            break Err(io::Error::other("Login was not completed"));
+                        };
+
+                        let url_raw = req.url().to_string();
+                        let response =
+                            process_request(&url_raw, &opts, &redirect_uri, &pkce, actual_port, &state).await;
+
+                        let exit_result = match response {
+                            HandledRequest::Response(response) => {
+                                let _ = tokio::task::spawn_blocking(move || req.respond(response)).await;
+                                None
+                            }
+                            HandledRequest::ResponseAndExit {
+                                headers,
+                                body,
+                                result,
+                            } => {
+                                let _ = tokio::task::spawn_blocking(move || {
+                                    send_response_with_disconnect(req, headers, body)
+                                })
+                                .await;
+                                Some(result)
+                            }
+                            HandledRequest::RedirectWithHeader(header) => {
+                                let redirect = Response::empty(302).with_header(header);
+                                let _ = tokio::task::spawn_blocking(move || req.respond(redirect)).await;
+                                None
+                            }
+                        };
+
+                        if let Some(result) = exit_result {
+                            break result;
+                        }
+                    }
+                }
+            };
+
+            server.unblock();
+            result
+        })
+    };
+
+    Ok(AnthropicLoginServer {
+        auth_url,
+        actual_port,
+        server_handle,
+        shutdown_handle: AnthropicShutdownHandle { shutdown_notify },
+    })
+}
+
+enum HandledRequest {
+    Response(Response<Cursor<Vec<u8>>>),
+    RedirectWithHeader(Header),
+    ResponseAndExit {
+        headers: Vec<Header>,
+        body: Vec<u8>,
+        result: io::Result<()>,
+    },
+}
+
+async fn process_request(
+    url_raw: &str,
+    opts: &AnthropicServerOptions,
+    redirect_uri: &str,
+    pkce: &PkceCodes,
+    actual_port: u16,
+    state: &str,
+) -> HandledRequest {
+    let parsed_url = match url::Url::parse(&format!("http://localhost{url_raw}")) {
+        Ok(u) => u,
+        Err(e) => {
+            eprintln!("URL parse error: {e}");
+            return HandledRequest::Response(
+                Response::from_string("Bad Request").with_status_code(400),
+            );
+        }
+    };
+    let path = parsed_url.path().to_string();
+
+    match path.as_str() {
+        "/callback" => {
+            let params: std::collections::HashMap<String, String> =
+                parsed_url.query_pairs().into_owned().collect();
+
+            // Check for errors first
+            if let Some(error) = params.get("error") {
+                let error_desc = params
+                    .get("error_description")
+                    .cloned()
+                    .unwrap_or_else(|| "Authentication failed".to_string());
+                return HandledRequest::ResponseAndExit {
+                    headers: match Header::from_bytes(
+                        &b"Content-Type"[..],
+                        &b"text/html; charset=utf-8"[..],
+                    ) {
+                        Ok(header) => vec![header],
+                        Err(_) => Vec::new(),
+                    },
+                    body: format!(
+                        "<html><body><h1>Authentication Failed</h1><p>{}: {}</p></body></html>",
+                        error, error_desc
+                    )
+                    .into_bytes(),
+                    result: Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!("{}: {}", error, error_desc),
+                    )),
+                };
+            }
+
+            // Verify state
+            if params.get("state").map(String::as_str) != Some(state) {
+                return HandledRequest::Response(
+                    Response::from_string("State mismatch").with_status_code(400),
+                );
+            }
+
+            let code = match params.get("code") {
+                Some(c) if !c.is_empty() => c.clone(),
+                _ => {
+                    return HandledRequest::Response(
+                        Response::from_string("Missing authorization code").with_status_code(400),
+                    );
+                }
+            };
+
+            match exchange_code_for_tokens(&opts.issuer, &opts.client_id, redirect_uri, pkce, &code)
+                .await
+            {
+                Ok(tokens) => {
+                    // Persist the tokens
+                    if let Err(err) =
+                        persist_anthropic_tokens(&opts.config_dir, &tokens.access_token).await
+                    {
+                        eprintln!("Persist error: {err}");
+                        return HandledRequest::Response(
+                            Response::from_string(format!("Unable to persist auth: {err}"))
+                                .with_status_code(500),
+                        );
+                    }
+
+                    let success_url = format!("http://localhost:{actual_port}/success");
+                    match tiny_http::Header::from_bytes(&b"Location"[..], success_url.as_bytes()) {
+                        Ok(header) => HandledRequest::RedirectWithHeader(header),
+                        Err(_) => HandledRequest::Response(
+                            Response::from_string("Internal Server Error").with_status_code(500),
+                        ),
+                    }
+                }
+                Err(err) => {
+                    eprintln!("Token exchange error: {err}");
+                    HandledRequest::Response(
+                        Response::from_string(format!("Token exchange failed: {err}"))
+                            .with_status_code(500),
+                    )
+                }
+            }
+        }
+        "/success" => {
+            let body = include_str!("assets/anthropic_success.html");
+            HandledRequest::ResponseAndExit {
+                headers: match Header::from_bytes(
+                    &b"Content-Type"[..],
+                    &b"text/html; charset=utf-8"[..],
+                ) {
+                    Ok(header) => vec![header],
+                    Err(_) => Vec::new(),
+                },
+                body: body.as_bytes().to_vec(),
+                result: Ok(()),
+            }
+        }
+        "/cancel" => HandledRequest::ResponseAndExit {
+            headers: Vec::new(),
+            body: b"Login cancelled".to_vec(),
+            result: Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "Login cancelled",
+            )),
+        },
+        _ => HandledRequest::Response(Response::from_string("Not Found").with_status_code(404)),
+    }
+}
+
+fn send_response_with_disconnect(
+    req: Request,
+    mut headers: Vec<Header>,
+    body: Vec<u8>,
+) -> io::Result<()> {
+    let status = StatusCode(200);
+    let mut writer = req.into_writer();
+    let reason = status.default_reason_phrase();
+    write!(writer, "HTTP/1.1 {} {}\r\n", status.0, reason)?;
+    headers.retain(|h| !h.field.equiv("Connection"));
+    if let Ok(close_header) = Header::from_bytes(&b"Connection"[..], &b"close"[..]) {
+        headers.push(close_header);
+    }
+
+    let content_length_value = format!("{}", body.len());
+    if let Ok(content_length_header) =
+        Header::from_bytes(&b"Content-Length"[..], content_length_value.as_bytes())
+    {
+        headers.push(content_length_header);
+    }
+
+    for header in headers {
+        write!(
+            writer,
+            "{}: {}\r\n",
+            header.field.as_str(),
+            header.value.as_str()
+        )?;
+    }
+
+    writer.write_all(b"\r\n")?;
+    writer.write_all(&body)?;
+    writer.flush()
+}
+
+fn build_authorize_url(
+    issuer: &str,
+    client_id: &str,
+    redirect_uri: &str,
+    pkce: &PkceCodes,
+    state: &str,
+) -> String {
+    let query = vec![
+        ("response_type".to_string(), "code".to_string()),
+        ("client_id".to_string(), client_id.to_string()),
+        ("redirect_uri".to_string(), redirect_uri.to_string()),
+        ("scope".to_string(), "openid profile email".to_string()),
+        (
+            "code_challenge".to_string(),
+            pkce.code_challenge.to_string(),
+        ),
+        ("code_challenge_method".to_string(), "S256".to_string()),
+        ("state".to_string(), state.to_string()),
+    ];
+    let qs = query
+        .into_iter()
+        .map(|(k, v)| format!("{k}={}", urlencoding::encode(&v)))
+        .collect::<Vec<_>>()
+        .join("&");
+    format!("{issuer}/oauth/authorize?{qs}")
+}
+
+fn generate_state() -> String {
+    let mut bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut bytes);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn send_cancel_request(port: u16) -> io::Result<()> {
+    let addr: SocketAddr = format!("127.0.0.1:{port}")
+        .parse()
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    let mut stream = TcpStream::connect_timeout(&addr, Duration::from_secs(2))?;
+    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(2)))?;
+
+    stream.write_all(b"GET /cancel HTTP/1.1\r\n")?;
+    stream.write_all(format!("Host: 127.0.0.1:{port}\r\n").as_bytes())?;
+    stream.write_all(b"Connection: close\r\n\r\n")?;
+
+    let mut buf = [0u8; 64];
+    let _ = stream.read(&mut buf);
+    Ok(())
+}
+
+fn bind_server(port: u16) -> io::Result<Server> {
+    let bind_address = format!("127.0.0.1:{port}");
+    let mut cancel_attempted = false;
+    let mut attempts = 0;
+    const MAX_ATTEMPTS: u32 = 10;
+    const RETRY_DELAY: Duration = Duration::from_millis(200);
+
+    loop {
+        match Server::http(&bind_address) {
+            Ok(server) => return Ok(server),
+            Err(err) => {
+                attempts += 1;
+                let is_addr_in_use = err
+                    .downcast_ref::<io::Error>()
+                    .map(|io_err| io_err.kind() == io::ErrorKind::AddrInUse)
+                    .unwrap_or(false);
+
+                if is_addr_in_use {
+                    if !cancel_attempted {
+                        cancel_attempted = true;
+                        if let Err(cancel_err) = send_cancel_request(port) {
+                            eprintln!("Failed to cancel previous login server: {cancel_err}");
+                        }
+                    }
+
+                    thread::sleep(RETRY_DELAY);
+
+                    if attempts >= MAX_ATTEMPTS {
+                        return Err(io::Error::new(
+                            io::ErrorKind::AddrInUse,
+                            format!("Port {bind_address} is already in use"),
+                        ));
+                    }
+
+                    continue;
+                }
+
+                return Err(io::Error::other(err));
+            }
+        }
+    }
+}
+
+struct ExchangedTokens {
+    access_token: String,
+    #[allow(dead_code)]
+    refresh_token: Option<String>,
+}
+
+async fn exchange_code_for_tokens(
+    issuer: &str,
+    client_id: &str,
+    redirect_uri: &str,
+    pkce: &PkceCodes,
+    code: &str,
+) -> io::Result<ExchangedTokens> {
+    #[derive(serde::Deserialize)]
+    struct TokenResponse {
+        access_token: String,
+        refresh_token: Option<String>,
+    }
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{issuer}/oauth/token"))
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(format!(
+            "grant_type=authorization_code&code={}&redirect_uri={}&client_id={}&code_verifier={}",
+            urlencoding::encode(code),
+            urlencoding::encode(redirect_uri),
+            urlencoding::encode(client_id),
+            urlencoding::encode(&pkce.code_verifier)
+        ))
+        .send()
+        .await
+        .map_err(io::Error::other)?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(io::Error::other(format!(
+            "token endpoint returned status {}: {}",
+            status, body
+        )));
+    }
+
+    let tokens: TokenResponse = resp.json().await.map_err(io::Error::other)?;
+    Ok(ExchangedTokens {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+    })
+}
+
+async fn persist_anthropic_tokens(config_dir: &Path, access_token: &str) -> io::Result<()> {
+    // Claude Code stores credentials in ~/.claude/credentials.json
+    // We'll store the API key that was obtained via OAuth
+    let claude_dir = config_dir.join(".claude");
+    tokio::fs::create_dir_all(&claude_dir).await?;
+
+    let credentials_file = claude_dir.join("credentials.json");
+    let credentials = serde_json::json!({
+        "claudeAiOauth": {
+            "accessToken": access_token,
+            "expiresAt": null
+        }
+    });
+
+    tokio::fs::write(
+        &credentials_file,
+        serde_json::to_string_pretty(&credentials).map_err(io::Error::other)?,
+    )
+    .await
+}

--- a/codex-rs/login/src/assets/anthropic_success.html
+++ b/codex-rs/login/src/assets/anthropic_success.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sign into Claude Code</title>
+    <link rel="icon" href='data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"%3E%3Crect width="256" height="256" fill="%23CC785C" rx="60"/%3E%3Cpath fill="%23fff" d="m169.3 100.3-51.7 107.6L91.1 100.3h-28l37.3 106.9c4.3 12.5 10.1 20.1 25.3 20.1s20.6-7.6 24.9-20.1l37.5-106.9zM141 28.7h-26v22.7l13.1 26.9 12.9-26.9z"/%3E%3C/svg%3E' type="image/svg+xml">
+    <style>
+      .container {
+        margin: auto;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+        background: white;
+
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+      }
+      .inner-container {
+        width: 400px;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: center;
+        gap: 20px;
+        display: inline-flex;
+      }
+      .content {
+        align-self: stretch;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: center;
+        gap: 20px;
+        display: flex;
+        margin-top: 15vh;
+      }
+      .svg-wrapper {
+        position: relative;
+      }
+      .title {
+        text-align: center;
+        color: var(--text-primary, #0D0D0D);
+        font-size: 32px;
+        font-weight: 400;
+        line-height: 40px;
+        word-wrap: break-word;
+      }
+      .description {
+        text-align: center;
+        color: var(--text-secondary, #5D5D5D);
+        font-size: 14px;
+        font-weight: 400;
+        line-height: 20px;
+        word-wrap: break-word;
+      }
+      .logo {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 4rem;
+        height: 4rem;
+        border-radius: 16px;
+        border: .5px solid rgba(0, 0, 0, 0.1);
+        box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 16px 0px;
+        box-sizing: border-box;
+        background-color: #CC785C;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="inner-container">
+        <div class="content">
+          <div class="logo">
+            <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 256 256">
+              <path fill="#fff" d="m169.3 100.3-51.7 107.6L91.1 100.3h-28l37.3 106.9c4.3 12.5 10.1 20.1 25.3 20.1s20.6-7.6 24.9-20.1l37.5-106.9zM141 28.7h-26v22.7l13.1 26.9 12.9-26.9z"/>
+            </svg>
+          </div>
+          <div class="title">Signed in to Claude Code</div>
+          <div class="description">You may now close this page and return to the terminal.</div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -1,7 +1,14 @@
+mod anthropic_server;
 mod device_code_auth;
 mod pkce;
 mod server;
 
+pub use anthropic_server::AnthropicLoginServer;
+pub use anthropic_server::AnthropicServerOptions;
+pub use anthropic_server::AnthropicShutdownHandle;
+pub use anthropic_server::ANTHROPIC_CLIENT_ID;
+pub use anthropic_server::ANTHROPIC_ISSUER;
+pub use anthropic_server::run_anthropic_login_server;
 pub use device_code_auth::run_device_code_login;
 pub use server::LoginServer;
 pub use server::ServerOptions;

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -362,6 +362,8 @@ pub(crate) struct ChatWidget {
     session_stats: SessionStats,
     // Login handler for /login command
     login_handler: Option<LoginHandler>,
+    // Agent being logged into (for login completion message)
+    pending_login_agent: Option<codex_acp::AgentKind>,
 }
 
 /// Information about a pending agent switch in ChatWidget.
@@ -1500,6 +1502,7 @@ impl ChatWidget {
             acp_handle: spawn_result.acp_handle,
             session_stats: SessionStats::new(),
             login_handler: None,
+            pending_login_agent: None,
         };
 
         widget.prefetch_rate_limits();
@@ -1594,6 +1597,7 @@ impl ChatWidget {
             acp_handle: None,
             session_stats: SessionStats::new(),
             login_handler: None,
+            pending_login_agent: None,
         };
 
         widget.prefetch_rate_limits();
@@ -3289,6 +3293,8 @@ impl ChatWidget {
 
     /// Handle the /login slash command
     fn handle_login_command(&mut self) {
+        use codex_acp::AgentKind;
+
         // Use pending agent if set (user selected via /agent picker but hasn't submitted yet),
         // otherwise use the current config model
         let model_name = self
@@ -3323,14 +3329,32 @@ impl ChatWidget {
                 let mut handler = LoginHandler::new();
                 handler.start_oauth();
 
-                // Show auth method selection message
+                // Store which agent we're logging into
+                self.pending_login_agent = Some(agent);
+
+                // Show agent-specific auth message
+                let (provider, env_var) = match agent {
+                    AgentKind::ClaudeCode => ("Anthropic", "ANTHROPIC_API_KEY"),
+                    AgentKind::Codex => ("OpenAI", "OPENAI_API_KEY"),
+                    AgentKind::Gemini => ("Google", "GOOGLE_API_KEY"),
+                };
+
                 self.add_info_message(
-                    "Starting authentication...\n\nA browser window will open for you to sign in with your OpenAI account.\n\nAlternatively, you can set the OPENAI_API_KEY environment variable.".to_string(),
+                    format!(
+                        "Starting authentication...\n\nA browser window will open for you to sign in with your {provider} account.\n\nAlternatively, you can set the {env_var} environment variable."
+                    ),
                     Some("Press Esc to cancel".to_string()),
                 );
 
-                // Start the actual login server
-                self.start_oauth_login_flow(handler);
+                // Start the appropriate login server based on agent
+                match agent {
+                    AgentKind::ClaudeCode => self.start_anthropic_oauth_login_flow(handler),
+                    AgentKind::Codex => self.start_oauth_login_flow(handler),
+                    AgentKind::Gemini => {
+                        // Gemini should not reach here as it returns NotSupported
+                        self.add_error_message("Gemini in-app login is not yet supported.".to_string());
+                    }
+                }
             }
             AgentLoginSupport::NotSupported { agent_name } => {
                 // Provide agent-specific instructions
@@ -3339,11 +3363,6 @@ impl ChatWidget {
                         "In-app login for Gemini is not yet supported.\n\n\
                          To authenticate, run `gemini` in a separate terminal and select 'Login with Google'.\n\n\
                          Alternatively, set the GOOGLE_API_KEY environment variable."
-                    }
-                    "Claude Code" => {
-                        "In-app login for Claude Code is not yet supported.\n\n\
-                         To authenticate, run `claude` in a separate terminal and use the /login command.\n\n\
-                         Alternatively, set the ANTHROPIC_API_KEY environment variable."
                     }
                     _ => {
                         "In-app login for this agent is not yet supported. Please authenticate externally using the agent's native login command or API keys."
@@ -3362,6 +3381,8 @@ impl ChatWidget {
 
     /// Handle the /login <agent> command with explicit agent name
     fn handle_login_command_with_agent(&mut self, agent_name: &str) {
+        use codex_acp::AgentKind;
+
         match LoginHandler::check_agent_support(agent_name) {
             AgentLoginSupport::Supported {
                 agent,
@@ -3385,12 +3406,32 @@ impl ChatWidget {
                 let mut handler = LoginHandler::new();
                 handler.start_oauth();
 
+                // Store which agent we're logging into
+                self.pending_login_agent = Some(agent);
+
+                // Show agent-specific auth message
+                let (provider, env_var) = match agent {
+                    AgentKind::ClaudeCode => ("Anthropic", "ANTHROPIC_API_KEY"),
+                    AgentKind::Codex => ("OpenAI", "OPENAI_API_KEY"),
+                    AgentKind::Gemini => ("Google", "GOOGLE_API_KEY"),
+                };
+
                 self.add_info_message(
-                    "Starting authentication...\n\nA browser window will open for you to sign in with your OpenAI account.\n\nAlternatively, you can set the OPENAI_API_KEY environment variable.".to_string(),
+                    format!(
+                        "Starting authentication...\n\nA browser window will open for you to sign in with your {provider} account.\n\nAlternatively, you can set the {env_var} environment variable."
+                    ),
                     Some("Press Esc to cancel".to_string()),
                 );
 
-                self.start_oauth_login_flow(handler);
+                // Start the appropriate login server based on agent
+                match agent {
+                    AgentKind::ClaudeCode => self.start_anthropic_oauth_login_flow(handler),
+                    AgentKind::Codex => self.start_oauth_login_flow(handler),
+                    AgentKind::Gemini => {
+                        // Gemini should not reach here as it returns NotSupported
+                        self.add_error_message("Gemini in-app login is not yet supported.".to_string());
+                    }
+                }
             }
             AgentLoginSupport::NotSupported { agent_name } => {
                 let instructions = match agent_name.as_str() {
@@ -3398,11 +3439,6 @@ impl ChatWidget {
                         "In-app login for Gemini is not yet supported.\n\n\
                          To authenticate, run `gemini` in a separate terminal and select 'Login with Google'.\n\n\
                          Alternatively, set the GOOGLE_API_KEY environment variable."
-                    }
-                    "Claude Code" => {
-                        "In-app login for Claude Code is not yet supported.\n\n\
-                         To authenticate, run `claude` in a separate terminal and use the /login command.\n\n\
-                         Alternatively, set the ANTHROPIC_API_KEY environment variable."
                     }
                     _ => {
                         "In-app login for this agent is not yet supported. Please authenticate externally using the agent's native login command or API keys."
@@ -3419,7 +3455,7 @@ impl ChatWidget {
         }
     }
 
-    /// Start the OAuth login flow
+    /// Start the OAuth login flow for OpenAI (Codex)
     fn start_oauth_login_flow(&mut self, mut handler: LoginHandler) {
         use codex_core::auth::CLIENT_ID;
         use codex_login::ServerOptions;
@@ -3470,13 +3506,75 @@ impl ChatWidget {
         }
     }
 
+    /// Start the Anthropic OAuth login flow for Claude Code
+    fn start_anthropic_oauth_login_flow(&mut self, handler: LoginHandler) {
+        use codex_login::AnthropicServerOptions;
+        use codex_login::run_anthropic_login_server;
+
+        // Use home directory for Claude credentials (standard location: ~/.claude/)
+        let home_dir = dirs::home_dir().unwrap_or_else(|| self.config.codex_home.clone());
+        let opts = AnthropicServerOptions::new(home_dir);
+
+        match run_anthropic_login_server(opts) {
+            Ok(child) => {
+                let auth_url = child.auth_url.clone();
+                // Convert the Anthropic shutdown handle to a codex_login ShutdownHandle
+                // by storing it in the handler (we'll handle cancellation via the handler)
+                let cancel_handle = child.cancel_handle();
+
+                // Store the handler
+                self.login_handler = Some(handler);
+
+                // Update the info message with the URL
+                self.add_info_message(
+                    format!(
+                        "Opening browser for authentication...\n\nIf the browser doesn't open automatically, visit:\n{auth_url}\n\nWaiting for authentication to complete..."
+                    ),
+                    Some("Press Esc to cancel".to_string()),
+                );
+
+                // Spawn a task to wait for completion
+                let app_event_tx = self.app_event_tx.clone();
+                tokio::spawn(async move {
+                    match child.block_until_done().await {
+                        Ok(()) => {
+                            app_event_tx.send(AppEvent::LoginComplete { success: true });
+                        }
+                        Err(e) => {
+                            tracing::error!("Anthropic OAuth login failed: {e}");
+                            app_event_tx.send(AppEvent::LoginComplete { success: false });
+                        }
+                    }
+                    // Ensure cancel handle is kept alive
+                    drop(cancel_handle);
+                });
+            }
+            Err(e) => {
+                self.add_error_message(format!("Failed to start login server: {e}"));
+            }
+        }
+    }
+
     /// Handle login completion event
     pub(crate) fn handle_login_complete(&mut self, success: bool) {
+        use codex_acp::AgentKind;
+
+        let agent = self.pending_login_agent.take();
+
         if let Some(mut handler) = self.login_handler.take() {
             if success {
                 handler.oauth_complete();
+
+                // Show agent-specific success message
+                let (provider, agent_name) = match agent {
+                    Some(AgentKind::ClaudeCode) => ("Anthropic", "Claude Code"),
+                    Some(AgentKind::Codex) => ("OpenAI", "Codex"),
+                    Some(AgentKind::Gemini) => ("Google", "Gemini"),
+                    None => ("the provider", "the agent"),
+                };
+
                 self.add_info_message(
-                    "Successfully authenticated with OpenAI!\n\nYou can now use Codex.".to_string(),
+                    format!("Successfully authenticated with {provider}!\n\nYou can now use {agent_name}."),
                     None,
                 );
             } else {

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -391,6 +391,7 @@ pub(crate) fn make_chatwidget_manual() -> (
         acp_handle: None,
         session_stats: crate::session_stats::SessionStats::new(),
         login_handler: None,
+        pending_login_agent: None,
     };
     (widget, rx, op_rx)
 }

--- a/codex-rs/tui/src/login_handler.rs
+++ b/codex-rs/tui/src/login_handler.rs
@@ -85,13 +85,15 @@ impl LoginHandler {
                         is_installed: info.is_installed,
                         login_method: LoginMethod::OAuthBrowser,
                     },
+                    // Claude Code supports in-app login via OAuth browser flow
+                    AgentKind::ClaudeCode => AgentLoginSupport::Supported {
+                        agent: AgentKind::ClaudeCode,
+                        is_installed: info.is_installed,
+                        login_method: LoginMethod::OAuthBrowser,
+                    },
                     // Gemini requires interactive CLI for auth - show instructions
                     AgentKind::Gemini => AgentLoginSupport::NotSupported {
                         agent_name: "Gemini".to_string(),
-                    },
-                    // Other agents don't support in-app login yet
-                    other => AgentLoginSupport::NotSupported {
-                        agent_name: other.display_name().to_string(),
                     },
                 }
             }
@@ -154,15 +156,19 @@ mod tests {
     }
 
     #[test]
-    fn check_agent_support_returns_not_supported_for_claude() {
-        // Claude Code login support will be added later
+    fn check_agent_support_returns_supported_for_claude_with_oauth() {
         let support = LoginHandler::check_agent_support("claude-code");
 
         match support {
-            AgentLoginSupport::NotSupported { agent_name } => {
-                assert_eq!(agent_name, "Claude Code");
+            AgentLoginSupport::Supported {
+                agent,
+                login_method,
+                ..
+            } => {
+                assert_eq!(agent, AgentKind::ClaudeCode);
+                assert_eq!(login_method, LoginMethod::OAuthBrowser);
             }
-            _ => panic!("Expected NotSupported variant for claude-code"),
+            _ => panic!("Expected Supported variant for claude-code"),
         }
     }
 


### PR DESCRIPTION
Add support for in-app OAuth browser authentication for Claude Code, similar to the existing Codex login flow.

Changes:
- Add Anthropic OAuth server module with PKCE support
- Update login_handler to mark Claude Code as supported for OAuth login
- Add separate Anthropic OAuth flow in chatwidget
- Update login completion messages to be agent-specific
- Add anthropic_success.html for login completion page

This allows users to run /login when using Claude Code agents and authenticate via browser-based OAuth with Anthropic's console.