### PR TITLE
feat(tui): Improve Nori session stats display with TUI widgets

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -45,6 +45,8 @@ use ratatui::style::Modifier;
 use ratatui::style::Style;
 use ratatui::style::Styled;
 use ratatui::style::Stylize;
+use ratatui::widgets::Block;
+use ratatui::widgets::Borders;
 use ratatui::widgets::Paragraph;
 use ratatui::widgets::Wrap;
 use std::any::Any;
@@ -64,11 +66,24 @@ pub(crate) trait HistoryCell: std::fmt::Debug + Send + Sync + Any {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>>;
 
     fn desired_height(&self, width: u16) -> u16 {
-        Paragraph::new(Text::from(self.display_lines(width)))
+        let block = self.border_block();
+        let inner_width = if block.is_some() {
+            width.saturating_sub(2) // Account for left/right borders
+        } else {
+            width
+        };
+
+        let content_height: u16 = Paragraph::new(Text::from(self.display_lines(inner_width)))
             .wrap(Wrap { trim: false })
-            .line_count(width)
+            .line_count(inner_width)
             .try_into()
-            .unwrap_or(0)
+            .unwrap_or(0);
+
+        if block.is_some() {
+            content_height.saturating_add(2) // Account for top/bottom borders
+        } else {
+            content_height
+        }
     }
 
     fn transcript_lines(&self, width: u16) -> Vec<Line<'static>> {
@@ -97,20 +112,35 @@ pub(crate) trait HistoryCell: std::fmt::Debug + Send + Sync + Any {
     fn is_stream_continuation(&self) -> bool {
         false
     }
+
+    /// Returns an optional Block to wrap the cell's content.
+    /// When Some, the Renderable impl will use this block for rendering
+    /// and pass the inner area width to display_lines.
+    fn border_block(&self) -> Option<Block<'static>> {
+        None
+    }
 }
 
 impl Renderable for Box<dyn HistoryCell> {
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let lines = self.display_lines(area.width);
-        let y = if area.height == 0 {
+        let block = self.border_block();
+        let inner_area = block.as_ref().map(|b| b.inner(area)).unwrap_or(area);
+
+        let lines = self.display_lines(inner_area.width);
+        let y = if inner_area.height == 0 {
             0
         } else {
-            let overflow = lines.len().saturating_sub(usize::from(area.height));
+            let overflow = lines.len().saturating_sub(usize::from(inner_area.height));
             u16::try_from(overflow).unwrap_or(u16::MAX)
         };
-        Paragraph::new(Text::from(lines))
-            .scroll((y, 0))
-            .render(area, buf);
+
+        let paragraph = Paragraph::new(Text::from(lines)).scroll((y, 0));
+
+        if let Some(b) = block {
+            paragraph.block(b).render(area, buf);
+        } else {
+            paragraph.render(area, buf);
+        }
     }
     fn desired_height(&self, width: u16) -> u16 {
         HistoryCell::desired_height(self.as_ref(), width)

--- a/codex-rs/tui/src/session_stats.rs
+++ b/codex-rs/tui/src/session_stats.rs
@@ -4,9 +4,10 @@
 //! during a conversation session. Displays as a bordered table at session end.
 
 use crate::history_cell::HistoryCell;
-use crate::history_cell::with_border;
 use ratatui::prelude::*;
 use ratatui::style::Stylize;
+use ratatui::widgets::Block;
+use ratatui::widgets::Borders;
 use std::collections::HashMap;
 use unicode_width::UnicodeWidthStr;
 
@@ -199,8 +200,8 @@ impl HistoryCell for SessionStatisticsCell {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
         let mut content_lines: Vec<Line<'static>> = Vec::new();
 
-        // Calculate inner width for separator lines (accounting for border padding)
-        let inner_width = width.saturating_sub(4).max(20) as usize;
+        // Use the full width for separator lines (border is handled by Block)
+        let inner_width = width.max(20) as usize;
 
         // Title
         content_lines.push(Line::from(vec![
@@ -215,7 +216,7 @@ impl HistoryCell for SessionStatisticsCell {
             Span::from(format!("  {} total", total_messages)).dim(),
         ]));
         content_lines.push(Line::from(vec![
-            Span::from("   User: ").dim(),
+            Span::from("  User: ").dim(),
             Span::from(format!("{}", self.stats.user_messages)).green(),
             Span::from("  │  ").dim(),
             Span::from("Assistant: ").dim(),
@@ -223,7 +224,9 @@ impl HistoryCell for SessionStatisticsCell {
         ]));
 
         // Section separator
-        content_lines.push(Line::from("─".repeat(inner_width.min(50)).dim()));
+        content_lines.push(Line::from(
+            "─".repeat(inner_width.saturating_sub(2).min(50)).dim(),
+        ));
 
         // Tool Calls section with sorted table
         let total_tool_calls: u32 = self.stats.tool_calls.values().sum();
@@ -233,7 +236,7 @@ impl HistoryCell for SessionStatisticsCell {
         ]));
 
         if self.stats.tool_calls.is_empty() {
-            content_lines.push(Line::from(vec![Span::from("   (none)").dim().italic()]));
+            content_lines.push(Line::from(vec![Span::from("  (none)").dim().italic()]));
         } else {
             // Sort by count (descending), then by name
             let mut sorted: Vec<_> = self.stats.tool_calls.iter().collect();
@@ -260,7 +263,7 @@ impl HistoryCell for SessionStatisticsCell {
                         content_lines.push(Line::from(row_items.clone()));
                         row_items.clear();
                     }
-                    row_items.push(Span::from("   "));
+                    row_items.push(Span::from("  "));
                 } else {
                     row_items.push(Span::from("  │  ").dim());
                 }
@@ -276,7 +279,9 @@ impl HistoryCell for SessionStatisticsCell {
         }
 
         // Section separator
-        content_lines.push(Line::from("─".repeat(inner_width.min(50)).dim()));
+        content_lines.push(Line::from(
+            "─".repeat(inner_width.saturating_sub(2).min(50)).dim(),
+        ));
 
         // Skills Used section
         content_lines.push(Line::from(vec![
@@ -284,18 +289,20 @@ impl HistoryCell for SessionStatisticsCell {
             Span::from(format!("  {}", self.stats.skills_used.len())).dim(),
         ]));
         if self.stats.skills_used.is_empty() {
-            content_lines.push(Line::from(vec![Span::from("   (none)").dim().italic()]));
+            content_lines.push(Line::from(vec![Span::from("  (none)").dim().italic()]));
         } else {
             for skill in &self.stats.skills_used {
                 content_lines.push(Line::from(vec![
-                    Span::from("   • ").dim(),
+                    Span::from("  • ").dim(),
                     Span::from(skill.clone()).magenta(),
                 ]));
             }
         }
 
         // Section separator
-        content_lines.push(Line::from("─".repeat(inner_width.min(50)).dim()));
+        content_lines.push(Line::from(
+            "─".repeat(inner_width.saturating_sub(2).min(50)).dim(),
+        ));
 
         // Subagents Used section
         content_lines.push(Line::from(vec![
@@ -303,17 +310,25 @@ impl HistoryCell for SessionStatisticsCell {
             Span::from(format!("  {}", self.stats.subagents_used.len())).dim(),
         ]));
         if self.stats.subagents_used.is_empty() {
-            content_lines.push(Line::from(vec![Span::from("   (none)").dim().italic()]));
+            content_lines.push(Line::from(vec![Span::from("  (none)").dim().italic()]));
         } else {
             for subagent in &self.stats.subagents_used {
                 content_lines.push(Line::from(vec![
-                    Span::from("   • ").dim(),
+                    Span::from("  • ").dim(),
                     Span::from(subagent.clone()).yellow(),
                 ]));
             }
         }
 
-        with_border(content_lines)
+        content_lines
+    }
+
+    fn border_block(&self) -> Option<Block<'static>> {
+        Some(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().dim()),
+        )
     }
 }
 
@@ -827,25 +842,14 @@ mod tests {
     }
 
     #[test]
-    fn display_lines_has_border() {
+    fn display_lines_has_border_block() {
         let stats = SessionStats::new();
         let cell = SessionStatisticsCell::new(stats);
-        let lines = cell.display_lines(60);
 
-        let text: String = lines
-            .iter()
-            .flat_map(|l| l.spans.iter())
-            .map(|s| s.content.as_ref())
-            .collect();
-
-        // Should have box-drawing characters for border
+        // Border is now provided by the Block widget via border_block()
         assert!(
-            text.contains("╭") || text.contains("┌"),
-            "Expected top-left corner"
-        );
-        assert!(
-            text.contains("╯") || text.contains("┘"),
-            "Expected bottom-right corner"
+            cell.border_block().is_some(),
+            "Expected border_block to return Some(Block)"
         );
     }
 


### PR DESCRIPTION
- Display totals for messages and tool calls in section headers
- Sort tool calls by count (descending) with aligned multi-column layout
- Add section separators with horizontal lines
- Use color-coded values (green for user, cyan for assistant, magenta for skills, yellow for subagents)
- Use rounded corners (╭╰╯) for console output borders
- Add bullet points for skills and subagents lists
- Make display responsive to terminal width