### PR TITLE
feat: add Bring Your Own Agent section to README

### DIFF
--- a/.claude/skills/registering-custom-acp-agent/SKILL.md
+++ b/.claude/skills/registering-custom-acp-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Registering Custom ACP Agents
-description: Use when the user wants to register a custom ACP agent in Nori, or try one of the example agents (elizacp, kimi-cli, opencode)
+description: Use when the user wants to register a custom ACP agent in Nori, or try one of the example agents (elizacp, kimi-cli, vibe-acp)
 ---
 
 <required>
@@ -8,7 +8,7 @@ description: Use when the user wants to register a custom ACP agent in Nori, or 
 
 1. Ask the user: custom agent setup or example demo?
 2. If custom agent: gather agent details and write config
-3. If example: let user choose (elizacp, kimi-cli, opencode) and walk through setup
+3. If example: let user choose (elizacp, kimi-cli, vibe-acp) and walk through setup
 4. Write the `[[agents]]` entry to `~/.nori/cli/config.toml`
 5. Verify the agent appears in Nori's agent picker
 </required>
@@ -51,7 +51,7 @@ args = ["acp"]
 
 ## elizacp (Rust/Cargo)
 
-Minimal Eliza chatbot. Install: `cargo install --git https://github.com/agentclientprotocol/symposium-acp elizacp`
+Minimal Eliza chatbot. Install: `cargo install --locked elizacp`
 
 No `cargo` distribution variant exists -- use `local` since cargo puts binaries in PATH.
 
@@ -80,18 +80,17 @@ package = "kimi-cli"
 args = ["acp"]
 ```
 
-## opencode
+## vibe-acp (Mistral Vibe)
 
-Install: `curl -fsSL https://opencode.ai/install | bash` (or `npm install -g opencode-ai` / `brew install anomalyco/tap/opencode`)
+Mistral's coding agent. Install: `curl -LsSf https://mistral.ai/vibe/install.sh | bash` (or `uv tool install mistral-vibe` / `pip install mistral-vibe`). Installs both `vibe` (interactive CLI) and `vibe-acp` (ACP server). First-time setup: run `vibe --setup` to configure your Mistral API key.
 
 ```toml
 [[agents]]
-name = "OpenCode"
-slug = "opencode"
+name = "Mistral Vibe"
+slug = "vibe-acp"
 
 [agents.distribution.local]
-command = "opencode"
-args = ["acp"]
+command = "vibe-acp"
 ```
 
 # Step 3: Write the Config

--- a/README.md
+++ b/README.md
@@ -38,6 +38,41 @@ You should be good to go. If not, first follow the authentication for your desir
 | Gemini   | Run `npx @google/gemini-cli` in your terminal, then when the Gemini CLI opens, type `/auth` there.                                                      |
 | OpenAI   | In Nori, use `/agent` to switch to Codex, then run `/login` inside the Nori interface. Nori will prompt you to install OpenAI via npm if needed.        |
 
+## Bring Your Own Agent
+
+Have your own ACP agent? Add it to Nori CLI! Any agent that speaks [Agent Client Protocol](https://github.com/agentclientprotocol/agent-client-protocol) over stdin/stdout can be registered in `~/.nori/cli/config.toml` and used alongside the built-in providers.
+
+Add one or more `[[agents]]` entries to your config:
+
+```toml
+[[agents]]
+name = "Mistral Vibe"
+slug = "vibe-acp"
+
+[agents.distribution.local]
+command = "vibe-acp"
+
+[[agents]]
+name = "ElizACP"
+slug = "elizacp"
+
+[agents.distribution.local]
+command = "elizacp"
+args = ["acp"]
+```
+
+Then switch to your agent with `/agent` inside Nori.
+
+**Example agents to try:**
+
+| Agent | Install | Notes |
+|-------|---------|-------|
+| [Mistral Vibe](https://docs.mistral.ai/mistral-vibe/introduction/install) | `curl -LsSf https://mistral.ai/vibe/install.sh \| bash` | Installs both `vibe` and `vibe-acp`. Run `vibe --setup` to configure your API key. |
+| [ElizACP](https://github.com/agentclientprotocol/symposium-acp) | `cargo install --locked elizacp` | Minimal Eliza chatbot, useful for testing. |
+| [Kimi](https://github.com/nicepkg/kimi-cli) | No install needed — uses `uvx` | First-time auth: run `uvx --python 3.13 kimi-cli`, then `/login`. |
+
+Want your AI agent to configure this automatically? Point it at the raw skill file: https://github.com/tilework-tech/nori-cli/blob/main/.claude/skills/registering-custom-acp-agent/SKILL.md
+
 ## Features
 
 - **Multi-provider**: Anthropic's Claude Code, Google DeepMind's Gemini, and OpenAI's Codex


### PR DESCRIPTION
## Summary
- Adds a **Bring Your Own Agent** section to README between Providers and Features
- Includes `config.toml` snippet with `vibe-acp` and `elizacp` examples
- Install table for three example agents: Mistral Vibe, ElizACP, Kimi
- Links to the raw skill file so users' AI agents can self-configure
- Updates the custom ACP agent skill: replaces opencode with vibe-acp, simplifies elizacp install command

## Test plan
- [ ] Verify README renders correctly on GitHub (table, code blocks, links)
- [ ] Verify skill file raw link resolves: `.claude/skills/registering-custom-acp-agent/SKILL.md`
- [ ] Spot-check that the TOML examples match the config schema in `codex-rs/acp/src/config/types/mod.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)