### PR TITLE
perf(tui): stop polling nori-skillsets; cache version

### DIFF
--- a/codex-rs/tui/docs.md
+++ b/codex-rs/tui/docs.md
@@ -227,6 +227,22 @@ Two collection methods are provided:
 
 The first-message is obtained from `ChatWidget::first_prompt_text()`, which stores the text of the first submitted prompt. This flows through `SystemInfoRefreshRequest` to the background worker, enabling accurate transcript matching when multiple sessions exist in the same project directory.
 
+**Refresh model:**
+
+`spawn_system_info_worker` runs a background thread that blocks on its request channel: a refresh happens only when a `SystemInfoRefreshRequest` is sent via `request_system_info_refresh()`. There is no periodic polling. Refreshes are triggered on:
+
+1. Startup (explicit initial refresh in `App::run()`)
+2. User message submit (`chatwidget/user_input.rs`)
+3. Task completion (`chatwidget/event_handlers.rs`)
+4. Effective cwd change observed from tool-call directories or file-change paths (debounced 500ms by `EffectiveCwdTracker`)
+5. Successful skillset install or switch (`app/event_handling.rs`)
+
+This means an external change (e.g., the user runs `nori-skillsets switch` in another terminal) will not be reflected in the footer until the next event-driven refresh. Footer staleness is bounded by user activity, not by wall-clock time.
+
+**Version caching:**
+
+`get_nori_version()` shells out to `nori-skillsets --version` (or `nori-ai --version` as a legacy fallback) and caches the result in a process-wide `OnceLock` (`NORI_VERSION_CACHE`). The installed CLI version is stable for the lifetime of a TUI process, so the subprocess runs at most once per session. Only `nori-skillsets list-active` is re-invoked on every refresh.
+
 **`/diff` Slash Command** (`get_git_diff.rs`):
 
 The `/diff` handler in `key_handling.rs` resolves the effective CWD from the `effective_cwd_tracker` (falling back to `config.cwd`) and passes it to `get_git_diff()`. This ensures `/diff` works correctly in git worktrees and directories different from the process launch directory. All git commands in `get_git_diff.rs` use `.current_dir()` when a directory is provided.

