### PR TITLE
feat(cli): Rename executable to nori-ai-cli

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -59,6 +59,7 @@ use codex_core::features::is_known_feature_key;
 /// If no subcommand is specified, options will be forwarded to the interactive CLI.
 #[derive(Debug, Parser)]
 #[clap(
+    name = "nori-ai-cli",
     author,
     version,
     // If a sub‑command is given, ignore requirements of the default args.


### PR DESCRIPTION
Add `name = "nori-ai-cli"` to the clap attribute so that `nori --version` displays "nori-ai-cli" instead of "codex-cli" (which was the Cargo package name).