### PR TITLE
fix(cd): consolidate dist-tag update into publish step with OIDC auth

### DIFF
--- a/.github/workflows/nori-release.yml
+++ b/.github/workflows/nori-release.yml
@@ -648,15 +648,12 @@ jobs:
           echo "npm install -g ${{ env.NPM_PACKAGE_NAME }}@$VERSION" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Update @next tag to point to latest
-        if: ${{ needs.validate.outputs.is_prerelease != 'true' }}
-        continue-on-error: true
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          npm dist-tag add "${{ env.NPM_PACKAGE_NAME }}@${{ needs.validate.outputs.version }}" next
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "Also updated \`@next\` tag to point to \`${{ needs.validate.outputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          # For stable releases, also update @next to point to this version
+          if [[ "$IS_PRERELEASE" != "true" ]]; then
+            npm dist-tag add "${{ env.NPM_PACKAGE_NAME }}@$VERSION" next || echo "Warning: Failed to update @next tag"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Also updated \`@next\` tag to point to \`$VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   # ============================================================================
   # CREATE GITHUB RELEASE (only for tag push)


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Move the @next dist-tag update from a separate step into the npm publish step
- Uses OIDC Trusted Publishing instead of requiring NPM_TOKEN secret
- Matches the pattern used in skillsets-release.yml which is confirmed working

## Test Plan
- [ ] Workflow YAML syntax is valid (verified locally)
- [ ] Wait for CI to pass
- [ ] Test with a dry run: `gh workflow run nori-release.yml -f version=0.2.0-test.1 -f dry_run=true`
- [ ] Test with actual publish_next release

Share Nori with your team: https://www.npmjs.com/package/nori-ai