--- a/codex-rs/tui/src/app/mod.rs
+++ b/codex-rs/tui/src/app/mod.rs
@@ -351,13 +351,8 @@ impl App {
         let upgrade_version = crate::updates::get_upgrade_version(&config);
 
         let (system_info_tx, system_info_rx) = mpsc::channel();
-        let _system_info_worker = Self::spawn_system_info_worker(
-            system_info_rx,
-            app_event_tx.clone(),
-            config.cwd.clone(),
-            config.model.clone(),
-            initial_prompt.clone(),
-        );
+        let _system_info_worker =
+            Self::spawn_system_info_worker(system_info_rx, app_event_tx.clone());
 
         let mut app = Self {
             app_event_tx,
@@ -556,31 +551,22 @@ impl App {
     fn spawn_system_info_worker(
         system_info_rx: mpsc::Receiver<SystemInfoRefreshRequest>,
         app_event_tx: AppEventSender,
-        initial_dir: PathBuf,
-        initial_model: String,
-        initial_first_message: Option<String>,
     ) -> thread::JoinHandle<()> {
         thread::spawn(move || {
-            let mut last_request = SystemInfoRefreshRequest {
-                dir: initial_dir,
-                model: Some(initial_model),
-                first_message: initial_first_message,
-            };
-            loop {
-                match system_info_rx.recv_timeout(Duration::from_secs(5)) {
-                    Ok(request) => last_request = request,
-                    Err(mpsc::RecvTimeoutError::Timeout) => {}
-                    Err(mpsc::RecvTimeoutError::Disconnected) => break,
-                }
-
-                let agent_kind = last_request
+            // Refresh only when a request arrives. The initial refresh is
+            // scheduled explicitly via `request_system_info_refresh` at
+            // startup, and subsequent refreshes are driven by user actions
+            // (message submit, task completion, tool-call cwd changes,
+            // skillset install/switch). No periodic polling.
+            while let Ok(request) = system_info_rx.recv() {
+                let agent_kind = request
                     .model
                     .as_ref()
                     .and_then(|model| codex_acp::AgentKind::from_slug(model));
                 let info = crate::system_info::SystemInfo::collect_for_directory_with_message(
-                    &last_request.dir,
+                    &request.dir,
                     agent_kind,
-                    last_request.first_message.as_deref(),
+                    request.first_message.as_deref(),
                 );
                 app_event_tx.send(AppEvent::SystemInfoRefreshed(info));
             }

--- a/codex-rs/tui/src/system_info.rs
+++ b/codex-rs/tui/src/system_info.rs
@@ -2,6 +2,7 @@ use codex_acp::AgentKind;
 use codex_acp::TranscriptLocation;
 use std::env;
 use std::process::Command;
+use std::sync::OnceLock;
 
 /// Indicates which command was used to detect the Nori version.
 /// This affects the UI display text.
@@ -161,7 +162,19 @@ fn discover_transcript(
     })
 }
 
+/// Cached result of `nori-skillsets --version` / `nori-ai --version`.
+///
+/// The installed CLI version is stable for the lifetime of a TUI process, so
+/// we detect it once and reuse the result on every subsequent `SystemInfo`
+/// refresh. This avoids spawning a heavyweight Node.js subprocess on every
+/// footer update.
+static NORI_VERSION_CACHE: OnceLock<(Option<String>, Option<NoriVersionSource>)> = OnceLock::new();
+
 fn get_nori_version() -> (Option<String>, Option<NoriVersionSource>) {
+    NORI_VERSION_CACHE.get_or_init(detect_nori_version).clone()
+}
+
+fn detect_nori_version() -> (Option<String>, Option<NoriVersionSource>) {
     // Try nori-skillsets first (new installer)
     if let Ok(output) = Command::new("nori-skillsets").arg("--version").output()
         && output.status.success()


### PR DESCRIPTION
## Summary

- `spawn_system_info_worker` in `codex-rs/tui/src/app/mod.rs` was firing a full `SystemInfo` refresh every 5 seconds via `recv_timeout` fall-through, which in turn spawned `nori-skillsets --version` and `nori-skillsets list-active` as Node.js subprocesses. With several concurrent `nori` sessions this produced sustained CPU load just to paint the footer (see discovery notes below). Switch to blocking `recv()` so refreshes only happen on explicit `request_system_info_refresh()` calls.
- Cache `nori-skillsets --version` in a process-wide `OnceLock` (`NORI_VERSION_CACHE`) in `codex-rs/tui/src/system_info.rs`. The installed CLI version is stable for the lifetime of the TUI process, so the subprocess runs at most once per session. `list-active` is still re-invoked on every refresh.
- Document the new event-driven refresh model and version caching in `codex-rs/tui/docs.md`.

Refreshes are still triggered on: startup, user message submit, task completion, effective cwd changes (debounced 500ms by `EffectiveCwdTracker`), and skillset install/switch success.

### Tradeoff

An external `nori-skillsets switch` run in another terminal while the TUI is idle will not be reflected in the footer until the user does something that triggers a refresh. Discussed and accepted.

### Impact

- Per-session baseline load: ~0.4 `nori-skillsets` spawns/sec → **0** when idle.
- Per-refresh cost: 2 subprocesses → 1.

## Test plan

- [x] `cargo test -p nori-tui` — 1199 passed, 0 failed
- [x] `just fmt` + `just fix -p nori-tui` — clean
- [x] `cargo build --bin nori` — success
- [x] `cargo test -p tui-pty-e2e` — all suites pass
- [x] End-to-end: launched `nori --agent elizacp` under tmux; TUI rendered, `›` prompt appeared, footer populated with active skillset and cached version string; user submit triggered a refresh that updated the footer. No panics.