### PR TITLE
fix(tui): move ACP session usage into footer context

### DIFF
--- a/codex-rs/acp/docs.md
+++ b/codex-rs/acp/docs.md
@@ -89,7 +89,7 @@ The live backend path in `user_input.rs`, `submit_and_ops.rs`, `spawn_and_relay.
 
 Metadata notifications that ACP permits while idle are treated as session-owned rather than request-owned. `AvailableCommandsUpdate`, `CurrentModeUpdate`, `ConfigOptionUpdate`, `SessionInfoUpdate`, and `UsageUpdate` no longer produce "no request is active" warnings; instead the reducer persists the latest values and forwards normalized `ClientEvent`s downstream.
 
-`session/load` replay also preserves more session context than before. User-side `MessageDelta { stream: User, .. }` values are reassembled into `ReplayEntry::UserMessage`, while `SessionUpdateInfo` notes pass through unchanged so restored transcripts can show lightweight session metadata alongside the loaded conversation.
+`session/load` replay also preserves more session context than before. User-side `MessageDelta { stream: User, .. }` values are reassembled into `ReplayEntry::UserMessage`, while `SessionUpdateInfo` notes pass through unchanged. For usage updates, that replay path now restores the structured footer context state without needing to re-render the verbose message in history.
 
 **Custom Agent TOML Schema** (`config/types/mod.rs`):
 
@@ -494,9 +494,9 @@ Codex `token_count` events contain two token usage objects with different semant
 | Object | Meaning | Used For |
 |--------|---------|----------|
 | `total_token_usage` | Cumulative billing counter across ALL API calls in the session; grows unboundedly | `input_tokens`, `output_tokens`, `cached_tokens` fields (the "Tokens" footer segment) |
-| `last_token_usage` | Tokens from the most recent API call only; represents actual context window fill | `last_context_tokens` field (the "Context: XK (Y%)" footer segment) |
+| `last_token_usage` | Tokens from the most recent API call only; represents actual context window fill | `last_context_tokens` field used by transcript-discovery fallback for the "Context Y% (XK)" footer segment |
 
-Using `total_token_usage.input_tokens` for context window percentage would produce nonsensical results (e.g., 995K tokens for a 258K context window) because the cumulative counter sums across all turns. The `last_token_usage.input_tokens` correctly reflects how full the context window is for the current turn. When `last_token_usage` is absent (older transcript formats), `last_context_tokens` is `None` and the context percentage is not displayed.
+Using `total_token_usage.input_tokens` for context window percentage would produce nonsensical results (e.g., 995K tokens for a 258K context window) because the cumulative counter sums across all turns. The `last_token_usage.input_tokens` correctly reflects how full the context window is for the current turn. When ACP `UsageUpdate` events are present, the TUI prefers those live session values for the footer; transcript parsing remains a fallback for older agents/sessions where `UsageUpdate` is absent. When `last_token_usage` is absent (older transcript formats), `last_context_tokens` is `None` and the transcript fallback does not display a context percentage.
 
 **Claude Code Streaming Deduplication:**
 

--- a/codex-rs/acp/src/backend/transcript.rs
+++ b/codex-rs/acp/src/backend/transcript.rs
@@ -357,6 +357,7 @@ mod tests {
                 kind: nori_protocol::SessionUpdateKind::SessionInfo,
                 message: "Session info updated: title=\"Resume chat\"".into(),
                 hint: None,
+                usage: None,
             }),
             nori_protocol::ClientEvent::MessageDelta(nori_protocol::MessageDelta {
                 stream: nori_protocol::MessageStream::Answer,
@@ -374,6 +375,7 @@ mod tests {
                     kind: nori_protocol::SessionUpdateKind::SessionInfo,
                     message: "Session info updated: title=\"Resume chat\"".into(),
                     hint: None,
+                    usage: None,
                 }),
                 nori_protocol::ClientEvent::ReplayEntry(
                     nori_protocol::ReplayEntry::AssistantMessage {
@@ -392,6 +394,11 @@ mod tests {
                     kind: nori_protocol::SessionUpdateKind::Usage,
                     message: "Session usage: 128 / 4096 tokens".into(),
                     hint: None,
+                    usage: Some(nori_protocol::session_runtime::SessionUsageState {
+                        used_tokens: 128,
+                        total_tokens: 4096,
+                        cost_display: None,
+                    }),
                 },
             ),
         })]);
@@ -405,6 +412,11 @@ mod tests {
                     kind: nori_protocol::SessionUpdateKind::Usage,
                     message: "Session usage: 128 / 4096 tokens".into(),
                     hint: None,
+                    usage: Some(nori_protocol::session_runtime::SessionUsageState {
+                        used_tokens: 128,
+                        total_tokens: 4096,
+                        cost_display: None,
+                    }),
                 },
             )]
         );

--- a/codex-rs/nori-protocol/docs.md
+++ b/codex-rs/nori-protocol/docs.md
@@ -6,7 +6,7 @@ Path: @/codex-rs/nori-protocol
 
 - Defines the normalized `ClientEvent` protocol that sits between raw ACP session updates (from `agent-client-protocol-schema`) and the TUI rendering layer. All ACP tool calls, messages, plans, approvals, and replay entries are transformed into this crate's types before reaching the TUI.
 - The `ClientEventNormalizer` is the stateful entry point: it accepts `acp::SessionUpdate` and `acp::RequestPermissionRequest` values and emits `Vec<ClientEvent>`.
-- Session-scoped ACP metadata that does not deserve bespoke widgets yet is normalized into `ClientEvent::SessionUpdateInfo`, giving the rest of the stack one minimal rendering/replay path for mode, config, session-info, and usage updates.
+- Session-scoped ACP metadata is normalized into `ClientEvent::SessionUpdateInfo`, giving the rest of the stack one minimal rendering/replay path for mode, config, and session-info updates while still letting usage updates carry structured footer state.
 - Single-file crate (`lib.rs`) with no submodules.
 
 ### How it fits into the larger codebase
@@ -29,7 +29,8 @@ agent_client_protocol_schema::SessionUpdate
 - **`SessionRuntime` support types** in `session_runtime.rs` define the reducer-owned ACP runtime model used by `codex-acp`: `SessionPhase`, `PersistedSessionState`, `ActiveRequestState`, `OpenMessage`, and `QueuedPrompt`. These types let the backend treat prompt turns, `session/load`, queued prompts, and ownership of tool/approval updates as one ordered state machine instead of reconstructing turn state from racing tasks.
 - **Session update normalization** keeps the first pass intentionally small:
   - `UserMessageChunk` becomes `MessageDelta { stream: User, .. }`, which lets replay paths reconstruct visible user history during `session/load`.
-  - `CurrentModeUpdate`, `ConfigOptionUpdate`, `SessionInfoUpdate`, and `UsageUpdate` become `SessionUpdateInfo`, a display-oriented summary with a stable `kind`.
+  - `CurrentModeUpdate`, `ConfigOptionUpdate`, and `SessionInfoUpdate` become lightweight `SessionUpdateInfo` summaries.
+  - `UsageUpdate` also becomes `SessionUpdateInfo`, but the usage variant additionally carries `SessionUsageState` so the TUI can update footer context without reparsing the display string.
 - **Persisted session metadata** now includes `session_info` and `session_usage` alongside available commands, current mode, and config options. `codex-acp` owns persistence, but these structs live here so the reducer and replay pipeline share one runtime model.
 - **`is_generic_tool_call()`** gates initial `ToolCall` emission: tool calls with no `raw_input`, no `locations`, empty `content`, and no `/` in the title are suppressed (return empty `Vec`). The normalizer still records them internally so that later attributed `ToolCallUpdate` messages can refine the existing call without forcing the TUI to render a placeholder cell first.
 - **Invocation priority cascade** in `invocation_from_tool_call()` resolves what the tool is doing, in priority order:
@@ -48,7 +49,7 @@ agent_client_protocol_schema::SessionUpdate
 ### Things to Know
 
 - The `is_generic_tool_call()` filter means the normalizer is not 1:1 with incoming events. Initial `ToolCall` messages that are sufficiently sparse are silently dropped, but later `ToolCallUpdate` messages still become visible `ToolSnapshot`s even if no initial `ToolCall` ever arrived.
-- `SessionUpdateInfo` is intentionally lossy. It exists to stop valid ACP session updates from disappearing while the UI remains lightweight; richer dedicated widgets can still be layered on later without changing ACP reducer semantics.
+- `SessionUpdateInfo` stays intentionally lightweight, but it is no longer fully lossy: the `Usage` variant also carries structured `SessionUsageState` so replay and live footer updates can share the same path.
 - The location fallback (tier 4) only handles `Read` and `Search` kinds. Edit/Delete/Move with locations but no `raw_input` return `None` from the normalizer and fall through to the TUI's location-path display fallback, avoiding creation of empty-diff `FileOperations` that would route to `PatchHistoryCell`.
 - `sanitize_title()` is a two-pass operation: first strips the `[current working directory ...]` bracket, then strips trailing `(description)` parenthetical. The parenthetical strip only fires after a cwd bracket was found, because Gemini appends descriptions after the cwd metadata.
 - Shell wrapper detection (`is_shell_wrapper()`) recognizes `bash`, `sh`, `zsh`, `fish`, `pwsh`, and `powershell` with `-c` or `-lc` flags. When a 3-element command array matches this pattern, only the script portion is extracted as the command string.

--- a/codex-rs/nori-protocol/src/lib.rs
+++ b/codex-rs/nori-protocol/src/lib.rs
@@ -76,6 +76,8 @@ pub struct SessionUpdateInfo {
     pub kind: SessionUpdateKind,
     pub message: String,
     pub hint: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<session_runtime::SessionUsageState>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -959,6 +961,7 @@ fn session_update_info_from_current_mode(update: &acp::CurrentModeUpdate) -> Ses
         kind: SessionUpdateKind::CurrentMode,
         message: format!("ACP mode changed to {}", update.current_mode_id),
         hint: None,
+        usage: None,
     }
 }
 
@@ -978,6 +981,7 @@ fn session_update_info_from_config_options(update: &acp::ConfigOptionUpdate) -> 
         kind: SessionUpdateKind::ConfigOptions,
         message,
         hint: None,
+        usage: None,
     }
 }
 
@@ -1001,6 +1005,7 @@ fn session_update_info_from_session_info(update: &acp::SessionInfoUpdate) -> Ses
         kind: SessionUpdateKind::SessionInfo,
         message,
         hint: None,
+        usage: None,
     }
 }
 
@@ -1028,6 +1033,14 @@ fn session_update_info_from_usage(update: &acp::UsageUpdate) -> SessionUpdateInf
         kind: SessionUpdateKind::Usage,
         message,
         hint: None,
+        usage: Some(session_runtime::SessionUsageState {
+            used_tokens: update.used as i64,
+            total_tokens: update.size as i64,
+            cost_display: update
+                .cost
+                .as_ref()
+                .map(|cost| format!("{:.2} {}", cost.amount, cost.currency)),
+        }),
     }
 }
 
@@ -2168,6 +2181,14 @@ mod tests {
         };
 
         assert_eq!(info.kind, SessionUpdateKind::Usage);
+        assert_eq!(
+            info.usage,
+            Some(session_runtime::SessionUsageState {
+                used_tokens: 128,
+                total_tokens: 4096,
+                cost_display: Some("0.42 USD".to_string()),
+            })
+        );
         assert_eq!(
             info.message,
             "Session usage: 128 / 4096 tokens, cost 0.42 USD"

--- a/codex-rs/nori-protocol/src/session_runtime.rs
+++ b/codex-rs/nori-protocol/src/session_runtime.rs
@@ -9,6 +9,8 @@ use std::collections::HashSet;
 use std::collections::VecDeque;
 
 use agent_client_protocol_schema as acp;
+use serde::Deserialize;
+use serde::Serialize;
 
 use crate::AgentCommandInfo;
 use crate::PlanSnapshot;
@@ -163,7 +165,7 @@ pub struct SessionInfoState {
     pub updated_at: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionUsageState {
     pub used_tokens: i64,
     pub total_tokens: i64,

--- a/codex-rs/tui/docs.md
+++ b/codex-rs/tui/docs.md
@@ -47,7 +47,7 @@ The main event loop in `app/mod.rs` processes:
 2. **Backend events** from ACP: `BackendEvent::Client` carries normalized `nori_protocol::ClientEvent` session data, while `BackendEvent::Control` carries shared control-plane events
 3. **App events** for state changes (agent selection, config updates)
 
-The client-event stream now also includes lightweight ACP session metadata summaries. Rather than adding dedicated UI chrome for every ACP session update, the first-pass TUI behavior renders `ClientEvent::SessionUpdateInfo` as ordinary info/history cells and includes the same text in the view-only transcript.
+The client-event stream now also includes lightweight ACP session metadata summaries. Most `ClientEvent::SessionUpdateInfo` values still render as ordinary info/history cells, but usage updates are handled specially: they update the footer context segment and are omitted from both live history cells and the view-only transcript.
 
 The chat interface is managed by the `chatwidget/` module (`chatwidget/mod.rs` + submodules), which handles:
 - User input composition with multi-line editing
@@ -415,7 +415,7 @@ The card always shows: version, directory, agent, skillset (Nori profile). Optio
 |---------|-----------|---------|
 | Task summary | `prompt_summary` present | "Task: Fix auth bug" |
 | Approval mode | `approval_mode_label` present | "approvals: Agent" |
-| Context line | `context_window_percent` present, with or without token data | "Context: 77.0K (27%)" or just "42%" |
+| Context line | `context_window_percent` present, with or without token data | "Context 27% (77.0K)" or just "Context 42%" |
 | Token totals | `token_breakdown` has non-zero total | "Tokens: 123K total (32.0K cached)" |
 
 The Tokens section renders if either `token_breakdown` has a non-zero total OR `context_window_percent` is present. This means context window percentage from the live API (`TokenUsageInfo`) can appear even before transcript token data is available.
@@ -598,7 +598,7 @@ The footer displays configurable segments, each of which can be enabled/disabled
 | Git Branch | `git_branch` | Current branch name with ⎇ symbol (yellow for main repo, orange for worktree) |
 | Worktree Name | `worktree_name` | "Worktree: {name}" (light red) when running in an auto-worktree session -- the immutable directory name, distinct from the git branch which gets renamed after the first prompt |
 | Git Stats | `git_stats` | Lines added/removed in current session |
-| Context Window | `context` | "Context: 34K (27%)" when running within an agent environment |
+| Context Window | `context` | "Context 27% (34K)" when running within an agent environment |
 | Approval Mode | `approval_mode` | "Approvals: Agent/Full Access/Read Only" |
 | Nori Profile | `nori_profile` | "Skillset: name" for one active skillset, "Skillsets: a, b" for multiple, hidden when none are active. Uses `active_skillsets` from `SystemInfo` (populated by `nori-skillsets list-active`). |
 | Nori Version | `nori_version` | "Skillsets v<version>" |
@@ -614,6 +614,7 @@ git_stats = false
 All segments are enabled by default. The order of segments in the footer is fixed (cannot be reordered via config).
 
 Token data flows from `TranscriptLocation.token_breakdown` (provided by `codex_acp::discover_transcript_for_agent_with_message()`) through `FooterProps` to the footer renderer. The breakdown includes separate input, output, and cached token counts for accurate usage reporting.
+Footer context usage is sourced in priority order: ACP `SessionUpdateInfo { kind: Usage, usage: Some(..) }` updates drive the footer when available, while `TranscriptLocation.token_breakdown` remains the provider-specific fallback for older sessions or agents that do not emit ACP usage updates.
 
 The prompt summary flows from the ACP backend as an `EventMsg::PromptSummary` event, handled by `ChatWidget::on_prompt_summary()`, which propagates it down: `ChatWidget` -> `BottomPane::set_prompt_summary()` -> `ChatComposer::set_prompt_summary()` -> `FooterProps.prompt_summary` -> `footer_segments()` renderer.
 

--- a/codex-rs/tui/src/bottom_pane/chat_composer/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer/mod.rs
@@ -120,6 +120,7 @@ pub(crate) struct ChatComposer {
     footer_mode: FooterMode,
     footer_hint_override: Option<Vec<(String, String)>>,
     context_window_percent: Option<i64>,
+    session_usage: Option<nori_protocol::session_runtime::SessionUsageState>,
     system_info: Option<crate::system_info::SystemInfo>,
     /// The approval mode label to display in the footer (e.g., "Read Only", "Agent", "Full Access").
     approval_mode_label: Option<String>,
@@ -179,6 +180,7 @@ impl ChatComposer {
             footer_mode: FooterMode::ShortcutSummary,
             footer_hint_override: None,
             context_window_percent: None,
+            session_usage: None,
             system_info: None,
             approval_mode_label: None,
             vim_enter_behavior: codex_acp::config::VimEnterBehavior::Off,
@@ -367,6 +369,13 @@ impl ChatComposer {
         if self.context_window_percent != percent {
             self.context_window_percent = percent;
         }
+    }
+
+    pub(crate) fn set_session_usage(
+        &mut self,
+        usage: Option<nori_protocol::session_runtime::SessionUsageState>,
+    ) {
+        self.session_usage = usage;
     }
 
     pub(crate) fn set_system_info(&mut self, info: crate::system_info::SystemInfo) {

--- a/codex-rs/tui/src/bottom_pane/chat_composer/rendering.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer/rendering.rs
@@ -79,6 +79,21 @@ impl ChatComposer {
                 })
             })
         });
+        let (context_tokens, context_window_percent) =
+            if let Some(session_usage) = &self.session_usage {
+                (
+                    Some(session_usage.used_tokens).filter(|&tokens| tokens > 0),
+                    (session_usage.total_tokens > 0).then(|| {
+                        session_usage
+                            .used_tokens
+                            .saturating_mul(100)
+                            .saturating_div(session_usage.total_tokens)
+                            .clamp(0, 100)
+                    }),
+                )
+            } else {
+                (context_tokens, context_window_percent)
+            };
 
         FooterProps {
             mode: self.footer_mode(),

--- a/codex-rs/tui/src/bottom_pane/footer.rs
+++ b/codex-rs/tui/src/bottom_pane/footer.rs
@@ -362,18 +362,21 @@ fn footer_segments(props: &FooterProps) -> Vec<Line<'static>> {
         ]));
     }
 
-    // Add context window info if available and enabled: "Context: 34K (27%)" (white/default)
-    if config.is_enabled(FooterSegment::Context)
-        && let Some(tokens) = props.context_tokens
-        && tokens > 0
-    {
-        let formatted_tokens = format_si_suffix(tokens);
-        let context_text = if let Some(pct) = props.context_window_percent {
-            format!("Context: {formatted_tokens} ({pct}%)")
-        } else {
-            format!("Context: {formatted_tokens}")
+    // Add context window info if available and enabled: "Context 27% (34K)".
+    if config.is_enabled(FooterSegment::Context) {
+        let formatted_tokens = props
+            .context_tokens
+            .filter(|&tokens| tokens > 0)
+            .map(format_si_suffix);
+        let context_text = match (props.context_window_percent, formatted_tokens) {
+            (Some(pct), Some(tokens)) => Some(format!("Context {pct}% ({tokens})")),
+            (Some(pct), None) => Some(format!("Context {pct}%")),
+            (None, Some(tokens)) => Some(format!("Context {tokens}")),
+            (None, None) => None,
         };
-        segments.push(Line::from(context_text));
+        if let Some(context_text) = context_text {
+            segments.push(Line::from(context_text));
+        }
     }
 
     // Add approval mode if available and enabled: "Approvals: Agent" (magenta)
@@ -621,6 +624,7 @@ const SHORTCUTS: &[ShortcutDescriptor] = &[
 mod tests {
     use super::*;
     use insta::assert_snapshot;
+    use pretty_assertions::assert_eq;
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
 
@@ -661,6 +665,27 @@ mod tests {
             })
             .unwrap();
         assert_snapshot!(name, terminal.backend());
+    }
+
+    fn render_footer_text(props: FooterProps) -> String {
+        let height = footer_height(&props).max(1);
+        let mut terminal = Terminal::new(TestBackend::new(80, height)).unwrap();
+        terminal
+            .draw(|f| {
+                let area = Rect::new(0, 0, f.area().width, height);
+                render_footer(area, f.buffer_mut(), &props);
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer().clone();
+        (0..height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     #[test]
@@ -928,6 +953,17 @@ mod tests {
                 ..default_props()
             },
         );
+    }
+
+    #[test]
+    fn footer_context_renders_percent_before_tokens() {
+        let rendered = render_footer_text(FooterProps {
+            context_window_percent: Some(16),
+            context_tokens: Some(42_600),
+            ..default_props()
+        });
+
+        assert_eq!(rendered.trim(), "Context 16% (42.6K) · ? for shortcuts");
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -531,6 +531,15 @@ impl BottomPane {
         self.request_redraw();
     }
 
+    /// Update ACP-reported session usage displayed in the footer.
+    pub(crate) fn set_session_usage(
+        &mut self,
+        usage: Option<nori_protocol::session_runtime::SessionUsageState>,
+    ) {
+        self.composer.set_session_usage(usage);
+        self.request_redraw();
+    }
+
     /// Get the prompt summary for status card display.
     pub(crate) fn prompt_summary(&self) -> Option<String> {
         self.composer.prompt_summary()

--- a/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_shortcuts_context_running.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_shortcuts_context_running.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ? for shortcuts                                                               "
+"  Context 72% · ? for shortcuts                                                 "

--- a/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_shortcuts_vertical.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_shortcuts_vertical.snap
@@ -4,6 +4,7 @@ expression: terminal.backend()
 ---
 "  ⎇ feature/test                                                                "
 "  +10 -3                                                                        "
+"  Context 72%                                                                   "
 "  Approvals: Agent                                                              "
 "  Skillset: clifford                                                            "
 "  Skillsets v19.1.1                                                             "

--- a/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_vertical_with_segments_disabled.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_vertical_with_segments_disabled.snap
@@ -3,6 +3,6 @@ source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
 "  ⎇ feature/test                                                                "
-"  Context: 34.0K (27%)                                                          "
+"  Context 27% (34.0K)                                                           "
 "  Approvals: Agent                                                              "
 "  ? for shortcuts                                                               "

--- a/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_approval_mode_agent.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_approval_mode_agent.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ⎇ feature/test · +10 -3 · Approvals: Agent · Skillset: clifford · Skillsets v1"
+"  ⎇ feature/test · +10 -3 · Context 72% · Approvals: Agent · Skillset: clifford "

--- a/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_cached_tokens.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_cached_tokens.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  Context: 34.0K (27%) · Tokens: 155K total (32.0K cached) · ? for shortcuts    "
+"  Context 27% (34.0K) · Tokens: 155K total (32.0K cached) · ? for shortcuts     "

--- a/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_context_no_percent.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_context_no_percent.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  Context: 34.0K · Tokens: 34.0K total · ? for shortcuts                        "
+"  Context 34.0K · Tokens: 34.0K total · ? for shortcuts                         "

--- a/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_full_nori_info.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_full_nori_info.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ⎇ feature/test · +10 -3 · Skillset: clifford · Skillsets v19.1.1 · ? for short"
+"  ⎇ feature/test · +10 -3 · Context 72% · Skillset: clifford · Skillsets v19.1.1"

--- a/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_large_token_usage.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_large_token_usage.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  Context: 1.23M · Tokens: 1.23M total · ? for shortcuts                        "
+"  Context 1.23M · Tokens: 1.23M total · ? for shortcuts                         "

--- a/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_multiple_segments_disabled.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_multiple_segments_disabled.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  Context: 34.0K (27%) · Approvals: Agent · ? for shortcuts                     "
+"  Context 27% (34.0K) · Approvals: Agent · ? for shortcuts                      "

--- a/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_no_nori.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_no_nori.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ? for shortcuts                                                               "
+"  Context 85% · ? for shortcuts                                                 "

--- a/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_only_git.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_only_git.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ⎇ main · +5 -2 · ? for shortcuts                                              "
+"  ⎇ main · +5 -2 · Context 100% · ? for shortcuts                               "

--- a/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_token_usage.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_token_usage.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ⎇ feature/test · +10 -3 · Context: 123K (72%) · Skillset: clifford · Skillsets"
+"  ⎇ feature/test · +10 -3 · Context 72% (123K) · Skillset: clifford · Skillsets "

--- a/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_worktree_orange.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_worktree_orange.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ⎇ feature/worktree-branch · +5 -2 · Skillset: clifford · Skillsets v19.1.1 · ?"
+"  ⎇ feature/worktree-branch · +5 -2 · Context 72% · Skillset: clifford · Skillse"

--- a/codex-rs/tui/src/chatwidget/event_handlers.rs
+++ b/codex-rs/tui/src/chatwidget/event_handlers.rs
@@ -1147,7 +1147,13 @@ impl ChatWidget {
                 self.bottom_pane.set_agent_commands(update.commands);
             }
             nori_protocol::ClientEvent::SessionUpdateInfo(update) => {
-                self.add_info_message(update.message, update.hint);
+                if update.kind == nori_protocol::SessionUpdateKind::Usage
+                    && let Some(usage) = update.usage
+                {
+                    self.bottom_pane.set_session_usage(Some(usage));
+                } else {
+                    self.add_info_message(update.message, update.hint);
+                }
                 self.request_redraw();
             }
             nori_protocol::ClientEvent::Warning(warning) => {

--- a/codex-rs/tui/src/chatwidget/tests/part3.rs
+++ b/codex-rs/tui/src/chatwidget/tests/part3.rs
@@ -328,7 +328,7 @@ fn replay_entry_user_and_assistant_render_history() {
 }
 
 #[test]
-fn session_update_info_event_renders_history_snapshot() {
+fn session_update_info_events_only_render_non_usage_history() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
 
     chat.handle_client_event(nori_protocol::ClientEvent::SessionUpdateInfo(
@@ -336,13 +336,19 @@ fn session_update_info_event_renders_history_snapshot() {
             kind: nori_protocol::SessionUpdateKind::CurrentMode,
             message: "ACP mode changed to review".into(),
             hint: None,
+            usage: None,
         },
     ));
     chat.handle_client_event(nori_protocol::ClientEvent::SessionUpdateInfo(
         nori_protocol::SessionUpdateInfo {
             kind: nori_protocol::SessionUpdateKind::Usage,
-            message: "Session usage: 128 / 4096 tokens, cost 0.42 USD".into(),
+            message: "Session usage: 42600 / 258400 tokens".into(),
             hint: None,
+            usage: Some(nori_protocol::session_runtime::SessionUsageState {
+                used_tokens: 42_600,
+                total_tokens: 258_400,
+                cost_display: None,
+            }),
         },
     ));
 
@@ -354,6 +360,58 @@ fn session_update_info_event_renders_history_snapshot() {
         .join("\n");
 
     assert_snapshot!("session_update_info_history", combined);
+}
+
+#[test]
+fn session_usage_updates_footer_and_disables_transcript_fallback() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
+
+    chat.apply_system_info_refresh(crate::system_info::SystemInfo {
+        transcript_location: Some(codex_acp::TranscriptLocation {
+            agent_kind: codex_acp::AgentKind::Codex,
+            transcript_path: PathBuf::from("/tmp/codex-transcript.jsonl"),
+            session_id: "codex-session".to_string(),
+            token_breakdown: Some(codex_acp::TranscriptTokenUsage {
+                input_tokens: 995_726,
+                output_tokens: 8_452,
+                cached_tokens: 500_000,
+                last_context_tokens: Some(69_246),
+            }),
+        }),
+        ..Default::default()
+    });
+    chat.handle_client_event(nori_protocol::ClientEvent::SessionUpdateInfo(
+        nori_protocol::SessionUpdateInfo {
+            kind: nori_protocol::SessionUpdateKind::Usage,
+            message: "Session usage: 42600 / 258400 tokens".into(),
+            hint: None,
+            usage: Some(nori_protocol::session_runtime::SessionUsageState {
+                used_tokens: 42_600,
+                total_tokens: 258_400,
+                cost_display: None,
+            }),
+        },
+    ));
+
+    assert!(drain_insert_history(&mut rx).is_empty());
+
+    let height = chat.desired_height(80);
+    let mut terminal =
+        ratatui::Terminal::new(VT100Backend::new(80, height)).expect("create terminal");
+    terminal.set_viewport_area(Rect::new(0, 0, 80, height));
+    terminal
+        .draw(|f| chat.render(f.area(), f.buffer_mut()))
+        .expect("draw chat with footer usage");
+    let contents = terminal.backend().vt100().screen().contents();
+
+    assert!(
+        contents.contains("Context 16% (42.6K)"),
+        "expected ACP session usage in footer, got: {contents:?}"
+    );
+    assert!(
+        !contents.contains("Context: 69.2K (27%)"),
+        "expected transcript fallback to be disabled, got: {contents:?}"
+    );
 }
 
 #[test]

--- a/codex-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part3__session_update_info_history.snap
+++ b/codex-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part3__session_update_info_history.snap
@@ -3,6 +3,3 @@ source: tui/src/chatwidget/tests/part3.rs
 expression: combined
 ---
 • ACP mode changed to review
-
-
-• Session usage: 128 / 4096 tokens, cost 0.42 USD

--- a/codex-rs/tui/src/viewonly_transcript.rs
+++ b/codex-rs/tui/src/viewonly_transcript.rs
@@ -166,7 +166,9 @@ fn format_client_event(event: &nori_protocol::ClientEvent) -> Option<String> {
                 &snapshot.artifacts,
             ))
         }
-        nori_protocol::ClientEvent::SessionUpdateInfo(info) => Some(info.message.clone()),
+        nori_protocol::ClientEvent::SessionUpdateInfo(info) => {
+            (info.kind != nori_protocol::SessionUpdateKind::Usage).then(|| info.message.clone())
+        }
         nori_protocol::ClientEvent::MessageDelta(_)
         | nori_protocol::ClientEvent::SessionPhaseChanged(_)
         | nori_protocol::ClientEvent::PromptCompleted(_)
@@ -576,6 +578,11 @@ mod tests {
                     kind: nori_protocol::SessionUpdateKind::Usage,
                     message: "Session usage: 128 / 4096 tokens".to_string(),
                     hint: None,
+                    usage: Some(nori_protocol::session_runtime::SessionUsageState {
+                        used_tokens: 128,
+                        total_tokens: 4096,
+                        cost_display: None,
+                    }),
                 },
             ),
         })]);
@@ -584,14 +591,9 @@ mod tests {
 
         assert_eq!(
             entries,
-            vec![
-                ViewonlyEntry::Info {
-                    content: "Session from 2025-01-27 12:00 (test-ses)".to_string(),
-                },
-                ViewonlyEntry::Info {
-                    content: "Session usage: 128 / 4096 tokens".to_string(),
-                },
-            ]
+            vec![ViewonlyEntry::Info {
+                content: "Session from 2025-01-27 12:00 (test-ses)".to_string(),
+            }]
         );
     }
 


### PR DESCRIPTION
## Summary
- route ACP `SessionUpdateInfo::Usage` updates into the footer context segment instead of rendering the verbose `Session usage: ...` history line
- use structured ACP session usage as the primary context source and only fall back to provider-specific transcript parsing when no ACP usage updates have arrived
- update transcript replay, view-only transcript behavior, docs, and snapshots so the footer shows values like `Context 16% (42.6K)` consistently

## Why
The new ACP usage history render was technically correct but too noisy in the transcript and interrupted more important output. The footer already has a dedicated context surface, so this change keeps the usage signal visible without adding extra transcript clutter.

## Impact
Users on the ACP-backed Nori CLI now see context usage in the footer instead of as a standalone history item, and replayed sessions restore that footer state through the structured protocol path.

## Test Plan
- `just fmt`
- `cargo test -p nori-protocol`
- `cargo test -p codex-acp`
- `cargo test -p nori-tui`
- `cargo test`
- `cargo build --bin nori`
- `cargo test -p tui-pty-e2e`
- manual tmux verification with `elizacp`: launch `nori`, assert prompt appears, submit `hello`, assert prompt returns

## Notes
- originally developed as a short stacked follow-up, then rebased onto the latest `main` after the parent work landed