### PR TITLE
feat(tui): Use placeholder logout instructions

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1764,13 +1764,11 @@ impl ChatWidget {
                 self.handle_login_command();
             }
             SlashCommand::Logout => {
-                if let Err(e) = codex_core::auth::logout(
-                    &self.config.codex_home,
-                    self.config.cli_auth_credentials_store_mode,
-                ) {
-                    tracing::error!("failed to logout: {e}");
-                }
-                self.request_exit();
+                self.add_info_message(
+                    "To logout, run the agent's logout command directly (e.g., `claude /logout`)"
+                        .to_string(),
+                    None,
+                );
             }
             SlashCommand::Undo => {
                 self.app_event_tx.send(AppEvent::CodexOp(Op::Undo));

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -52,7 +52,7 @@ impl SlashCommand {
             SlashCommand::Approvals => "choose what Nori can do without approval",
             SlashCommand::Mcp => "list configured MCP tools",
             SlashCommand::Login => "log in to the current agent",
-            SlashCommand::Logout => "log out of Nori",
+            SlashCommand::Logout => "show logout instructions",
             SlashCommand::Rollout => "print the rollout file path",
             SlashCommand::TestApproval => "test approval request",
         }


### PR DESCRIPTION
The /logout command now shows a message instructing users to run the agent's logout command directly (e.g., `claude /logout`) instead of performing the logout action itself.