### PR TITLE
feat(acp): Add ACP session/load support

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ffe7d502c1e451aafc5aff655000f84d09c9af681354ac0012527009b1af13"
+checksum = "1ea4b85f3bcd56ebe65f830321d34bc939af1b5a33b9dcb683195a3b72de0cdb"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.10.1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1de0bd518a2b1a4ce0cbde47d3fdf7c7babced977d697120132bd44924e30ad"
+checksum = "70829a300bd178abe42836ac779cd3eb3b0dd3881250c752b2621b5324735df1"
 dependencies = [
  "anyhow",
  "derive_more 2.0.1",

--- a/codex-rs/acp/Cargo.toml
+++ b/codex-rs/acp/Cargo.toml
@@ -12,7 +12,7 @@ unstable = []
 workspace = true
 
 [dependencies]
-agent-client-protocol = { version = "0.9.0", features = ["unstable"] }
+agent-client-protocol = { version = "0.9.3", features = ["unstable"] }
 anyhow = { workspace = true }
 codex-core = { workspace = true }
 codex-protocol = { path = "../protocol" }

--- a/codex-rs/acp/docs.md
+++ b/codex-rs/acp/docs.md
@@ -95,6 +95,21 @@ Re-exported types under `unstable`:
 - `SessionModelState`, `ModelInfo`, `ModelId`: Model information from agent
 - `SetSessionModelRequest`, `SetSessionModelResponse`: Protocol messages for switching
 
+### Session Loading (`session/load`)
+
+The ACP backend supports resuming an existing session when the agent advertises the
+`loadSession` capability:
+
+- `AcpBackendConfig.session_id` (when set) triggers `session/load` instead of `session/new`.
+- The backend streams the replayed conversation via `session/update` notifications and
+  forwards them through the same translation pipeline used for live prompts.
+- MCP servers from `AcpBackendConfig.mcp_servers` are passed to both `session/new` and
+  `session/load`. Stdio env vars (`env_vars`) and HTTP header env vars (`env_http_headers`)
+  are resolved from the current process environment at startup.
+
+This enables the TUI to reconstruct chat history for ACP sessions without relying on
+local rollout files.
+
 ### Embedded Provider Info
 
 ACP providers embed their configuration directly in `AcpAgentConfig` via `AcpProviderInfo`:
@@ -443,7 +458,7 @@ The `AcpBackend` provides a TUI-compatible interface that wraps `AcpConnection`:
 └─────────────────────────┘                      └─────────────────────────┘
 ```
 
-- `AcpBackendConfig`: Configuration for spawning (model, cwd, approval_policy, sandbox_policy, notify, nori_home, history_persistence)
+- `AcpBackendConfig`: Configuration for spawning (model, cwd, session_id, mcp_servers, approval_policy, sandbox_policy, notify, nori_home, history_persistence)
 - `AcpBackend::spawn()`: Creates AcpConnection, session, and starts approval handler task. Uses enhanced error handling to provide actionable error messages on spawn or session creation failure.
 - `AcpBackend::submit(Op)`: Translates Codex Ops to ACP actions:
   - `Op::UserInput` → ACP `prompt()`

--- a/codex-rs/acp/src/backend.rs
+++ b/codex-rs/acp/src/backend.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 
 use agent_client_protocol as acp;
 use anyhow::Result;
+use codex_core::config::types::McpServerConfig;
+use codex_core::config::types::McpServerTransportConfig;
 use codex_protocol::ConversationId;
 use codex_protocol::parse_command::ParsedCommand;
 use codex_protocol::protocol::AskForApproval;
@@ -139,6 +141,10 @@ pub struct AcpBackendConfig {
     pub model: String,
     /// Working directory for the session
     pub cwd: PathBuf,
+    /// Optional ACP session id to load
+    pub session_id: Option<acp::SessionId>,
+    /// MCP servers to connect to
+    pub mcp_servers: std::collections::HashMap<String, McpServerConfig>,
     /// Approval policy for command execution
     pub approval_policy: AskForApproval,
     /// Sandbox policy for command execution
@@ -223,8 +229,28 @@ impl AcpBackend {
             }
         };
 
-        // Create a session with enhanced error handling
-        let session_result = connection.create_session(&cwd).await;
+        let mcp_servers = mcp_servers_to_acp(&config.mcp_servers);
+
+        // Create or load a session with enhanced error handling
+        let session_result = if let Some(session_id) = config.session_id.clone() {
+            let (update_tx, update_rx) = mpsc::channel(32);
+
+            let update_handler = tokio::spawn(forward_session_updates(
+                update_rx,
+                event_tx.clone(),
+                String::new(),
+            ));
+
+            let result = connection
+                .load_session(session_id, &cwd, mcp_servers, update_tx)
+                .await;
+
+            let _ = update_handler.await;
+            result
+        } else {
+            connection.create_session(&cwd, mcp_servers).await
+        };
+
         let session_id = match session_result {
             Ok(id) => id,
             Err(e) => {
@@ -487,7 +513,7 @@ impl AcpBackend {
         let prompt = vec![translator::text_to_content_block(&prompt_text)];
 
         // Create channel for receiving session updates
-        let (update_tx, mut update_rx) = mpsc::channel(32);
+        let (update_tx, update_rx) = mpsc::channel(32);
 
         // Clone what we need for the background task
         let event_tx = self.event_tx.clone();
@@ -517,58 +543,11 @@ impl AcpBackend {
                 .await;
 
             // Spawn update consumer task
-            let event_tx_clone = event_tx.clone();
-            let id_for_updates = id_clone.clone();
-            let update_handler = tokio::spawn(async move {
-                let mut event_sequence: u64 = 0;
-                // Track call_ids that have already had ExecCommandBegin emitted.
-                // The ACP protocol can emit multiple ToolCall events for the same call_id
-                // as details become available, but the TUI expects exactly one Begin per call_id.
-                let mut emitted_begin_call_ids: std::collections::HashSet<String> =
-                    std::collections::HashSet::new();
-                // Track pending patch operations: store FileChange data from ToolCall events
-                // so we can emit PatchApplyBegin on ToolCallUpdate (after approval).
-                let mut pending_patch_changes: std::collections::HashMap<
-                    String,
-                    std::collections::HashMap<PathBuf, codex_protocol::protocol::FileChange>,
-                > = std::collections::HashMap::new();
-                while let Some(update) = update_rx.recv().await {
-                    let events =
-                        translate_session_update_to_events(&update, &mut pending_patch_changes);
-                    for event_msg in events {
-                        // Deduplicate ExecCommandBegin events - only emit the first one per call_id
-                        if let EventMsg::ExecCommandBegin(ref begin_ev) = event_msg {
-                            if emitted_begin_call_ids.contains(&begin_ev.call_id) {
-                                debug!(
-                                    target: "acp_event_flow",
-                                    call_id = %begin_ev.call_id,
-                                    "ACP dispatch: skipping duplicate ExecCommandBegin"
-                                );
-                                continue;
-                            }
-                            emitted_begin_call_ids.insert(begin_ev.call_id.clone());
-                        }
-                        event_sequence += 1;
-                        debug!(
-                            target: "acp_event_flow",
-                            seq = event_sequence,
-                            event_type = get_event_msg_type(&event_msg),
-                            "ACP dispatch: sending event to TUI"
-                        );
-                        let _ = event_tx_clone
-                            .send(Event {
-                                id: id_for_updates.clone(),
-                                msg: event_msg,
-                            })
-                            .await;
-                    }
-                }
-                debug!(
-                    target: "acp_event_flow",
-                    total_events = event_sequence,
-                    "ACP dispatch: update stream completed"
-                );
-            });
+            let update_handler = tokio::spawn(forward_session_updates(
+                update_rx,
+                event_tx.clone(),
+                id_clone.clone(),
+            ));
 
             // Send the prompt (clone session_id before moving it since we need it for idle timer)
             let session_id_for_timer = session_id.to_string();
@@ -766,12 +745,143 @@ impl AcpBackend {
     }
 }
 
+async fn forward_session_updates(
+    mut update_rx: mpsc::Receiver<acp::SessionUpdate>,
+    event_tx: mpsc::Sender<Event>,
+    id: String,
+) {
+    let mut event_sequence: u64 = 0;
+    // Track call_ids that have already had ExecCommandBegin emitted.
+    // The ACP protocol can emit multiple ToolCall events for the same call_id
+    // as details become available, but the TUI expects exactly one Begin per call_id.
+    let mut emitted_begin_call_ids: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
+    // Track pending patch operations: store FileChange data from ToolCall events
+    // so we can emit PatchApplyBegin on ToolCallUpdate (after approval).
+    let mut pending_patch_changes: std::collections::HashMap<
+        String,
+        std::collections::HashMap<PathBuf, codex_protocol::protocol::FileChange>,
+    > = std::collections::HashMap::new();
+    while let Some(update) = update_rx.recv().await {
+        let events = translate_session_update_to_events(&update, &mut pending_patch_changes);
+        for event_msg in events {
+            // Deduplicate ExecCommandBegin events - only emit the first one per call_id
+            if let EventMsg::ExecCommandBegin(ref begin_ev) = event_msg {
+                if emitted_begin_call_ids.contains(&begin_ev.call_id) {
+                    debug!(
+                        target: "acp_event_flow",
+                        call_id = %begin_ev.call_id,
+                        "ACP dispatch: skipping duplicate ExecCommandBegin"
+                    );
+                    continue;
+                }
+                emitted_begin_call_ids.insert(begin_ev.call_id.clone());
+            }
+            event_sequence += 1;
+            debug!(
+                target: "acp_event_flow",
+                seq = event_sequence,
+                event_type = get_event_msg_type(&event_msg),
+                "ACP dispatch: sending event to TUI"
+            );
+            let _ = event_tx
+                .send(Event {
+                    id: id.clone(),
+                    msg: event_msg,
+                })
+                .await;
+        }
+    }
+    debug!(
+        target: "acp_event_flow",
+        total_events = event_sequence,
+        "ACP dispatch: update stream completed"
+    );
+}
+
 /// Generate a unique ID for operations
 fn generate_id() -> String {
     use std::sync::atomic::AtomicU64;
     use std::sync::atomic::Ordering;
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     format!("acp-{}", COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+fn mcp_servers_to_acp(
+    servers: &std::collections::HashMap<String, McpServerConfig>,
+) -> Vec<acp::McpServer> {
+    let mut resolved = Vec::new();
+    for (name, server) in servers {
+        if !server.enabled {
+            continue;
+        }
+
+        match &server.transport {
+            McpServerTransportConfig::Stdio {
+                command,
+                args,
+                env,
+                env_vars,
+                ..
+            } => {
+                let mut env_entries = Vec::new();
+                if let Some(env_map) = env {
+                    env_entries.extend(
+                        env_map
+                            .iter()
+                            .map(|(key, value)| acp::EnvVariable::new(key.clone(), value.clone())),
+                    );
+                }
+                for env_var in env_vars {
+                    if let Ok(value) = std::env::var(env_var) {
+                        env_entries.push(acp::EnvVariable::new(env_var.clone(), value));
+                    }
+                }
+
+                let stdio = acp::McpServerStdio::new(name.clone(), command.clone())
+                    .args(args.clone())
+                    .env(env_entries);
+                resolved.push(acp::McpServer::Stdio(stdio));
+            }
+            McpServerTransportConfig::StreamableHttp {
+                url,
+                bearer_token_env_var,
+                http_headers,
+                env_http_headers,
+            } => {
+                let mut headers = Vec::new();
+                if let Some(header_map) = http_headers {
+                    headers.extend(
+                        header_map
+                            .iter()
+                            .map(|(key, value)| acp::HttpHeader::new(key.clone(), value.clone())),
+                    );
+                }
+                if let Some(header_env_map) = env_http_headers {
+                    headers.extend(header_env_map.iter().filter_map(|(key, env_var)| {
+                        std::env::var(env_var)
+                            .ok()
+                            .map(|value| acp::HttpHeader::new(key.clone(), value))
+                    }));
+                }
+                if let Some(env_var) = bearer_token_env_var
+                    && let Ok(token) = std::env::var(env_var)
+                    && !headers
+                        .iter()
+                        .any(|header| header.name.eq_ignore_ascii_case("authorization"))
+                {
+                    headers.push(acp::HttpHeader::new(
+                        "Authorization",
+                        format!("Bearer {token}"),
+                    ));
+                }
+
+                let http = acp::McpServerHttp::new(name.clone(), url.clone()).headers(headers);
+                resolved.push(acp::McpServer::Http(http));
+            }
+        }
+    }
+    resolved
 }
 
 /// Get a human-readable name for an Op variant
@@ -2264,6 +2374,8 @@ mod tests {
         let config = AcpBackendConfig {
             model: "mock-model".to_string(),
             cwd: temp_dir.path().to_path_buf(),
+            session_id: None,
+            mcp_servers: std::collections::HashMap::new(),
             approval_policy: AskForApproval::Never,
             sandbox_policy: SandboxPolicy::new_read_only_policy(),
             notify: None,

--- a/codex-rs/acp/src/connection.rs
+++ b/codex-rs/acp/src/connection.rs
@@ -111,6 +111,14 @@ impl AcpModelState {
 enum AcpCommand {
     CreateSession {
         cwd: PathBuf,
+        mcp_servers: Vec<acp::McpServer>,
+        response_tx: oneshot::Sender<Result<acp::SessionId>>,
+    },
+    LoadSession {
+        session_id: acp::SessionId,
+        cwd: PathBuf,
+        mcp_servers: Vec<acp::McpServer>,
+        update_tx: mpsc::Sender<acp::SessionUpdate>,
         response_tx: oneshot::Sender<Result<acp::SessionId>>,
     },
     Prompt {
@@ -246,11 +254,16 @@ impl AcpConnection {
     }
 
     /// Create a new session with the agent.
-    pub async fn create_session(&self, cwd: &Path) -> Result<acp::SessionId> {
+    pub async fn create_session(
+        &self,
+        cwd: &Path,
+        mcp_servers: Vec<acp::McpServer>,
+    ) -> Result<acp::SessionId> {
         let (response_tx, response_rx) = oneshot::channel();
         self.command_tx
             .send(AcpCommand::CreateSession {
                 cwd: cwd.to_path_buf(),
+                mcp_servers,
                 response_tx,
             })
             .await
@@ -287,6 +300,32 @@ impl AcpConnection {
         self.command_tx
             .send(AcpCommand::Cancel {
                 session_id: session_id.clone(),
+                response_tx,
+            })
+            .await
+            .context("ACP worker thread died")?;
+        response_rx.await.context("ACP worker thread died")?
+    }
+
+    /// Load an existing session and stream replayed updates.
+    pub async fn load_session(
+        &self,
+        session_id: acp::SessionId,
+        cwd: &Path,
+        mcp_servers: Vec<acp::McpServer>,
+        update_tx: mpsc::Sender<acp::SessionUpdate>,
+    ) -> Result<acp::SessionId> {
+        if !self.agent_capabilities.load_session {
+            return Err(anyhow::anyhow!("ACP agent does not support session/load"));
+        }
+
+        let (response_tx, response_rx) = oneshot::channel();
+        self.command_tx
+            .send(AcpCommand::LoadSession {
+                session_id,
+                cwd: cwd.to_path_buf(),
+                mcp_servers,
+                update_tx,
                 response_tx,
             })
             .await
@@ -607,7 +646,11 @@ async fn run_command_loop(
 
     while let Some(cmd) = command_rx.recv().await {
         match cmd {
-            AcpCommand::CreateSession { cwd, response_tx } => {
+            AcpCommand::CreateSession {
+                cwd,
+                mcp_servers,
+                response_tx,
+            } => {
                 // TODO: [Future] Resume/Fork Integration
                 // When creating a session, check if there's an existing session to resume.
                 // This would require:
@@ -618,7 +661,7 @@ async fn run_command_loop(
 
                 let result = inner
                     .connection
-                    .new_session(acp::NewSessionRequest::new(cwd))
+                    .new_session(acp::NewSessionRequest::new(cwd).mcp_servers(mcp_servers))
                     .await;
 
                 // Capture model state from the response if available
@@ -638,6 +681,45 @@ async fn run_command_loop(
                 let result = result
                     .map(|r| r.session_id)
                     .context("Failed to create ACP session");
+                let _ = response_tx.send(result);
+            }
+            AcpCommand::LoadSession {
+                session_id,
+                cwd,
+                mcp_servers,
+                update_tx,
+                response_tx,
+            } => {
+                inner
+                    .client_delegate
+                    .register_session(session_id.clone(), update_tx);
+
+                let result = inner
+                    .connection
+                    .load_session(
+                        acp::LoadSessionRequest::new(session_id.clone(), cwd)
+                            .mcp_servers(mcp_servers),
+                    )
+                    .await;
+
+                #[cfg(feature = "unstable")]
+                if let Ok(ref response) = result
+                    && let Some(ref models) = response.models
+                    && let Ok(mut state) = model_state.write()
+                {
+                    *state = AcpModelState::from_session_model_state(models);
+                    debug!(
+                        "Model state updated after session load: current={:?}, available={}",
+                        state.current_model_id,
+                        state.available_models.len()
+                    );
+                }
+
+                inner.client_delegate.unregister_session(&session_id);
+
+                let result = result
+                    .map(|_| session_id)
+                    .context("Failed to load ACP session");
                 let _ = response_tx.send(result);
             }
             AcpCommand::Prompt {
@@ -1155,7 +1237,7 @@ mod tests {
 
         // Create session
         let session_id = conn
-            .create_session(temp_dir.path())
+            .create_session(temp_dir.path(), Vec::new())
             .await
             .expect("Failed to create session");
 

--- a/codex-rs/acp/src/lib.rs
+++ b/codex-rs/acp/src/lib.rs
@@ -61,6 +61,7 @@ pub use agent_client_protocol::NewSessionRequest;
 pub use agent_client_protocol::NewSessionResponse;
 pub use agent_client_protocol::PromptRequest;
 pub use agent_client_protocol::PromptResponse;
+pub use agent_client_protocol::SessionId;
 pub use agent_client_protocol::SessionNotification;
 pub use agent_client_protocol::SessionUpdate;
 

--- a/codex-rs/docs/acp_session_load_plan.md
+++ b/codex-rs/docs/acp_session_load_plan.md
@@ -1,0 +1,66 @@
+# ACP `session/load` Implementation Plan (Nori ACP Backend)
+
+## Goal
+
+Enable the ACP client (`codex-acp`) to request an explicit session ID from an agent and replay the full conversation over `session/update` notifications, so a user can resume an existing agent session. This plan is scoped to the ACP backend and the `nori` binary. It relies on the ACP spec requirement that agents replay the full conversation through `session/update` and only send the `session/load` response after the replay is complete.【F:codex-rs/acp/docs.md†L1-L23】【F:codex-rs/acp/src/backend.rs†L1-L18】
+
+## Protocol requirements to implement
+
+- Clients **must** check the agent’s `loadSession` capability before calling `session/load`.【F:/workspace/agent-client-protocol/src/agent.rs†L2389-L2445】【F:/workspace/agent-client-protocol/docs/protocol/session-setup.mdx†L88-L103】
+- `session/load` requests require the `sessionId`, `cwd`, and optional MCP server list; the agent replays the full conversation as `session/update` notifications before completing the request.【F:/workspace/agent-client-protocol/src/agent.rs†L510-L563】【F:/workspace/agent-client-protocol/docs/protocol/session-setup.mdx†L103-L189】
+- `session/update` replays user/agent messages (and tool call events) in the same streaming format used for `session/prompt`, so we can reuse the existing translation path in `codex-acp` that turns `SessionUpdate` into TUI events.【F:/workspace/agent-client-protocol/docs/protocol/session-setup.mdx†L137-L189】【F:codex-rs/acp/src/backend.rs†L818-L1035】
+
+## Current state in Nori
+
+- `codex-acp` only creates new sessions via `AcpConnection::create_session` and does not expose a `load_session` path.【F:codex-rs/acp/src/connection.rs†L241-L306】
+- Session updates are already translated to `codex_protocol::Event` via `translate_session_update_to_events`, and are consumed through an update channel in `AcpBackend::handle_user_input`. This update-consumer pipeline can be reused for replayed updates from `session/load`.【F:codex-rs/acp/src/backend.rs†L430-L592】【F:codex-rs/acp/src/backend.rs†L818-L1035】
+- MCP server configuration exists in `codex-acp` config types, but is not yet passed into ACP session creation/load requests.【F:codex-rs/acp/src/config/types.rs†L214-L312】
+
+## Implementation plan
+
+### 1) Protocol surface in `codex-acp`
+
+- **Add a `load_session` command in `AcpConnection`:**
+  - Extend `AcpCommand` with a `LoadSession` variant carrying `session_id`, `cwd`, MCP server list, and an `update_tx` channel for replayed updates.
+  - Implement `AcpConnection::load_session(...)` alongside `create_session`, mirroring the `prompt` flow: send the command to the worker thread, stream `session/update` notifications into the provided `update_tx`, and only return once the `session/load` response arrives.
+  - Gate the call with `self.agent_capabilities.load_session`; if false, return a clear error that is surfaced to the UI.
+  - Capture `LoadSessionResponse.models` (when `unstable_session_model` is enabled) to update `AcpModelState`, keeping parity with how `NewSessionResponse.models` is handled today.【F:codex-rs/acp/src/connection.rs†L84-L149】【F:/workspace/agent-client-protocol/src/agent.rs†L567-L620】
+
+### 2) Session start flow in `AcpBackend`
+
+- **Add a “session start mode” to `AcpBackendConfig`:**
+  - Extend config to accept an optional session ID (e.g., `session_id: Option<String>`). This can be wired from CLI flags or persisted config later.
+  - On spawn, decide between:
+    - `create_session(cwd, mcp_servers)` when `session_id` is `None`.
+    - `load_session(session_id, cwd, mcp_servers)` when provided.
+- **Replay handling:**
+  - Factor the update consumer used in `handle_user_input` into a reusable helper (`spawn_update_consumer`) so it can be used for both replay and live prompts.
+  - When loading a session, stream the replayed updates through the same translation pipeline so the TUI reconstructs chat history uniformly with the prompt path.【F:codex-rs/acp/src/backend.rs†L430-L592】【F:codex-rs/acp/src/backend.rs†L818-L1035】
+
+### 3) MCP server mapping
+
+- **Translate `codex-acp` MCP configuration into ACP `McpServer` structs** for both `session/new` and `session/load`:
+  - Use `McpServerConfig` (stdio vs. HTTP transport) to build `acp::McpServer` values.
+  - Include only `enabled` servers, and preserve tool allow/deny lists and timeouts when the ACP schema supports them.
+  - Add tests for config-to-ACP conversion to avoid regressions.【F:codex-rs/acp/src/config/types.rs†L214-L312】【F:/workspace/agent-client-protocol/src/agent.rs†L360-L418】
+
+### 4) CLI + TUI integration
+
+- **CLI:** add a `--session <id>` (or equivalent) flag in the `nori` CLI that populates `AcpBackendConfig.session_id`.
+- **TUI:** when in ACP mode, accept a session ID from the CLI or config and invoke the load flow on startup. Reuse the existing “Connecting to [Agent]” UI for the replay phase and show errors if `loadSession` is unsupported.
+
+### 5) Mock agent + tests
+
+- **Mock ACP agent (`mock-acp-agent`):**
+  - Implement `load_session` to emit a deterministic replay via `session/update` (user/agent chunks plus tool call updates) before returning `LoadSessionResponse`, enabling repeatable tests.
+  - Add env-gated behavior (e.g., `MOCK_AGENT_LOAD_SESSION_REPLAY=1`) to keep existing tests stable.【F:codex-rs/mock-acp-agent/src/main.rs†L211-L266】
+- **codex-acp integration tests:**
+  - Add a new test that uses the mock agent to load a session, asserts that updates are replayed, and verifies the backend emits the correct `codex_protocol::Event` sequence.
+  - Validate error handling when `loadSession` capability is absent.
+- **TUI E2E tests (ACP mode):**
+  - Add a PTY test that launches with a session ID and confirms the chat history is rendered from replayed updates.
+
+## Documentation updates (after implementation)
+
+- Update the ACP module docs (`codex-rs/acp/docs.md`) to describe session loading support, configuration, and user-facing CLI flag usage.
+- Extend the TUI/CLI docs if needed to mention the resume workflow and compatibility requirements.

--- a/codex-rs/mock-acp-agent/Cargo.toml
+++ b/codex-rs/mock-acp-agent/Cargo.toml
@@ -14,7 +14,7 @@ default = ["unstable"]
 unstable = ["agent-client-protocol/unstable"]
 
 [dependencies]
-agent-client-protocol = "0.9.0"
+agent-client-protocol = "0.9.3"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 async-trait = "0.1"

--- a/codex-rs/mock-acp-agent/docs.md
+++ b/codex-rs/mock-acp-agent/docs.md
@@ -20,7 +20,7 @@ Path: @/codex-rs/mock-acp-agent
 
 **Entry Point:** `main()` in `@/mock-acp-agent/src/main.rs`
 
-- Uses `agent_client_protocol` v0.9 crate with `unstable` feature for model switching support
+- Uses `agent_client_protocol` v0.9.3 crate with `unstable` feature for model switching support
 - Uses builder patterns for protocol types (e.g., `ToolCall::new()`, `ModelInfo::new()`)
 - Runs on single-threaded tokio runtime with `LocalSet` for `!Send` futures
 - Communicates via stdin/stdout with newline-delimited JSON-RPC messages
@@ -31,6 +31,7 @@ Path: @/codex-rs/mock-acp-agent
 |--------|----------|
 | `initialize` | Returns mock capabilities, emits "Mock agent: initialize" to stderr |
 | `new_session` | Generates incrementing session IDs, returns `session_model_state` with 3 test models |
+| `load_session` | Replays stored content via `session/update` when `MOCK_AGENT_LOAD_SESSION_REPLAY` is set |
 | `prompt` | Sends two text chunks, optionally reads files via client |
 | `cancel` | Sets flag to stop streaming |
 | `set_session_model` | Updates the current model ID in the session |
@@ -64,6 +65,7 @@ Path: @/codex-rs/mock-acp-agent
 | `MOCK_AGENT_WRITE_CONTENT` | Content to write when `MOCK_AGENT_WRITE_FILE` is set (defaults to "default content") |
 | `MOCK_AGENT_MULTI_CALL_EXPLORING` | Sends 3 Read tool calls with interleaved text streaming and out-of-order completion (call-2, call-3, call-1) to test multi-call exploring cell handling |
 | `MOCK_AGENT_NO_FINAL_TEXT` | Suppresses final text message after tool calls complete; combine with `MOCK_AGENT_MULTI_CALL_EXPLORING` to test immediate flush without subsequent text |
+| `MOCK_AGENT_LOAD_SESSION_REPLAY` | Replays a synthetic conversation history during `session/load` |
 | `MOCK_AGENT_MODEL_NAME` | Set by `AcpAgentConfig.env` to identify the model variant (e.g., "mock-model" or "mock-model-alt"); enables model-specific behavior |
 | `MOCK_AGENT_STARTUP_DELAY_MS` | Generic startup delay in ms during `initialize()` (tests "Connecting" status indicator) |
 | `MOCK_AGENT_STARTUP_DELAY_MS_{MODEL}` | Model-specific startup delay (e.g., `MOCK_AGENT_STARTUP_DELAY_MS_MOCK_MODEL_ALT`); takes precedence over generic delay when model name matches |

--- a/codex-rs/mock-acp-agent/src/main.rs
+++ b/codex-rs/mock-acp-agent/src/main.rs
@@ -82,6 +82,20 @@ impl MockAgent {
         .await
     }
 
+    async fn send_user_text_chunk(
+        &self,
+        session_id: acp::SessionId,
+        text: &str,
+    ) -> Result<(), acp::Error> {
+        self.send_update(
+            session_id,
+            acp::SessionUpdate::UserMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
+                acp::TextContent::new(text),
+            ))),
+        )
+        .await
+    }
+
     /// Send a tool call notification
     async fn send_tool_call(
         &self,
@@ -157,6 +171,26 @@ impl MockAgent {
     }
 }
 
+fn mock_session_model_state() -> acp::SessionModelState {
+    acp::SessionModelState::new(
+        acp::ModelId::new("mock-model-default"),
+        vec![
+            acp::ModelInfo::new(
+                acp::ModelId::new("mock-model-default"),
+                "Mock Default Model",
+            )
+            .description("The default mock model"),
+            acp::ModelInfo::new(acp::ModelId::new("mock-model-fast"), "Mock Fast Model")
+                .description("A faster mock model variant"),
+            acp::ModelInfo::new(
+                acp::ModelId::new("mock-model-powerful"),
+                "Mock Powerful Model",
+            )
+            .description("A more capable mock model variant"),
+        ],
+    )
+}
+
 #[async_trait::async_trait(?Send)]
 impl acp::Agent for MockAgent {
     async fn initialize(
@@ -196,6 +230,7 @@ impl acp::Agent for MockAgent {
 
         eprintln!("Mock agent: initialize");
         Ok(acp::InitializeResponse::new(acp::ProtocolVersion::LATEST)
+            .agent_capabilities(acp::AgentCapabilities::new().load_session(true))
             .agent_info(acp::Implementation::new("mock-agent", "0.1.0").title("Mock Agent")))
     }
 
@@ -215,23 +250,7 @@ impl acp::Agent for MockAgent {
         eprintln!("Mock agent: new_session id={}", session_id);
 
         // Include model state with available models for testing model switching
-        let session_model_state = acp::SessionModelState::new(
-            acp::ModelId::new("mock-model-default"),
-            vec![
-                acp::ModelInfo::new(
-                    acp::ModelId::new("mock-model-default"),
-                    "Mock Default Model",
-                )
-                .description("The default mock model"),
-                acp::ModelInfo::new(acp::ModelId::new("mock-model-fast"), "Mock Fast Model")
-                    .description("A faster mock model variant"),
-                acp::ModelInfo::new(
-                    acp::ModelId::new("mock-model-powerful"),
-                    "Mock Powerful Model",
-                )
-                .description("A more powerful mock model variant"),
-            ],
-        );
+        let session_model_state = mock_session_model_state();
 
         Ok(
             acp::NewSessionResponse::new(acp::SessionId::new(session_id.to_string()))
@@ -241,9 +260,24 @@ impl acp::Agent for MockAgent {
 
     async fn load_session(
         &self,
-        _arguments: acp::LoadSessionRequest,
+        arguments: acp::LoadSessionRequest,
     ) -> Result<acp::LoadSessionResponse, acp::Error> {
-        Ok(acp::LoadSessionResponse::new())
+        let session_id = arguments.session_id.clone();
+        eprintln!("Mock agent: load_session id={session_id}");
+
+        if std::env::var("MOCK_AGENT_LOAD_SESSION_REPLAY").is_ok() {
+            self.send_user_text_chunk(session_id.clone(), "Replayed user message")
+                .await?;
+            self.send_text_chunk(session_id.clone(), "Replayed assistant message")
+                .await?;
+        }
+
+        let mut response = acp::LoadSessionResponse::new();
+        #[cfg(feature = "unstable")]
+        {
+            response = response.models(mock_session_model_state());
+        }
+        Ok(response)
     }
 
     async fn prompt(

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -254,6 +254,7 @@ impl App {
         initial_prompt: Option<String>,
         initial_images: Vec<PathBuf>,
         resume_selection: ResumeSelection,
+        acp_session_id: Option<String>,
         #[cfg(feature = "feedback")] feedback: crate::feedback_compat::CodexFeedback,
     ) -> Result<AppExitInfo> {
         use tokio_stream::StreamExt;
@@ -301,6 +302,7 @@ impl App {
                     auth_manager: auth_manager.clone(),
                     #[cfg(feature = "feedback")]
                     feedback: feedback.clone(),
+                    acp_session_id: acp_session_id.clone(),
                     expected_model: None, // No filtering for fresh sessions
                 };
                 ChatWidget::new(init, conversation_manager.clone())
@@ -326,6 +328,7 @@ impl App {
                     auth_manager: auth_manager.clone(),
                     #[cfg(feature = "feedback")]
                     feedback: feedback.clone(),
+                    acp_session_id: None,
                     expected_model: None, // No filtering for resumed sessions
                 };
                 ChatWidget::new_from_existing(
@@ -497,6 +500,7 @@ impl App {
                     auth_manager: self.auth_manager.clone(),
                     #[cfg(feature = "feedback")]
                     feedback: self.feedback.clone(),
+                    acp_session_id: None,
                     expected_model: None, // No filtering for /new command
                 };
                 self.chat_widget = ChatWidget::new(init, self.server.clone());
@@ -1033,6 +1037,7 @@ impl App {
                     auth_manager: self.auth_manager.clone(),
                     #[cfg(feature = "feedback")]
                     feedback: self.feedback.clone(),
+                    acp_session_id: None,
                     expected_model: Some(model_name.clone()),
                 };
                 self.chat_widget = ChatWidget::new(init, self.server.clone());

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -348,6 +348,7 @@ impl App {
             auth_manager: self.auth_manager.clone(),
             #[cfg(feature = "feedback")]
             feedback: self.feedback.clone(),
+            acp_session_id: None,
             expected_model: None, // No filtering for backtracked conversations
         };
         self.chat_widget =

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -322,6 +322,7 @@ pub(crate) struct ChatWidgetInit {
     pub(crate) auth_manager: Arc<AuthManager>,
     #[cfg(feature = "feedback")]
     pub(crate) feedback: crate::feedback_compat::CodexFeedback,
+    pub(crate) acp_session_id: Option<String>,
     /// Expected model name for this widget. When set, events from other models
     /// (e.g., from a previous agent) are ignored until SessionConfigured arrives
     /// with a matching model. This prevents race conditions when switching agents.
@@ -1484,11 +1485,17 @@ impl ChatWidget {
             auth_manager,
             #[cfg(feature = "feedback")]
             feedback,
+            acp_session_id,
             expected_model,
         } = common;
         let mut rng = rand::rng();
         let placeholder = EXAMPLE_PROMPTS[rng.random_range(0..EXAMPLE_PROMPTS.len())].to_string();
-        let spawn_result = spawn_agent(config.clone(), app_event_tx.clone(), conversation_manager);
+        let spawn_result = spawn_agent(
+            config.clone(),
+            app_event_tx.clone(),
+            conversation_manager,
+            acp_session_id,
+        );
 
         let mut widget = Self {
             app_event_tx: app_event_tx.clone(),
@@ -1574,11 +1581,13 @@ impl ChatWidget {
             auth_manager,
             #[cfg(feature = "feedback")]
             feedback,
+            acp_session_id,
             expected_model,
         } = common;
         let mut rng = rand::rng();
         let placeholder = EXAMPLE_PROMPTS[rng.random_range(0..EXAMPLE_PROMPTS.len())].to_string();
 
+        let _ = acp_session_id;
         let codex_op_tx =
             spawn_agent_from_existing(conversation, session_configured, app_event_tx.clone());
 

--- a/codex-rs/tui/src/chatwidget/agent.rs
+++ b/codex-rs/tui/src/chatwidget/agent.rs
@@ -95,12 +95,13 @@ pub(crate) fn spawn_agent(
     config: Config,
     app_event_tx: AppEventSender,
     server: Arc<ConversationManager>,
+    acp_session_id: Option<String>,
 ) -> SpawnAgentResult {
     let acp_agent_result = get_agent_config(&config.model);
 
     match (acp_agent_result.is_ok(), config.acp_allow_http_fallback) {
         // Model is registered in ACP registry -> use ACP
-        (true, _) => spawn_acp_agent(config, app_event_tx),
+        (true, _) => spawn_acp_agent(config, app_event_tx, acp_session_id),
 
         // Model NOT registered, but HTTP fallback is allowed -> use HTTP
         (false, true) => {
@@ -156,7 +157,11 @@ fn spawn_error_agent(
 ///
 /// This uses the `codex_acp` crate to spawn an agent subprocess and handle
 /// communication via the Agent Client Protocol.
-fn spawn_acp_agent(config: Config, app_event_tx: AppEventSender) -> SpawnAgentResult {
+fn spawn_acp_agent(
+    config: Config,
+    app_event_tx: AppEventSender,
+    acp_session_id: Option<String>,
+) -> SpawnAgentResult {
     let (codex_op_tx, mut codex_op_rx) = unbounded_channel::<Op>();
 
     // Create the model command channel for model switching operations
@@ -176,9 +181,14 @@ fn spawn_acp_agent(config: Config, app_event_tx: AppEventSender) -> SpawnAgentRe
 
         // Create ACP backend config from codex config
         let nori_home = find_nori_home().unwrap_or_else(|_| config.cwd.clone());
+        let session_id = acp_session_id
+            .filter(|id| !id.is_empty())
+            .map(codex_acp::SessionId::new);
         let acp_config = AcpBackendConfig {
             model: config.model.clone(),
             cwd: config.cwd.clone(),
+            session_id,
+            mcp_servers: config.mcp_servers.clone(),
             approval_policy: config.approval_policy,
             sandbox_policy: config.sandbox_policy.clone(),
             notify: config.notify.clone(),

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -316,6 +316,7 @@ async fn helpers_are_available_and_do_not_panic() {
         auth_manager,
         #[cfg(feature = "feedback")]
         feedback: crate::feedback_compat::CodexFeedback::new(),
+        acp_session_id: None,
         expected_model: None,
     };
     let mut w = ChatWidget::new(init, conversation_manager);

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -578,8 +578,33 @@ async fn run_ratatui_app(
         initial_config
     };
 
+    let is_acp_model = codex_acp::get_agent_config(&config.model).is_ok();
+    let acp_resume_session_id = if is_acp_model {
+        cli.resume_session_id.clone()
+    } else {
+        None
+    };
+
     // Determine resume behavior: explicit id, then resume last, then picker.
-    let resume_selection = if let Some(id_str) = cli.resume_session_id.as_deref() {
+    let resume_selection = if is_acp_model {
+        if cli.resume_last || cli.resume_picker {
+            restore();
+            session_log::log_session_end();
+            let _ = tui.terminal.clear();
+            if let Err(err) = writeln!(
+                std::io::stdout(),
+                "ACP agents do not support session listing yet. Use `codex resume <SESSION_ID>` to load a specific ACP session."
+            ) {
+                error!("Failed to write ACP resume error message: {err}");
+            }
+            return Ok(AppExitInfo {
+                token_usage: codex_core::protocol::TokenUsage::default(),
+                conversation_id: None,
+                update_action: None,
+            });
+        }
+        resume_picker::ResumeSelection::StartFresh
+    } else if let Some(id_str) = cli.resume_session_id.as_deref() {
         match find_conversation_path_by_id_str(&config.codex_home, id_str).await? {
             Some(path) => resume_picker::ResumeSelection::Resume(path),
             None => {
@@ -654,6 +679,7 @@ async fn run_ratatui_app(
         prompt,
         images,
         resume_selection,
+        acp_resume_session_id,
         feedback,
     )
     .await;
@@ -666,6 +692,7 @@ async fn run_ratatui_app(
         prompt,
         images,
         resume_selection,
+        acp_resume_session_id,
     )
     .await;
 


### PR DESCRIPTION
### Motivation
- Enable the ACP client to resume existing agent sessions via the unstable `session/load` capability so the TUI can reconstruct chat history from the agent instead of local rollout files. 
- Ensure MCP server configuration is passed through to agent session setup so agents can initialize MCP tool context consistently for both `session/new` and `session/load`.
- Wire an ACP session id through the TUI/agent spawn path so `codex resume <SESSION_ID>` can initiate an ACP session load when applicable.

### Description
- Added `AcpConnection::load_session(...)`, extended `AcpCommand` with `LoadSession`, and threaded `mcp_servers` through `create_session`/`load_session` and the worker loop to call `session/new` or `session/load` as appropriate. 
- Updated `AcpBackend` to accept `AcpBackendConfig.session_id` and to choose between creating or loading a session; factored update-consumer logic into `forward_session_updates` and added `mcp_servers_to_acp` to translate local MCP config into `acp::McpServer` values. 
- Plumbed an optional `acp_session_id` from CLI → TUI (`run_ratatui_app`/`App::run`) → `ChatWidget` → `spawn_agent` → `AcpBackendConfig`, and guarded resume UI behavior for ACP models. 
- Extended `mock-acp-agent` to advertise `loadSession` capability and implemented `load_session` with an env-gated replay mode (`MOCK_AGENT_LOAD_SESSION_REPLAY`) to emit `session/update` notifications; updated mock docs. 
- Re-exported `SessionId` from the ACP crate and updated ACP docs with a new section describing session loading; added a short implementation plan file describing the design and test strategy.

### Testing
- Ran `just fmt` (succeeded) and `just fix -p codex-acp -p codex-tui -p mock-acp-agent` (ran and applied Clippy fixes successfully). 
- Ran `cargo test -p codex-acp` (all tests passed) and `cargo test -p mock-acp-agent` (passed). 
- Ran `cargo test -p codex-tui` which completed but reported 4 failing vt100/color-oriented tests in `insert_history` (these are UI rendering assertions). 
- Ran `cargo test -p tui-pty-e2e` but E2E tests failed in this environment due to missing external runtime artifacts/dependencies (tests that spawn the TUI/agent encounter missing external CLI or binary in this sandbox), so full E2E verification requires the CI/test environment that provides those external tools.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69697bf6980083268b84ab611a8f24ae)