### PR TITLE
fix(tui): Render tool calls only inline

### DIFF
--- a/codex-rs/mock-acp-agent/docs.md
+++ b/codex-rs/mock-acp-agent/docs.md
@@ -53,6 +53,7 @@ Path: @/codex-rs/mock-acp-agent
 | `MOCK_AGENT_HANG` | Sleeps 60s during initialize (timeout testing) |
 | `MOCK_AGENT_REQUIRE_AUTH` | Returns error code -32000 "Authentication required" during initialize (auth failure testing) |
 | `MOCK_AGENT_PROMPT_FAIL` | Returns error code -32001 "Mock prompt failure for testing" during prompt() (prompt failure testing) |
+| `MOCK_AGENT_PENDING_TOOL_THEN_STREAM` | Starts a tool call (pending), sends text to flush the cell to pending, then streams until cancelled; tests interrupt chronology where pending cells should appear before the interrupt message |
 | `MOCK_AGENT_REQUEST_FILE` | Reads file path via client during prompt |
 | `MOCK_AGENT_STREAM_UNTIL_CANCEL` | Continuously streams until cancel notification |
 | `MOCK_AGENT_STDERR_COUNT` | Emits N lines of `MOCK_AGENT_STDERR_LINE:{i}` to stderr during prompt |

--- a/codex-rs/mock-acp-agent/src/main.rs
+++ b/codex-rs/mock-acp-agent/src/main.rs
@@ -272,6 +272,48 @@ impl acp::Agent for MockAgent {
             return Err(acp::Error::new(-32001, "Mock prompt failure for testing"));
         }
 
