### PR TITLE
feat(acp): Add synthetic ToolCall events for Gemini compatibility

### DIFF
--- a/codex-rs/acp/src/connection.rs
+++ b/codex-rs/acp/src/connection.rs
@@ -796,20 +796,21 @@ impl acp::Client for ClientDelegate {
         // Emit synthetic ToolCall event for TUI rendering (Gemini compatibility)
         // Gemini agents use client capability methods instead of session/update notifications,
         // so we synthesize the events here to enable proper TUI display.
-        let tool_call_id = acp::ToolCallId::from(format!("write_text_file-{}", arguments.path.display()));
+        let tool_call_id =
+            acp::ToolCallId::from(format!("write_text_file-{}", arguments.path.display()));
         let title = format!("Writing {}", arguments.path.display());
-        
+
         let tool_call = acp::ToolCall::new(tool_call_id, title)
             .kind(acp::ToolKind::Execute)
             .status(acp::ToolCallStatus::Pending);
-        
+
         // Send the ToolCall update to the session if registered
         let sessions = self.sessions.borrow();
         if let Some(tx) = sessions.get(&arguments.session_id) {
             let _ = tx.try_send(acp::SessionUpdate::ToolCall(tool_call));
         }
         drop(sessions); // Release borrow before performing I/O
-        
+
         let path = &arguments.path;
 
         // Resolve relative paths against the working directory
@@ -886,20 +887,21 @@ impl acp::Client for ClientDelegate {
         // Emit synthetic ToolCall event for TUI rendering (Gemini compatibility)
         // Gemini agents use client capability methods instead of session/update notifications,
         // so we synthesize the events here to enable proper TUI display.
-        let tool_call_id = acp::ToolCallId::from(format!("read_text_file-{}", arguments.path.display()));
+        let tool_call_id =
+            acp::ToolCallId::from(format!("read_text_file-{}", arguments.path.display()));
         let title = format!("Reading {}", arguments.path.display());
-        
+
         let tool_call = acp::ToolCall::new(tool_call_id, title)
             .kind(acp::ToolKind::Execute)
             .status(acp::ToolCallStatus::Pending);
-        
+
         // Send the ToolCall update to the session if registered
         let sessions = self.sessions.borrow();
         if let Some(tx) = sessions.get(&arguments.session_id) {
             let _ = tx.try_send(acp::SessionUpdate::ToolCall(tool_call));
         }
         drop(sessions); // Release borrow before performing I/O
-        
+
         // Read file content
         let content =
             std::fs::read_to_string(&arguments.path).map_err(acp::Error::into_internal_error)?;
@@ -1105,7 +1107,11 @@ mod tests {
 
         // Call write_text_file
         let content = "Hello, world!";
-        let request = acp::WriteTextFileRequest::new(session_id.clone(), test_file.clone(), content.to_string());
+        let request = acp::WriteTextFileRequest::new(
+            session_id.clone(),
+            test_file.clone(),
+            content.to_string(),
+        );
         let response = delegate
             .write_text_file(request)
             .await


### PR DESCRIPTION
## Summary

Adds synthetic ToolCall event emission for Gemini agent file operations to enable TUI rendering.

Gemini agents use client capability methods (`fs/read_text_file`, `fs/write_text_file`) instead of session/update notifications like Claude Code. This causes file operations to be invisible in the TUI.

This PR synthesizes ToolCall SessionUpdate events when these methods are invoked, enabling the TUI to render file operations from Gemini agents just like it does for Claude.

## Changes

- `ClientDelegate::read_text_file` now emits ToolCall event before reading files
- `ClientDelegate::write_text_file` now emits ToolCall event before writing files  
- Added comprehensive tests for both methods
- All 145 tests passing

## Technical Details

The implementation:
1. Extracts the `session_id` from the client capability request
2. Creates a synthetic `ToolCall` with descriptive title (e.g., "Reading path/to/file") and status `Pending`
3. Sends it through the session's update channel (same mechanism as real session updates)
4. The existing translator picks this up and renders it in the TUI

## Testing

- New unit tests verify ToolCall events are emitted correctly
- Tests verify event structure (title, kind, status)
- All existing tests continue to pass

## Next Steps

This is the first step toward full Gemini ACP support. Future work includes:
- Handling permission request diffs (Gemini sends diffs in permission content)
- Supporting other tool operations (glob, grep, shell commands)
- Emitting completion status updates

## Test Plan

- [x] Unit tests pass for read_text_file ToolCall emission
- [x] Unit tests pass for write_text_file ToolCall emission  
- [x] All 145 existing tests continue to pass
- [ ] Manual testing with real Gemini agent (requires Gemini agent setup)