### PR TITLE
fix(cargo): Make sccache optional to fix release CI/CD builds

### DIFF
--- a/codex-rs/.cargo/config.toml
+++ b/codex-rs/.cargo/config.toml
@@ -9,9 +9,6 @@ rustflags = ["-C", "link-arg=/STACK:8388608"]
 rustflags = ["-C", "link-arg=-Wl,--stack,8388608"]
 
 [build]
-# Use sccache to cache compiled artifacts across builds and worktrees.
-# This dramatically reduces disk usage and build times for incremental builds.
-rustc-wrapper = "sccache"
 # Remap the workspace path to a static string so hashes match across worktrees
 rustflags = ["--remap-path-prefix", "$CARGO_MANIFEST_DIR=."]
 

--- a/codex-rs/docs.md
+++ b/codex-rs/docs.md
@@ -42,17 +42,29 @@ Key architectural patterns:
 
 The workspace is configured with build optimizations in `.cargo/config.toml`:
 
-- **sccache**: Compilation cache that shares artifacts across builds and worktrees. Reduces build times significantly for incremental builds.
+- **sccache (optional)**: Compilation cache that shares artifacts across builds and worktrees. Enable with `export RUSTC_WRAPPER=sccache`. Reduces build times and disk usage significantly when using multiple worktrees.
 - **mold linker**: Uses the faster mold linker on Linux for faster linking.
 - **Test parallelism**: `RUST_TEST_THREADS=4` limits test parallelism to prevent CPU exhaustion.
-- **Path remapping**: `--remap-path-prefix` ensures cache hits work across worktrees with different absolute paths.
+- **Path remapping**: `--remap-path-prefix` ensures build artifact cache hits work across worktrees with different absolute paths.
+
+To enable sccache for local development:
+```bash
+# Install sccache (if not already installed)
+cargo install sccache
+
+# Enable sccache for all builds
+export RUSTC_WRAPPER=sccache
+
+# Add to your shell profile for persistence
+echo 'export RUSTC_WRAPPER=sccache' >> ~/.bashrc  # or ~/.zshrc
+```
 
 To clean old build artifacts and reclaim disk space:
 ```bash
 # Clean a specific worktree's target directory
 rm -rf .worktrees/old-branch/codex-rs/target
 
-# View sccache statistics
+# View sccache statistics (if using sccache)
 sccache --show-stats
 
 # Clear sccache if needed (rarely necessary)


### PR DESCRIPTION
## Summary

- Removed mandatory `rustc-wrapper = "sccache"` from `codex-rs/.cargo/config.toml`
- Updated documentation to explain optional sccache usage via `RUSTC_WRAPPER` env var
- Fixes nori-release.yml test job failure without adding complexity to the release workflow

## Problem

The nori-release.yml workflow's test job failed with:
```
error: could not execute process 'sccache ... -vV' (never executed)
Caused by: No such file or directory (os error 2)
```

Root cause: Commit 7cbd16f5c added `rustc-wrapper = "sccache"` to the cargo config, making sccache mandatory for all builds. However, the release workflow doesn't install sccache.

## Solution

Instead of adding sccache to the release CI/CD (which adds complexity), this PR makes sccache optional:

- Removed the `rustc-wrapper` line from cargo config
- Developers who want sccache benefits (disk savings across worktrees) can enable it via:
  ```bash
  export RUSTC_WRAPPER=sccache
  ```
- The rust-ci.yml workflow already uses this env var approach (line 105), so CI performance is unaffected
- Keeps the release workflow simple and transparent

## Test plan

- [x] Verified `cargo check` works without sccache installed
- [x] Confirmed rust-ci.yml already uses `RUSTC_WRAPPER` environment variable
- [x] Updated documentation in codex-rs/docs.md
- [ ] CI/CD tests will verify the fix works in the release workflow

## Related

- Fixes the failure seen in https://github.com/tilework-tech/nori-cli/actions/runs/20931911438/job/60147855852
- Alternative to commit c877c14c5 which added sccache to the release workflow