### PR TITLE
feat(installed): Align install and session lifecycle with new schema

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -4064,15 +4064,16 @@ dependencies = [
  "anyhow",
  "chrono",
  "codex-acp",
- "hex",
  "libc",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
  "tokio",
  "tracing",
+ "uuid",
  "windows-sys 0.59.0",
 ]
 

--- a/codex-rs/installed/Cargo.toml
+++ b/codex-rs/installed/Cargo.toml
@@ -17,13 +17,14 @@ workspace = true
 anyhow = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 codex-acp = { workspace = true }
-hex = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
+semver = "1.0.27"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 tracing = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/codex-rs/installed/docs.md
+++ b/codex-rs/installed/docs.md
@@ -4,15 +4,15 @@ Path: @/codex-rs/installed
 
 ### Overview
 
-- Tracks CLI lifecycle events (first install, version upgrades, sessions) via a persistent state file
-- Sends analytics events to the Tilework backend for usage insights
-- Generates privacy-protecting user identifiers based on hashed hostname:username
+- Tracks CLI lifecycle events (first install, version upgrades, sessions, resurrection) via a persistent state file
+- Sends analytics events to the shared Nori analytics proxy for usage insights
+- Generates deterministic client IDs from hashed hostname + username for churn tracking
 
 ### How it fits into the larger codebase
 
 - **Called from** `@/codex-rs/tui/src/lib.rs` via `track_launch()` at TUI startup
 - **State persistence**: Writes to `$NORI_HOME/.nori-install.json` (where `NORI_HOME` is typically `~/.nori/cli`)