+        // Support testing interrupt chronology - starts a tool call, sends text (to flush
+        // the cell to pending_exec_cells), then streams until cancelled. This tests that
+        // pending cells are drained before the interrupt message appears in the transcript.
+        if std::env::var("MOCK_AGENT_PENDING_TOOL_THEN_STREAM").is_ok() {
+            eprintln!("Mock agent: sending pending tool call then streaming until cancel");
+
+            let tool_call_id = acp::ToolCallId::new("pending-tool-001");
+
+            // Step 1: Send tool call (pending)
+            self.send_tool_call(
+                session_id.clone(),
+                acp::ToolCall::new(tool_call_id.clone(), "Long running operation")
+                    .kind(acp::ToolKind::Execute)
+                    .status(acp::ToolCallStatus::Pending)
+                    .raw_input(json!({"command": "sleep 60"})),
+            )
+            .await?;
+
+            sleep(Duration::from_millis(50)).await;
+
+            // Step 2: Send text to trigger flush of incomplete ExecCell to pending_exec_cells
+            self.send_text_chunk(session_id.clone(), "Starting long operation...")
+                .await?;
+
+            sleep(Duration::from_millis(50)).await;
+
+            // Step 3: Stream until cancelled (tool call remains pending)
+            let mut iterations = 0usize;
+            while !self.cancel_requested.get() && iterations < 10_000 {
+                self.send_text_chunk(session_id.clone(), ".").await?;
+                iterations += 1;
+                sleep(Duration::from_millis(100)).await;
+            }
+
+            // Note: Tool call is NOT completed - it remains pending when interrupted
+            return Ok(acp::PromptResponse::new(if self.cancel_requested.get() {
+                acp::StopReason::Cancelled
+            } else {
+                acp::StopReason::EndTurn
+            }));
+        }
+
         // Support mixed exploring and exec workflow to test exploring cells appearing after assistant message
         if std::env::var("MOCK_AGENT_MIXED_EXPLORING_AND_EXEC").is_ok() {
             eprintln!("Mock agent: sending mixed exploring and exec workflow");

--- a/codex-rs/tui-pty-e2e/tests/acp_tool_calls.rs
+++ b/codex-rs/tui-pty-e2e/tests/acp_tool_calls.rs
@@ -605,3 +605,114 @@ fn test_explored_cells_appear_after_assistant_message() {
     //     final_msg_pos
     // );
 }
+
+/// Test that pending tool cells appear BEFORE the interrupt message when a turn is interrupted.
+///
+/// This is a regression test for a bug where pending ExecCells were drained only at TaskComplete,
+/// causing them to appear at the bottom of the transcript after the "Conversation interrupted"
+/// message. The fix moves drain_failed() to finalize_turn(), ensuring cells appear in
+/// chronological order (tool call happened BEFORE the interrupt).
+///
+/// The test:
+/// 1. Starts a tool call that sends text (flushing the cell to pending_exec_cells)
+/// 2. Interrupts the turn before the tool call completes
+/// 3. Verifies the failed tool cell appears BEFORE the interrupt message
+#[test]
+#[cfg(target_os = "linux")]
+fn test_pending_cells_appear_before_interrupt_message() {
+    // Configure mock agent to:
+    // 1. Start a tool call (pending)
+    // 2. Send text (to flush cell to pending_exec_cells)
+    // 3. Stream until cancelled (tool call stays pending)
+    let config = SessionConfig::new()
+        .with_model("mock-model".to_owned())
+        .with_agent_env("MOCK_AGENT_PENDING_TOOL_THEN_STREAM", "1");
+
+    let mut session =
+        TuiSession::spawn_with_config(24, 80, config).expect("Failed to spawn in ACP mode");
+
+    // Wait for startup
+    session
+        .wait_for_text("›", TIMEOUT)
+        .expect("ACP mode should start");
+
+    std::thread::sleep(TIMEOUT_INPUT);
+
+    // Send a prompt to trigger the tool call
+    session.send_str("Run long operation").unwrap();
+    std::thread::sleep(TIMEOUT_INPUT);
+    session.send_key(Key::Enter).unwrap();
+
+    // Wait for the tool call to appear (shown as "Running 'Long running operation...")
+    session
+        .wait_for_text("Long running operation", Duration::from_secs(5))
+        .expect("Should see tool call indicator showing the operation started");
+
+    // Wait a moment for the cell to be flushed to pending_exec_cells
+    std::thread::sleep(Duration::from_millis(200));
+
+    // Interrupt the turn
+    session.send_key(Key::Escape).unwrap();
+
+    // Wait for the interrupt message to appear
+    session
+        .wait_for_text("Conversation interrupted", Duration::from_secs(5))
+        .expect("Should see interrupt message");
+
+    // Give a moment for the transcript to settle
+    std::thread::sleep(TIMEOUT_PRESNAPSHOT);
+
+    let contents = session.screen_contents();
+
+    // The key assertion: the failed tool cell (marked with ✗) should appear BEFORE
+    // the "Conversation interrupted" message, not after.
+    //
+    // Look for the tool call indicator (✗ for failed, or the command itself)
+    // The cell should show the failed tool call with a red ✗
+
+    let interrupt_pos = contents
+        .find("Conversation interrupted")
+        .expect("Should contain interrupt message");
+
+    // Look for evidence of the tool cell before the interrupt message
+    // The tool cell could show as:
+    // - "✗" (failed marker)
+    // - "Long running operation" (the tool call title)
+    // - "sleep 60" (the command in the tool call)
+    let content_before_interrupt = &contents[..interrupt_pos];
+
+    // The tool call should be visible before the interrupt message
+    // Either as a failed marker or the tool call content
+    let has_tool_evidence = content_before_interrupt.contains("✗")
+        || content_before_interrupt.contains("Long running")
+        || content_before_interrupt.contains("sleep");
+
+    assert!(
+        has_tool_evidence,
+        "The tool cell should appear BEFORE the 'Conversation interrupted' message. \
+         This ensures pending cells are drained at turn finalization, not at TaskComplete. \
+         Content before interrupt:\n{}\n\nFull screen:\n{}",
+        content_before_interrupt, contents
+    );
+
+    // Additionally verify the tool cell is NOT duplicated after the interrupt message
+    let content_after_interrupt = &contents[interrupt_pos..];
+
+    // Count tool call indicators - should be minimal after interrupt
+    // (Some UI elements may repeat, but the main tool cell should be before)
+    let tool_indicators_after = content_after_interrupt.matches("Long running").count();
+
+    assert!(
+        tool_indicators_after == 0,
+        "Tool cell should NOT appear after the interrupt message (found {} occurrences). \
+         Screen contents:\n{}",
+        tool_indicators_after,
+        contents
+    );
+
+    // Snapshot for visual verification
+    insta::assert_snapshot!(
+        "acp_pending_cell_before_interrupt",
+        normalize_for_input_snapshot(contents)
+    );
+}

--- a/codex-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_pending_cell_before_interrupt.snap
+++ b/codex-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_pending_cell_before_interrupt.snap
@@ -1,0 +1,17 @@
+---
+source: tui-pty-e2e/tests/acp_tool_calls.rs
+expression: normalize_for_input_snapshot(contents)
+---
+› Run long operation
+
+
+• Ran 'Long running operation(sleep 60)'
+  └ (no output)
+
+■ Conversation interrupted - tell the model what to do differently. Something
+went wrong? Hit `/feedback` to report the issue.
+
+
+› [DEFAULT_PROMPT]
+
+  ⎇ master · ? for shortcuts

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -609,7 +609,10 @@ impl ChatWidget {
         // separate AgentMessage event to trigger handle_stream_finished().
         self.flush_interrupt_queue();
 
-        // Flush any pending ExecCells that weren't completed (e.g., due to interruption).
+        // Defensive: drain any remaining pending cells. In normal error/interrupt flows,
+        // finalize_turn() already drained these, but this handles edge cases where
+        // TaskComplete arrives without a prior finalization (e.g., normal completion
+        // where some tool calls never received completion events).
         for pending_cell in self.pending_exec_cells.drain_failed() {
             self.needs_final_message_separator = true;
             self.app_event_tx
@@ -725,6 +728,15 @@ impl ChatWidget {
     }
     /// Finalize any active exec as failed and stop/clear running UI state.
     fn finalize_turn(&mut self) {
+        // Drain any pending ExecCells first - they chronologically occurred BEFORE
+        // whatever event is finalizing the turn (error, interrupt, etc.). This ensures
+        // cells appear in correct chronological order in the transcript.
+        for pending_cell in self.pending_exec_cells.drain_failed() {
+            self.needs_final_message_separator = true;
+            self.app_event_tx
+                .send(AppEvent::InsertHistoryCell(pending_cell));
+        }
+
         // Ensure any spinner is replaced by a red ✗ and flushed into history.
         self.finalize_active_cell_as_failed();
         // Reset running state and clear streaming buffers.


### PR DESCRIPTION

Previously, pending ExecCells were only drained in on_task_complete(), causing them to appear at the bottom of the transcript after error or interrupt messages. This broke chronological ordering since tool calls happen BEFORE the events that end the turn.

Move drain_failed() call to finalize_turn(), which is called by both on_error() and on_interrupted_turn(). This ensures pending cells are rendered in their correct chronological position - before any error or interruption indicator.

The drain in on_task_complete() is kept as a defensive fallback for edge cases where TaskComplete arrives without prior finalization.

Also adds:
- E2E test verifying pending cells appear before interrupt message
- Mock agent mode MOCK_AGENT_PENDING_TOOL_THEN_STREAM for testing