-- **Analytics endpoint**: Sends events to `https://demo.tilework.tech/api/analytics/track` (configurable via `NORI_ANALYTICS_URL` env var)
+- **Analytics endpoint**: Sends events to `https://noriskillsets.dev/api/analytics/track` (configurable via `NORI_ANALYTICS_URL` env var)
 - **Install source detection**: Reads `NORI_MANAGED_BY_BUN` or `NORI_MANAGED_BY_NPM` environment variables set by the nori.js wrapper
 
 ```
@@ -34,17 +34,17 @@ Path: @/codex-rs/installed
 
 `track_launch(nori_home: &Path)` spawns a background tokio task that:
 1. Reads existing state from `.nori-install.json` (treats missing/corrupt as first install)
-2. Determines event type: `FirstInstall`, `Upgrade`, or `Session`
+2. Determines lifecycle events: `app_install`, `app_update`, `user_resurrected`, and `session_start`
 3. Updates state and writes atomically (temp file + rename)
-4. Sends analytics event (no-op in debug builds)
+4. Sends analytics events unless opted out (`NORI_NO_ANALYTICS=1` or `opt_out: true`)
 
 **State Structure (`state.rs`):**
 
 | Field | Description |
 |-------|-------------|
 | `schema_version` | Forward-compatible versioning (currently 1) |
-| `client_id` | Always "nori-cli" |
-| `user_id` | Privacy hash: `sha256:<hex>` of `hostname:username` |
+| `client_id` | Deterministic UUID from `SHA256("nori_salt:<hostname>:<username>")` |
+| `opt_out` | Boolean flag to disable analytics |
 | `first_installed_at` | Immutable timestamp of first install |
 | `last_updated_at` | When version last changed |
 | `last_launched_at` | Most recent launch time |
@@ -53,23 +53,25 @@ Path: @/codex-rs/installed
 
 **Analytics Events (`analytics.rs`):**
 
-Two event types with standardized `tilework_cli_` prefixed parameters:
+Flat JSON payloads with `event`, `client_id`, `session_id`, `timestamp`, and a shared `properties` object:
 
-| Event | When Sent | Parameters |
-|-------|-----------|------------|
-| `plugin_install_completed` | First install or upgrade | `tilework_user_id`, `tilework_cli_installed_version`, `tilework_cli_install_source`, `tilework_cli_is_first_install`, `tilework_cli_days_since_install`, `tilework_cli_previous_version` (upgrade only) |
-| `nori_session_started` | Every launch (not first/upgrade) | `tilework_user_id`, `tilework_cli_installed_version`, `tilework_cli_install_source`, `tilework_cli_days_since_install` |
+| Event | When Sent | Notes |
+|-------|-----------|-------|
+| `app_install` | First install | Created when state file is missing |
+| `app_update` | Version upgrade | Semver comparison against `installed_version` |
+| `user_resurrected` | Returning after 30+ days | Emitted before `session_start` |
+| `session_start` | Every launch | Session-scoped UUID |
 
 **Detection (`detection.rs`):**
 
 - `detect_install_source()`: Checks `NORI_MANAGED_BY_BUN=1` then `NORI_MANAGED_BY_NPM=1`
-- `generate_user_id()`: SHA256 hash of `{hostname}:{username}` for privacy
+- `generate_client_id()`: SHA256 hash of `nori_salt:{hostname}:{username}` formatted as UUID
 
 ### Things to Know
 
-- **Debug builds skip analytics**: `send_event()` is a no-op when `debug_assertions` is enabled, preventing noise during development and E2E testing
+- **Opt-out honored**: `NORI_NO_ANALYTICS=1` or `opt_out: true` disables network requests but keeps state updated
 - **Atomic writes**: State file uses temp file + rename to prevent partial writes on crash
-- **User ID stability**: Once generated, the `user_id` is persisted in the state file and reused across sessions
-- **Version comparison**: Upgrade detection uses simple string equality on `installed_version` vs `CLI_VERSION` constant
+- **Client ID stability**: Once generated, the `client_id` is persisted in the state file and reused across sessions
+- **Version comparison**: Upgrade detection uses semver ordering on `installed_version` vs `CLI_VERSION`
 
 Created and maintained by Nori.

--- a/codex-rs/installed/src/analytics.rs
+++ b/codex-rs/installed/src/analytics.rs
@@ -1,284 +1,188 @@
 //! Analytics event sending
 //!
 //! Provides fire-and-forget analytics event sending for install tracking.
-//!
-//! Analytics events are only sent in release builds to avoid noise from
-//! development and E2E testing.
 
-use crate::state::InstallSource;
 use crate::state::InstallState;
+use chrono::DateTime;
+use chrono::Utc;
 use serde::Serialize;
 use tracing::debug;
 
-/// Event name for install/upgrade events
-pub const EVENT_PLUGIN_INSTALL_COMPLETED: &str = "plugin_install_completed";
-
-/// Event name for session start events
-pub const EVENT_SESSION_STARTED: &str = "nori_session_started";
-
 /// Analytics event request payload
 #[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct TrackEventRequest {
-    /// Client identifier (always "nori-cli")
+    /// Event name
+    pub event: String,
+
+    /// Client identifier (UUID string)
     pub client_id: String,
 
-    /// Privacy-protecting user identifier
-    pub user_id: String,
+    /// Session identifier (ephemeral per run)
+    pub session_id: String,
 
-    /// Name of the event
-    pub event_name: String,
+    /// Event timestamp (ISO-8601)
+    pub timestamp: String,
 
-    /// Event-specific parameters
-    pub event_params: serde_json::Value,
+    /// Event properties
+    pub properties: AnalyticsProperties,
 }
 
-/// Type of install event
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum InstallEventType {
-    /// First time installation
-    FirstInstall,
-    /// Version upgrade
-    Upgrade { previous_version: String },
+/// Analytics event properties
+#[derive(Debug, Clone, Serialize)]
+pub struct AnalyticsProperties {
+    pub version: String,
+    pub os: String,
+    pub arch: String,
+    pub node_version: String,
+    pub is_ci: bool,
 }
 
-/// Create an install/upgrade event
-pub fn create_install_event(
+/// Build the shared analytics properties payload.
+pub fn build_properties(version: &str) -> AnalyticsProperties {
+    AnalyticsProperties {
+        version: version.to_string(),
+        os: normalized_os().to_string(),
+        arch: normalized_arch().to_string(),
+        node_version: node_version(),
+        is_ci: is_ci(),
+    }
+}
+
+/// Create an analytics event payload.
+pub fn create_track_event(
     state: &InstallState,
-    event_type: InstallEventType,
-    days_since_install: i64,
+    event: &str,
+    session_id: &str,
+    timestamp: DateTime<Utc>,
+    properties: AnalyticsProperties,
 ) -> TrackEventRequest {
-    let (is_first_install, previous_version) = match &event_type {
-        InstallEventType::FirstInstall => (true, None),
-        InstallEventType::Upgrade { previous_version } => (false, Some(previous_version.clone())),
-    };
-
-    let mut params = serde_json::json!({
-        "tilework_user_id": state.user_id,
-        "tilework_cli_installed_version": state.installed_version,
-        "tilework_cli_install_source": install_source_to_string(state.install_source),
-        "tilework_cli_is_first_install": is_first_install,
-        "tilework_cli_days_since_install": days_since_install,
-    });
-
-    if let Some(prev) = previous_version {
-        params["tilework_cli_previous_version"] = serde_json::Value::String(prev);
-    }
-
     TrackEventRequest {
+        event: event.to_string(),
         client_id: state.client_id.clone(),
-        user_id: state.user_id.clone(),
-        event_name: EVENT_PLUGIN_INSTALL_COMPLETED.to_string(),
-        event_params: params,
+        session_id: session_id.to_string(),
+        timestamp: timestamp.to_rfc3339(),
+        properties,
     }
 }
 
-/// Create a session started event
-pub fn create_session_event(state: &InstallState, days_since_install: i64) -> TrackEventRequest {
-    let params = serde_json::json!({
-        "tilework_user_id": state.user_id,
-        "tilework_cli_installed_version": state.installed_version,
-        "tilework_cli_install_source": install_source_to_string(state.install_source),
-        "tilework_cli_days_since_install": days_since_install,
-    });
-
-    TrackEventRequest {
-        client_id: state.client_id.clone(),
-        user_id: state.user_id.clone(),
-        event_name: EVENT_SESSION_STARTED.to_string(),
-        event_params: params,
-    }
-}
-
-fn install_source_to_string(source: InstallSource) -> &'static str {
-    match source {
-        InstallSource::Npm => "npm",
-        InstallSource::Bun => "bun",
-        InstallSource::Unknown => "unknown",
-    }
-}
-
-/// Send an analytics event to the backend (release builds only)
+/// Send an analytics event to the backend.
 ///
-/// This function is a no-op in debug builds to avoid noise from
-/// development and E2E testing.
-///
-/// In release builds, it sends the event via HTTP POST to the analytics
-/// endpoint. Failures are silently ignored (fire-and-forget).
-#[cfg(not(debug_assertions))]
+/// It sends the event via HTTP POST to the analytics endpoint. Failures are
+/// silently ignored (fire-and-forget).
 pub async fn send_event(event: &TrackEventRequest) {
     /// Default analytics endpoint URL
-    const DEFAULT_ANALYTICS_URL: &str = "https://demo.tilework.tech/api/analytics/track";
+    const DEFAULT_ANALYTICS_URL: &str = "https://noriskillsets.dev/api/analytics/track";
 
     /// Environment variable to override the analytics URL
     const ANALYTICS_URL_ENV: &str = "NORI_ANALYTICS_URL";
 
     let url =
         std::env::var(ANALYTICS_URL_ENV).unwrap_or_else(|_| DEFAULT_ANALYTICS_URL.to_string());
-    debug!("Sending analytics event to {}: {:?}", url, event.event_name);
+    debug!("Sending analytics event to {}: {}", url, event.event);
 
     let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_millis(500))
         .build();
 
     let client = match client {
         Ok(c) => c,
-        Err(e) => {
-            debug!("Failed to create HTTP client for analytics: {e}");
-            return;
-        }
+        Err(_) => return,
     };
 
-    match client.post(&url).json(event).send().await {
-        Ok(response) => {
-            let status = response.status();
-            if status.is_success() {
-                debug!("Analytics event sent successfully: {}", event.event_name);
-            } else {
-                debug!("Analytics request failed with status {status}");
-            }
-        }
-        Err(e) => {
-            debug!("Failed to send analytics event: {e}");
-        }
+    let _ = client.post(&url).json(event).send().await;
+}
+
+fn normalized_os() -> &'static str {
+    match std::env::consts::OS {
+        "macos" => "darwin",
+        other => other,
     }
 }
 
-/// No-op analytics sending for debug builds
-#[cfg(debug_assertions)]
-pub async fn send_event(event: &TrackEventRequest) {
-    debug!(
-        "Analytics event skipped (debug build): {}",
-        event.event_name
-    );
-    let _ = event; // Suppress unused warning
+fn normalized_arch() -> &'static str {
+    match std::env::consts::ARCH {
+        "aarch64" => "arm64",
+        other => other,
+    }
+}
+
+fn node_version() -> String {
+    std::env::var("NORI_NODE_VERSION")
+        .or_else(|_| std::env::var("NODE_VERSION"))
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+fn is_ci() -> bool {
+    let truthy = |value: &str| matches!(value, "1" | "true" | "TRUE");
+    if let Ok(value) = std::env::var("CI") {
+        return truthy(&value);
+    }
+
+    [
+        "GITHUB_ACTIONS",
+        "BUILDKITE",
+        "CIRCLECI",
+        "GITLAB_CI",
+        "TEAMCITY_VERSION",
+        "JENKINS_URL",
+        "TRAVIS",
+        "APPVEYOR",
+    ]
+    .iter()
+    .any(|key| std::env::var(key).is_ok())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::TimeZone;
-    use chrono::Utc;
-
     fn create_test_state() -> InstallState {
         let now = Utc.with_ymd_and_hms(2025, 1, 15, 10, 30, 0).unwrap();
         InstallState::new_first_install(
-            "sha256:testhash".to_string(),
+            "7b9f7433-2b41-4d2f-94cc-2b27fe58b035".to_string(),
             "1.0.0".to_string(),
-            InstallSource::Bun,
+            crate::state::InstallSource::Bun,
             now,
         )
     }
 
     #[test]
-    fn test_create_first_install_event() {
+    fn test_create_track_event() {
         let state = create_test_state();
-        let event = create_install_event(&state, InstallEventType::FirstInstall, 0);
+        let properties = build_properties("1.0.0");
+        let timestamp = Utc.with_ymd_and_hms(2025, 1, 15, 10, 30, 0).unwrap();
+        let event =
+            create_track_event(&state, "session_start", "session-id", timestamp, properties);
 
-        assert_eq!(event.client_id, "nori-cli");
-        assert_eq!(event.user_id, "sha256:testhash");
-        assert_eq!(event.event_name, EVENT_PLUGIN_INSTALL_COMPLETED);
-
-        let params = &event.event_params;
-        // Verify new tilework_cli_ prefixed fields
-        assert_eq!(params["tilework_user_id"], "sha256:testhash");
-        assert_eq!(params["tilework_cli_install_source"], "bun");
-        assert_eq!(params["tilework_cli_installed_version"], "1.0.0");
-        assert_eq!(params["tilework_cli_is_first_install"], true);
-        assert_eq!(params["tilework_cli_days_since_install"], 0);
-        assert!(params.get("tilework_cli_previous_version").is_none());
-
-        // Verify removed fields are NOT present
-        assert!(params.get("install_type").is_none());
-        assert!(params.get("install_source").is_none());
-        assert!(params.get("installed_version").is_none());
-        assert!(params.get("is_first_install").is_none());
-    }
-
-    #[test]
-    fn test_create_upgrade_event() {
-        let mut state = create_test_state();
-        state.installed_version = "2.0.0".to_string();
-        state.install_source = InstallSource::Npm;
-
-        let event = create_install_event(
-            &state,
-            InstallEventType::Upgrade {
-                previous_version: "1.0.0".to_string(),
-            },
-            5, // 5 days since original install
-        );
-
-        assert_eq!(event.event_name, EVENT_PLUGIN_INSTALL_COMPLETED);
-
-        let params = &event.event_params;
-        // Verify new tilework_cli_ prefixed fields
-        assert_eq!(params["tilework_user_id"], "sha256:testhash");
-        assert_eq!(params["tilework_cli_install_source"], "npm");
-        assert_eq!(params["tilework_cli_installed_version"], "2.0.0");
-        assert_eq!(params["tilework_cli_is_first_install"], false);
-        assert_eq!(params["tilework_cli_previous_version"], "1.0.0");
-        assert_eq!(params["tilework_cli_days_since_install"], 5);
-
-        // Verify removed fields are NOT present
-        assert!(params.get("install_type").is_none());
-        assert!(params.get("install_source").is_none());
-        assert!(params.get("installed_version").is_none());
-        assert!(params.get("is_first_install").is_none());
-        assert!(params.get("previous_version").is_none());
-    }
-
-    #[test]
-    fn test_create_session_event() {
-        let state = create_test_state();
-        let event = create_session_event(&state, 5);
-
-        assert_eq!(event.client_id, "nori-cli");
-        assert_eq!(event.user_id, "sha256:testhash");
-        assert_eq!(event.event_name, EVENT_SESSION_STARTED);
-
-        let params = &event.event_params;
-        // Verify new tilework_cli_ prefixed fields
-        assert_eq!(params["tilework_user_id"], "sha256:testhash");
-        assert_eq!(params["tilework_cli_installed_version"], "1.0.0");
-        assert_eq!(params["tilework_cli_install_source"], "bun");
-        assert_eq!(params["tilework_cli_days_since_install"], 5);
-
-        // Verify removed fields are NOT present
-        assert!(params.get("install_type").is_none());
-        assert!(params.get("installed_version").is_none());
-        assert!(params.get("install_source").is_none());
-        assert!(params.get("days_since_install").is_none());
-
-        // Verify is_first_install is NOT in session events
-        assert!(params.get("tilework_cli_is_first_install").is_none());
+        assert_eq!(event.client_id, "7b9f7433-2b41-4d2f-94cc-2b27fe58b035");
+        assert_eq!(event.session_id, "session-id");
+        assert_eq!(event.event, "session_start");
+        assert_eq!(event.timestamp, "2025-01-15T10:30:00+00:00");
     }
 
     #[test]
     fn test_event_serialization() {
         let state = create_test_state();
-        let event = create_session_event(&state, 10);
+        let properties = AnalyticsProperties {
+            version: "1.0.0".to_string(),
+            os: "darwin".to_string(),
+            arch: "arm64".to_string(),
+            node_version: "20.0.0".to_string(),
+            is_ci: false,
+        };
+        let event = create_track_event(
+            &state,
+            "session_start",
+            "session-id",
+            Utc::now(),
+            properties,
+        );
 
         let json = serde_json::to_string(&event).expect("serialization failed");
 
-        // Verify camelCase field names
-        assert!(json.contains("\"clientId\""));
-        assert!(json.contains("\"userId\""));
-        assert!(json.contains("\"eventName\""));
-        assert!(json.contains("\"eventParams\""));
-    }
-
-    #[test]
-    fn test_install_source_unknown() {
-        let now = Utc.with_ymd_and_hms(2025, 1, 15, 10, 30, 0).unwrap();
-        let state = InstallState::new_first_install(
-            "sha256:test".to_string(),
-            "1.0.0".to_string(),
-            InstallSource::Unknown,
-            now,
-        );
-
-        let event = create_session_event(&state, 0);
-        assert_eq!(event.event_params["tilework_cli_install_source"], "unknown");
+        assert!(json.contains("\"client_id\""));
+        assert!(json.contains("\"session_id\""));
+        assert!(json.contains("\"event\""));
+        assert!(json.contains("\"properties\""));
     }
 }

--- a/codex-rs/installed/src/detection.rs
+++ b/codex-rs/installed/src/detection.rs
@@ -1,17 +1,20 @@
-//! Install source and user ID detection
+//! Install source and client ID detection
 //!
 //! Provides functions to detect how the CLI was installed and generate
-//! a privacy-protecting user identifier.
+//! a privacy-preserving client identifier.
 
 use crate::state::InstallSource;
 use sha2::Digest;
 use sha2::Sha256;
+use uuid::Uuid;
 
 /// Environment variable set by nori.js when installed via Bun
 const NORI_MANAGED_BY_BUN: &str = "NORI_MANAGED_BY_BUN";
 
 /// Environment variable set by nori.js when installed via npm
 const NORI_MANAGED_BY_NPM: &str = "NORI_MANAGED_BY_NPM";
+
+const CLIENT_ID_SALT: &str = "nori_salt";
 
 /// Detect the install source from environment variables
 ///
@@ -27,22 +30,26 @@ pub fn detect_install_source() -> InstallSource {
     }
 }
 
-/// Generate a privacy-protecting user identifier
+/// Generate a privacy-preserving client identifier
 ///
 /// Creates a deterministic hash of hostname and username that:
 /// - Is stable across sessions on the same machine
 /// - Cannot be reversed to recover the original values
 /// - Is suitable for analytics without PII exposure
 ///
-/// Format: `sha256:<hex_hash>`
-pub fn generate_user_id() -> String {
+/// Format: UUID string derived from SHA256("nori_salt:<hostname>:<username>")
+pub fn generate_client_id() -> String {
     let hostname = get_hostname();
     let username = get_username();
 
-    let input = format!("{hostname}:{username}");
+    let input = format!("{CLIENT_ID_SALT}:{hostname}:{username}");
     let hash = Sha256::digest(input.as_bytes());
 
-    format!("sha256:{}", hex::encode(hash))
+    let bytes: [u8; 16] = hash
+        .get(..16)
+        .and_then(|slice| <[u8; 16]>::try_from(slice).ok())
+        .unwrap_or_default();
+    Uuid::from_bytes(bytes).to_string()
 }
 
 /// Get the system hostname
@@ -181,44 +188,33 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_user_id_format() {
-        let user_id = generate_user_id();
+    fn test_generate_client_id_format() {
+        let client_id = generate_client_id();
 
-        // Should start with "sha256:"
-        assert!(
-            user_id.starts_with("sha256:"),
-            "user_id should start with 'sha256:'"
-        );
-
-        // Should have a 64-character hex hash after the prefix
-        let hash_part = user_id.strip_prefix("sha256:").expect("prefix not found");
-        assert_eq!(hash_part.len(), 64, "SHA256 hash should be 64 hex chars");
-
-        // Should be valid hex
-        assert!(
-            hash_part.chars().all(|c| c.is_ascii_hexdigit()),
-            "hash should be valid hex"
-        );
+        let parsed = Uuid::parse_str(&client_id).expect("client_id should be a UUID");
+        assert_eq!(parsed.to_string(), client_id);
     }
 
     #[test]
-    fn test_generate_user_id_deterministic() {
+    fn test_generate_client_id_deterministic() {
         // Same machine should always produce the same ID
-        let id1 = generate_user_id();
-        let id2 = generate_user_id();
-        assert_eq!(id1, id2, "user_id should be deterministic");
+        let id1 = generate_client_id();
+        let id2 = generate_client_id();
+        assert_eq!(id1, id2, "client_id should be deterministic");
     }
 
     #[test]
-    fn test_user_id_hash_computation() {
+    fn test_client_id_hash_computation() {
         // Verify the hash is computed correctly for known input
-        let input = "testhost:testuser";
+        let input = "nori_salt:testhost:testuser";
         let hash = Sha256::digest(input.as_bytes());
-        let expected = format!("sha256:{}", hex::encode(hash));
+        let bytes: [u8; 16] = hash[..16]
+            .try_into()
+            .expect("hash slice should be 16 bytes");
+        let expected = Uuid::from_bytes(bytes).to_string();
 
         // Manually check the hash matches what we'd expect
-        assert!(expected.starts_with("sha256:"));
-        assert_eq!(expected.len(), 7 + 64); // "sha256:" + 64 hex chars
+        assert!(Uuid::parse_str(&expected).is_ok());
     }
 
     fn restore_env(key: &str, value: Option<String>) {

--- a/codex-rs/installed/src/lib.rs
+++ b/codex-rs/installed/src/lib.rs
@@ -22,34 +22,41 @@ mod analytics;
 mod detection;
 mod state;
 
-pub use analytics::InstallEventType;
 pub use analytics::TrackEventRequest;
-pub use analytics::create_install_event;
-pub use analytics::create_session_event;
+pub use analytics::build_properties;
+pub use analytics::create_track_event;
 pub use analytics::send_event;
 pub use detection::detect_install_source;
-pub use detection::generate_user_id;
+pub use detection::generate_client_id;
 pub use state::InstallSource;
 pub use state::InstallState;
 pub use state::read_install_state;
 pub use state::write_install_state;
 
+use chrono::Duration;
 use chrono::Utc;
+use semver::Version;
 use std::path::Path;
 use tracing::debug;
+use uuid::Uuid;
 
 /// The current CLI version from Cargo.toml
 pub const CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const OPT_OUT_ENV: &str = "NORI_NO_ANALYTICS";
+const LEGACY_CLIENT_ID: &str = "nori-cli";
 
 /// Result of tracking a launch
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LaunchEvent {
     /// First time installation
-    FirstInstall,
+    AppInstall,
     /// Version was upgraded
-    Upgrade { previous_version: String },
+    AppUpdate { previous_version: String },
+    /// Resurrected user after inactivity
+    UserResurrected,
     /// Normal session start
-    Session { days_since_install: i64 },
+    SessionStart,
 }
 
 /// Track a CLI launch. Call this early in main().
@@ -58,7 +65,7 @@ pub enum LaunchEvent {
 /// 1. Read or create the install state file
 /// 2. Determine if this is a first install, upgrade, or normal session
 /// 3. Update the state file
-/// 4. Send analytics events (release builds only)
+/// 4. Send analytics events unless opted out
 ///
 /// The function returns immediately and never blocks startup.
 /// All errors are silently logged at debug level.
@@ -72,29 +79,37 @@ pub fn track_launch(nori_home: &Path) {
 }
 
 /// Internal implementation of launch tracking
-async fn track_launch_inner(nori_home: &Path) -> anyhow::Result<LaunchEvent> {
+async fn track_launch_inner(nori_home: &Path) -> anyhow::Result<Vec<LaunchEvent>> {
     let now = Utc::now();
     let current_version = CLI_VERSION;
     let install_source = detect_install_source();
-    let user_id = generate_user_id();
+    let client_id = generate_client_id();
+    let session_id = Uuid::new_v4().to_string();
 
     // Read existing state or treat missing/corrupt file as first install
     let existing_state = read_install_state(nori_home);
+    let resurrected = existing_state
+        .as_ref()
+        .is_some_and(|state| now - state.last_launched_at > Duration::days(30));
 
-    let (event, new_state) = match existing_state {
+    let (mut events, new_state) = match existing_state {
         None => {
             // First install
             debug!("First install detected, creating install state");
             let state = InstallState::new_first_install(
-                user_id,
+                client_id,
                 current_version.to_string(),
                 install_source,
                 now,
             );
-            (LaunchEvent::FirstInstall, state)
+            (vec![LaunchEvent::AppInstall], state)
         }
         Some(mut state) => {
-            if state.installed_version != current_version {
+            if state.client_id.is_empty() || state.client_id == LEGACY_CLIENT_ID {
+                state.client_id = client_id;
+            }
+
+            if is_version_upgrade(current_version, &state.installed_version) {
                 // Version upgrade
                 let previous = state.installed_version.clone();
                 debug!(
@@ -103,51 +118,46 @@ async fn track_launch_inner(nori_home: &Path) -> anyhow::Result<LaunchEvent> {
                 );
                 state.record_upgrade(current_version.to_string(), install_source, now);
                 (
-                    LaunchEvent::Upgrade {
+                    vec![LaunchEvent::AppUpdate {
                         previous_version: previous,
-                    },
+                    }],
                     state,
                 )
             } else {
                 // Normal session
-                let days = state.days_since_install(now);
-                debug!("Normal session, days since install: {days}");
                 state.record_session(now);
-                (
-                    LaunchEvent::Session {
-                        days_since_install: days,
-                    },
-                    state,
-                )
+                (Vec::new(), state)
             }
         }
     };
+
+    if resurrected {
+        events.insert(0, LaunchEvent::UserResurrected);
+    }
+    events.push(LaunchEvent::SessionStart);
 
     // Write updated state
     write_install_state(nori_home, &new_state).await?;
 
     // Send analytics event (no-op in debug builds)
-    let days = new_state.days_since_install(now);
-    let analytics_event = match &event {
-        LaunchEvent::FirstInstall => {
-            create_install_event(&new_state, InstallEventType::FirstInstall, days)
+    if !is_opted_out(&new_state) {
+        let properties = build_properties(current_version);
+        for event in &events {
+            let event_name = match event {
+                LaunchEvent::AppInstall => "app_install",
+                LaunchEvent::AppUpdate { .. } => "app_update",
+                LaunchEvent::UserResurrected => "user_resurrected",
+                LaunchEvent::SessionStart => "session_start",
+            };
+            let analytics_event =
+                create_track_event(&new_state, event_name, &session_id, now, properties.clone());
+            send_event(&analytics_event).await;
         }
-        LaunchEvent::Upgrade { previous_version } => create_install_event(
-            &new_state,
-            InstallEventType::Upgrade {
-                previous_version: previous_version.clone(),
-            },
-            days,
-        ),
-        LaunchEvent::Session { days_since_install } => {
-            create_session_event(&new_state, *days_since_install)
-        }
-    };
-    send_event(&analytics_event).await;
+    }
 
-    debug!("Install tracking complete: {event:?}");
+    debug!("Install tracking complete: {events:?}");
 
-    Ok(event)
+    Ok(events)
 }
 
 /// Synchronous version of launch tracking for testing
@@ -159,12 +169,27 @@ pub fn track_launch_sync(nori_home: &Path) -> anyhow::Result<LaunchEvent> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
-    rt.block_on(track_launch_inner(nori_home))
+    let events = rt.block_on(track_launch_inner(nori_home))?;
+    Ok(events.last().cloned().unwrap_or(LaunchEvent::SessionStart))
+}
+
+fn is_version_upgrade(current_version: &str, installed_version: &str) -> bool {
+    let parsed_current = Version::parse(current_version);
+    let parsed_installed = Version::parse(installed_version);
+    match (parsed_current, parsed_installed) {
+        (Ok(current), Ok(installed)) => current > installed,
+        _ => current_version != installed_version,
+    }
+}
+
+fn is_opted_out(state: &InstallState) -> bool {
+    std::env::var(OPT_OUT_ENV).as_deref() == Ok("1") || state.opt_out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use std::fs;
     use tempfile::TempDir;
 
@@ -172,18 +197,30 @@ mod tests {
         tempfile::tempdir().expect("failed to create temp dir")
     }
 
+    fn track_events(nori_home: &Path) -> Vec<LaunchEvent> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        rt.block_on(track_launch_inner(nori_home))
+            .expect("tracking failed")
+    }
+
     #[test]
     fn test_first_install() {
         let temp_home = setup_temp_home();
 
-        let event = track_launch_sync(temp_home.path()).expect("tracking failed");
+        let events = track_events(temp_home.path());
 
-        assert_eq!(event, LaunchEvent::FirstInstall);
+        assert_eq!(
+            events,
+            vec![LaunchEvent::AppInstall, LaunchEvent::SessionStart]
+        );
 
         // Verify state file was created
         let state = read_install_state(temp_home.path()).expect("state should exist");
         assert_eq!(state.installed_version, CLI_VERSION);
-        assert_eq!(state.client_id, "nori-cli");
+        assert!(!state.client_id.is_empty());
     }
 
     #[test]
@@ -191,18 +228,15 @@ mod tests {
         let temp_home = setup_temp_home();
 
         // First launch
-        let event1 = track_launch_sync(temp_home.path()).expect("first tracking failed");
-        assert_eq!(event1, LaunchEvent::FirstInstall);
+        let event1 = track_events(temp_home.path());
+        assert_eq!(
+            event1,
+            vec![LaunchEvent::AppInstall, LaunchEvent::SessionStart]
+        );
 
         // Second launch - should be a normal session
-        let event2 = track_launch_sync(temp_home.path()).expect("second tracking failed");
-
-        match event2 {
-            LaunchEvent::Session { days_since_install } => {
-                assert_eq!(days_since_install, 0); // Same day
-            }
-            _ => panic!("Expected Session event, got {event2:?}"),
-        }
+        let event2 = track_events(temp_home.path());
+        assert_eq!(event2, vec![LaunchEvent::SessionStart]);
     }
 
     #[test]
@@ -212,8 +246,8 @@ mod tests {
         // Create a state file with an older version
         let now = Utc::now();
         let old_state = InstallState::new_first_install(
-            generate_user_id(),
-            "0.0.1".to_string(), // Old version
+            generate_client_id(),
+            "0.0.0-alpha.0".to_string(), // Old version
             InstallSource::Npm,
             now,
         );
@@ -224,14 +258,16 @@ mod tests {
         fs::write(&state_path, format!("{json}\n")).expect("write failed");
 
         // Track launch with current version
-        let event = track_launch_sync(temp_home.path()).expect("tracking failed");
-
-        match event {
-            LaunchEvent::Upgrade { previous_version } => {
-                assert_eq!(previous_version, "0.0.1");
-            }
-            _ => panic!("Expected Upgrade event, got {event:?}"),
-        }
+        let events = track_events(temp_home.path());
+        assert_eq!(
+            events,
+            vec![
+                LaunchEvent::AppUpdate {
+                    previous_version: "0.0.0-alpha.0".to_string()
+                },
+                LaunchEvent::SessionStart
+            ]
+        );
 
         // Verify state was updated
         let state = read_install_state(temp_home.path()).expect("state should exist");
@@ -247,8 +283,11 @@ mod tests {
         fs::write(&state_path, "not valid json {{{").expect("write failed");
 
         // Should treat as first install
-        let event = track_launch_sync(temp_home.path()).expect("tracking failed");
-        assert_eq!(event, LaunchEvent::FirstInstall);
+        let events = track_events(temp_home.path());
+        assert_eq!(
+            events,
+            vec![LaunchEvent::AppInstall, LaunchEvent::SessionStart]
+        );
 
         // Verify state was recreated
         let state = read_install_state(temp_home.path()).expect("state should exist");
@@ -256,7 +295,7 @@ mod tests {
     }
 
     #[test]
-    fn test_user_id_persisted() {
+    fn test_client_id_persisted() {
         let temp_home = setup_temp_home();
 
         // First launch
@@ -267,8 +306,8 @@ mod tests {
         track_launch_sync(temp_home.path()).expect("second tracking failed");
         let state2 = read_install_state(temp_home.path()).expect("state should exist");
 
-        // User ID should remain the same
-        assert_eq!(state1.user_id, state2.user_id);
+        // Client ID should remain the same
+        assert_eq!(state1.client_id, state2.client_id);
     }
 
     #[test]
@@ -308,6 +347,31 @@ mod tests {
     }
 
     #[test]
+    fn test_user_resurrected_event() {
+        let temp_home = setup_temp_home();
+
+        let now = Utc::now();
+        let mut state = InstallState::new_first_install(
+            generate_client_id(),
+            CLI_VERSION.to_string(),
+            InstallSource::Unknown,
+            now - Duration::days(31),
+        );
+        state.last_launched_at = now - Duration::days(31);
+        state.last_updated_at = now - Duration::days(31);
+
+        let state_path = temp_home.path().join(".nori-install.json");
+        let json = serde_json::to_string_pretty(&state).expect("serialize failed");
+        fs::write(&state_path, format!("{json}\n")).expect("write failed");
+
+        let events = track_events(temp_home.path());
+        assert_eq!(
+            events,
+            vec![LaunchEvent::UserResurrected, LaunchEvent::SessionStart]
+        );
+    }
+
+    #[test]
     fn test_creates_directory_if_missing() {
         let temp_home = setup_temp_home();
         let nested_home = temp_home.path().join("nested").join("dir");
@@ -316,8 +380,11 @@ mod tests {
         assert!(!nested_home.exists());
 
         // Track launch should create it
-        let event = track_launch_sync(&nested_home).expect("tracking failed");
-        assert_eq!(event, LaunchEvent::FirstInstall);
+        let events = track_events(&nested_home);
+        assert_eq!(
+            events,
+            vec![LaunchEvent::AppInstall, LaunchEvent::SessionStart]
+        );
 
         // Verify directory and file were created
         assert!(nested_home.exists());

--- a/codex-rs/installed/src/state.rs
+++ b/codex-rs/installed/src/state.rs
@@ -15,9 +15,6 @@ pub const INSTALL_STATE_FILENAME: &str = ".nori-install.json";
 /// Current schema version
 pub const SCHEMA_VERSION: u32 = 1;
 
-/// Client ID for nori-cli
-pub const CLIENT_ID: &str = "nori-cli";
-
 /// Install source detection
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -39,11 +36,13 @@ pub struct InstallState {
     /// Schema version for forward compatibility
     pub schema_version: u32,
 
-    /// Client identifier (always "nori-cli")
+    /// Client identifier (UUID string)
+    #[serde(default)]
     pub client_id: String,
 
-    /// Privacy-protecting user identifier: sha256(hostname:username)
-    pub user_id: String,
+    /// Whether the user has opted out of analytics
+    #[serde(default)]
+    pub opt_out: bool,
 
     /// Timestamp of first launch (immutable after creation)
     pub first_installed_at: DateTime<Utc>,
@@ -64,15 +63,15 @@ pub struct InstallState {
 impl InstallState {
     /// Create a new install state for first-time installation
     pub fn new_first_install(
-        user_id: String,
+        client_id: String,
         version: String,
         source: InstallSource,
         now: DateTime<Utc>,
     ) -> Self {
         Self {
             schema_version: SCHEMA_VERSION,
-            client_id: CLIENT_ID.to_string(),
-            user_id,
+            client_id,
+            opt_out: false,
             first_installed_at: now,
             last_updated_at: now,
             last_launched_at: now,
@@ -151,7 +150,7 @@ mod tests {
     fn test_install_state_serialization() {
         let now = Utc.with_ymd_and_hms(2025, 1, 15, 10, 30, 0).unwrap();
         let state = InstallState::new_first_install(
-            "sha256:abc123".to_string(),
+            "7b9f7433-2b41-4d2f-94cc-2b27fe58b035".to_string(),
             "1.0.0".to_string(),
             InstallSource::Bun,
             now,
@@ -159,8 +158,8 @@ mod tests {
 
         let json = serde_json::to_string(&state).expect("serialization failed");
         assert!(json.contains("\"schema_version\":1"));
-        assert!(json.contains("\"client_id\":\"nori-cli\""));
-        assert!(json.contains("\"user_id\":\"sha256:abc123\""));
+        assert!(json.contains("\"client_id\":\"7b9f7433-2b41-4d2f-94cc-2b27fe58b035\""));
+        assert!(json.contains("\"opt_out\":false"));
         assert!(json.contains("\"installed_version\":\"1.0.0\""));
         assert!(json.contains("\"install_source\":\"bun\""));
     }
@@ -169,8 +168,8 @@ mod tests {
     fn test_install_state_deserialization() {
         let json = r#"{
             "schema_version": 1,
-            "client_id": "nori-cli",
-            "user_id": "sha256:def456",
+            "client_id": "0cd0a97c-e6f0-4f21-9ad5-1def94fa6994",
+            "opt_out": true,
             "first_installed_at": "2025-01-15T10:30:00Z",
             "last_updated_at": "2025-01-20T14:22:00Z",
             "last_launched_at": "2025-01-21T09:00:00Z",
@@ -180,8 +179,8 @@ mod tests {
 
         let state: InstallState = serde_json::from_str(json).expect("deserialization failed");
         assert_eq!(state.schema_version, 1);
-        assert_eq!(state.client_id, "nori-cli");
-        assert_eq!(state.user_id, "sha256:def456");
+        assert_eq!(state.client_id, "0cd0a97c-e6f0-4f21-9ad5-1def94fa6994");
+        assert!(state.opt_out);
         assert_eq!(state.installed_version, "1.2.3");
         assert_eq!(state.install_source, InstallSource::Npm);
     }
@@ -208,7 +207,7 @@ mod tests {
         let upgrade_time = Utc.with_ymd_and_hms(2025, 1, 15, 12, 0, 0).unwrap();
 
         let mut state = InstallState::new_first_install(
-            "sha256:test".to_string(),
+            "4cc4809a-6f7f-4e2d-98c4-c1030dc4097e".to_string(),
             "1.0.0".to_string(),
             InstallSource::Npm,
             initial,
@@ -230,7 +229,7 @@ mod tests {
         let session_time = Utc.with_ymd_and_hms(2025, 1, 10, 8, 0, 0).unwrap();
 
         let mut state = InstallState::new_first_install(
-            "sha256:test".to_string(),
+            "4cc4809a-6f7f-4e2d-98c4-c1030dc4097e".to_string(),
             "1.0.0".to_string(),
             InstallSource::Unknown,
             initial,
@@ -251,7 +250,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2025, 1, 6, 0, 0, 0).unwrap();
 
         let state = InstallState::new_first_install(
-            "sha256:test".to_string(),
+            "4cc4809a-6f7f-4e2d-98c4-c1030dc4097e".to_string(),
             "1.0.0".to_string(),
             InstallSource::Bun,
             install_time,
@@ -276,7 +275,7 @@ mod tests {
         let now = Utc::now();
 
         let state = InstallState::new_first_install(
-            "sha256:testuser".to_string(),
+            "4cc4809a-6f7f-4e2d-98c4-c1030dc4097e".to_string(),
             "1.0.0".to_string(),
             InstallSource::Npm,
             now,
@@ -292,7 +291,7 @@ mod tests {
 
         assert_eq!(loaded.schema_version, state.schema_version);
         assert_eq!(loaded.client_id, state.client_id);
-        assert_eq!(loaded.user_id, state.user_id);
+        assert_eq!(loaded.opt_out, state.opt_out);
         assert_eq!(loaded.installed_version, state.installed_version);
         assert_eq!(loaded.install_source, state.install_source);
     }


### PR DESCRIPTION
### Motivation
- Standardize install/session lifecycle tracking and analytics payloads so Nori CLI reports (install, update, churn/resurrection) match the shared analytics endpoint and GA dashboards.
- Make client identity deterministic and privacy-preserving so churn/resurrection measurements remain consistent after config resets while preserving opt-out control.
- Ensure events are non-blocking and follow a unified flat JSON schema with session-scoped fields for downstream aggregation and performance constraints.

### Description
- Replace the previous user-id approach with a deterministic client UUID generated from `SHA256("nori_salt:<hostname>:<username>")` and persist it as `client_id` in the state file, and add an `opt_out` boolean to the state schema saved at `$NORI_HOME/.nori-install.json`.
- Expand lifecycle events to emit `app_install`, `app_update`, `user_resurrected` (if last launch > 30 days), and `session_start`, generate an ephemeral `session_id` per run, and use semver comparison (via `semver` crate) to detect upgrades.
- Rework analytics payloads to a flat JSON event with `event`, `client_id`, `session_id`, `timestamp`, and `properties` (version/os/arch/node_version/is_ci), send to `NORI_ANALYTICS_URL` (default `https://noriskillsets.dev/api/analytics/track`) with a 500ms timeout, fire-and-forget behavior, and silent failure handling.
- Honor opt-out precedence: `NORI_NO_ANALYTICS=1` wins, otherwise the `opt_out` field in `.nori-install.json` prevents network sends while still updating local state timestamps atomically (temp file + rename preserved).
- Updated code, docs, and dependencies: added `semver` and `uuid`, updated `installed` crate implementation, tests, and `docs.md` to reflect the new schema and event types.

### Testing
- Ran formatting with `just fmt` and lint fixes with `just fix -p nori-installed` (ran automatically as part of the change process).
- Ran unit tests with `cargo test -p nori-installed`, and all tests passed (`28 passed; 0 failed`).
- Verified the updated behavior via the crate's unit tests for deterministic client id, upgrade detection, resurrection detection, state read/write, and analytics payload serialization (all test cases succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fbe2c4c6c8326be8180f0b83fa234)