### PR TITLE
fix(tui): show parent-directory CLAUDE.md files in info box

### DIFF
--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -271,6 +271,7 @@ During background system info collection on unix, `check_worktree_cleanup()` run
 | `/diff` | Show PR-like git diff (changes since merge-base with default branch, plus untracked files) |
 | `/mention` | Mention a file |
 | `/status` | Show session configuration and context window usage |
+| `/memory` | Show the contents of all active instruction files (CLAUDE.md / AGENTS.md / GEMINI.md) |
 | `/first-prompt` | Show the first prompt from this session |
 | `/mcp` | Manage MCP server connections (add, toggle, delete) via interactive wizard |
 | `/login` | Log in to the current agent |
@@ -437,6 +438,41 @@ The card always shows: version, directory, agent, skillset (Nori profile). Optio
 The Tokens section renders if either `token_breakdown` has a non-zero total OR `context_window_percent` is present. This means context window percentage from the live API (`TokenUsageInfo`) can appear even before transcript token data is available.
 
 Task summaries are truncated to 50 characters via `truncate_summary()`, which uses char-level operations (`chars().count()` / `chars().take()`) rather than byte slicing for UTF-8 safety with multi-byte characters.
+
+**Instruction File Discovery (`nori/session_header/mod.rs`):**
+
+The "Instruction Files" block in the startup welcome banner, the `/status` card, and the `/memory` output (`chatwidget/helpers.rs::add_memory_output()` -> `active_instruction_file_contents()`) all funnel through the same discovery pathway: `discover_all_instruction_files()` -> `discover_all_instruction_files_with_paths(cwd, agent_kind, home_dir, managed_policy_dir)`. The active subset of those files is what the agent will actually load, so the displayed list must mirror each agent's documented inheritance rules instead of using a single shared rule.
+
+The agent kind is inferred by `detect_agent_kind()` from the configured agent/model string ("claude*", "codex*", "gemini*"). The set of directories searched for instruction files is then chosen per agent:
+
+| Agent | Search range | Fallback when no `.git` is found |
+|-------|--------------|----------------------------------|
+| Claude | Full ancestor chain from cwd up to filesystem root (no git-root cutoff) | n/a -- always walks to root |
+| Codex | cwd up to the nearest `.git` ancestor | cwd only |
+| Gemini | cwd up to the nearest `.git` ancestor | cwd only |
+| Unknown | cwd up to the nearest `.git` ancestor | cwd only |
+
+Claude's behavior follows Claude Code's documented memory loader (https://code.claude.com/docs/en/memory). Walking only to the git root would underreport which CLAUDE.md files Claude will actually load (e.g. with cwd `/tmp/bar/baz`, a `CLAUDE.md` at `/tmp/bar/.claude/` would be missed), so the displayed list would not match what the agent sees.
+
+In each search directory, the discoverer probes for `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md`, `AGENTS.override.md`, `GEMINI.md`, and `.claude/CLAUDE.md`. Two extra passes layer in user-level and system-level configs:
+
+- Home-config pass: `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.gemini/GEMINI.md`.
+- Managed-policy pass (Claude only): platform-specific system-wide CLAUDE.md (`/etc/claude-code/CLAUDE.md` on Linux, `/Library/Application Support/ClaudeCode/CLAUDE.md` on macOS, `C:\Program Files\ClaudeCode\CLAUDE.md` on Windows) chosen by `default_managed_policy_dir()`.
+
+The final list is concatenated lowest-precedence first (managed-policy, then home, then ancestor walk) and then deduplicated by absolute path so a file reachable through more than one pass appears exactly once.
+
+After discovery, an activation pass marks each file `active` for the current agent:
+
+| Agent | Files marked active |
+|-------|---------------------|
+| Claude | `.claude/CLAUDE.md`, `CLAUDE.md`, `CLAUDE.local.md` (all of them, anywhere they appear) |
+| Codex | Per directory: `AGENTS.override.md` if present, else `AGENTS.md`. `dirs_with_override` tracks which directories had an override so the sibling `AGENTS.md` in the same directory is suppressed. |
+| Gemini | `GEMINI.md` only (no hidden variants, no overrides) |
+| Unknown | nothing is active |
+
+Token counts are computed only for active files (via `count_tokens()` from `nori/token_count.rs`), so inactive files render dim and contribute nothing to the per-section total in the status card.
+
+Tests inject fake home and managed-policy directories through `discover_all_instruction_files_with_paths()` (and the test-only `discover_all_instruction_files_with_home()` wrapper) to avoid touching real filesystem locations. In debug builds, setting `NORI_MOCK_INSTRUCTION_FILES=1` short-circuits discovery and returns a single fixed entry so E2E snapshots stay stable across machines.
 
 **Skillset Switching (`nori/skillset_picker.rs`):**
 

--- a/nori-rs/tui/src/nori/session_header/mod.rs
+++ b/nori-rs/tui/src/nori/session_header/mod.rs
@@ -90,17 +90,50 @@ fn discover_all_instruction_files(
         }];
     }
 
-    discover_all_instruction_files_with_home(cwd, agent_kind, dirs::home_dir().as_deref())
+    discover_all_instruction_files_with_paths(
+        cwd,
+        agent_kind,
+        dirs::home_dir().as_deref(),
+        default_managed_policy_dir().as_deref(),
+    )
+}
+
+/// Default platform-specific directory containing the managed-policy CLAUDE.md
+/// that Claude Code loads in addition to user/project files.
+fn default_managed_policy_dir() -> Option<PathBuf> {
+    if cfg!(target_os = "linux") {
+        Some(PathBuf::from("/etc/claude-code"))
+    } else if cfg!(target_os = "macos") {
+        Some(PathBuf::from("/Library/Application Support/ClaudeCode"))
+    } else if cfg!(target_os = "windows") {
+        Some(PathBuf::from(r"C:\Program Files\ClaudeCode"))
+    } else {
+        None
+    }
 }
 
 /// Internal function that discovers instruction files with an optional custom home directory.
-/// This allows testing with a fake home directory.
+/// Used by tests that want to inject a fake home directory but don't care about the
+/// managed-policy path.
+#[cfg(test)]
 fn discover_all_instruction_files_with_home(
     cwd: &Path,
     agent_kind: Option<AgentKindSimple>,
     home_dir: Option<&Path>,
 ) -> Vec<InstructionFile> {
-    // Build chain from cwd upwards and detect git root
+    discover_all_instruction_files_with_paths(cwd, agent_kind, home_dir, None)
+}
+
+/// Internal function that discovers instruction files with optional custom home and managed-policy
+/// directories. Tests can inject paths to avoid touching real filesystem locations.
+fn discover_all_instruction_files_with_paths(
+    cwd: &Path,
+    agent_kind: Option<AgentKindSimple>,
+    home_dir: Option<&Path>,
+    managed_policy_dir: Option<&Path>,
+) -> Vec<InstructionFile> {
+    // Build the full chain from cwd up to filesystem root, recording whether we
+    // saw a `.git` marker and at which level.
     let mut chain: Vec<PathBuf> = Vec::new();
     let mut current = cwd.to_path_buf();
     let mut git_root: Option<PathBuf> = None;
@@ -108,11 +141,8 @@ fn discover_all_instruction_files_with_home(
     loop {
         chain.push(current.clone());
 
-        // Check for .git marker
-        let git_marker = current.join(".git");
-        if git_marker.exists() {
+        if git_root.is_none() && current.join(".git").exists() {
             git_root = Some(current.clone());
-            break;
         }
 
         if !current.pop() {
@@ -120,25 +150,34 @@ fn discover_all_instruction_files_with_home(
         }
     }
 
-    // Determine search directories (from git root to cwd, or just cwd if no git root)
-    let search_dirs: Vec<PathBuf> = if let Some(root) = &git_root {
-        // Reverse the chain and filter to only include from git root onward
-        let mut dirs: Vec<PathBuf> = Vec::new();
-        let mut saw_root = false;
-        for p in chain.iter().rev() {
-            if !saw_root {
-                if p == root {
-                    saw_root = true;
-                } else {
-                    continue;
+    // Choose the set of directories to search based on the agent's documented behavior.
+    //
+    // - Claude Code: walks all the way up to filesystem root, regardless of `.git`.
+    //   See https://code.claude.com/docs/en/memory.
+    // - Codex / Gemini: walk up only as far as the git root; if no git root exists,
+    //   look at cwd only.
+    // - Unknown agent: same as Codex/Gemini (conservative).
+    let search_dirs: Vec<PathBuf> = match agent_kind {
+        Some(AgentKindSimple::Claude) => chain.iter().rev().cloned().collect(),
+        Some(AgentKindSimple::Codex) | Some(AgentKindSimple::Gemini) | None => {
+            if let Some(root) = &git_root {
+                let mut dirs: Vec<PathBuf> = Vec::new();
+                let mut saw_root = false;
+                for p in chain.iter().rev() {
+                    if !saw_root {
+                        if p == root {
+                            saw_root = true;
+                        } else {
+                            continue;
+                        }
+                    }
+                    dirs.push(p.clone());
                 }
+                dirs
+            } else {
+                vec![cwd.to_path_buf()]
             }
-            dirs.push(p.clone());
         }
-        dirs
-    } else {
-        // No git root, just search cwd
-        vec![cwd.to_path_buf()]
     };
 
     let mut found: Vec<InstructionFile> = Vec::new();
@@ -206,9 +245,28 @@ fn discover_all_instruction_files_with_home(
         }
     }
 
-    // Prepend home configs to discovered list so they appear first
-    let mut all_discovered = home_configs;
+    // Discover managed-policy CLAUDE.md (Claude Code only).
+    // This is a system-level CLAUDE.md that the Claude Code agent loads in addition
+    // to user/project files (e.g. /etc/claude-code/CLAUDE.md on Linux).
+    let mut policy_configs: Vec<(PathBuf, PathBuf)> = Vec::new();
+    if matches!(agent_kind, Some(AgentKindSimple::Claude))
+        && let Some(policy_dir) = managed_policy_dir
+    {
+        let policy_file = policy_dir.join("CLAUDE.md");
+        if policy_file.is_file() {
+            policy_configs.push((policy_file, policy_dir.to_path_buf()));
+        }
+    }
+
+    // Build the final list, lowest-precedence first: managed-policy, then home, then ancestor walk.
+    let mut all_discovered = policy_configs;
+    all_discovered.extend(home_configs);
     all_discovered.extend(discovered);
+
+    // Deduplicate by path so a file discovered both via the ancestor walk and the
+    // home-config / managed-policy passes appears exactly once.
+    let mut seen_paths: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+    all_discovered.retain(|(path, _)| seen_paths.insert(path.clone()));
 
     // Second pass: apply activation algorithm
     for (file_path, parent_dir) in all_discovered {
@@ -217,12 +275,11 @@ fn discover_all_instruction_files_with_home(
             .map(|s| s.to_string_lossy().to_string())
             .unwrap_or_default();
 
-        let is_hidden_claude = file_path.to_string_lossy().contains(".claude/CLAUDE.md");
-
         let active = match agent_kind {
             Some(AgentKindSimple::Claude) => {
-                // Claude activates: .claude/CLAUDE.md, CLAUDE.md, CLAUDE.local.md
-                is_hidden_claude || filename == "CLAUDE.md" || filename == "CLAUDE.local.md"
+                // Claude activates: CLAUDE.md, CLAUDE.local.md (basename match covers
+                // both `<dir>/CLAUDE.md` and `<dir>/.claude/CLAUDE.md`).
+                filename == "CLAUDE.md" || filename == "CLAUDE.local.md"
             }
             Some(AgentKindSimple::Codex) => {
                 // Codex activates: AGENTS.override.md OR AGENTS.md (prefer override)

--- a/nori-rs/tui/src/nori/session_header/tests.rs
+++ b/nori-rs/tui/src/nori/session_header/tests.rs
@@ -1432,3 +1432,360 @@ fn compact_mode_snapshot() {
 
     insta::assert_snapshot!(rendered);
 }
+
+// =========================================================================
+// Per-agent ancestor walk semantics
+// =========================================================================
+
+#[test]
+fn discover_walks_all_ancestors_for_claude_when_no_git() {
+    // Repro of the user-reported bug: with no .git anywhere in the chain,
+    // Claude should still discover CLAUDE.md files in parent directories.
+    //
+    // Layout (no .git anywhere):
+    //   tmp/.claude/CLAUDE.md         <- ancestor
+    //   tmp/sub/.claude/CLAUDE.md     <- cwd
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+
+    fs::create_dir_all(root.join(".claude")).expect("create root/.claude");
+    fs::write(root.join(".claude/CLAUDE.md"), "ancestor").expect("write ancestor CLAUDE.md");
+
+    let sub = root.join("sub");
+    fs::create_dir_all(sub.join(".claude")).expect("create sub/.claude");
+    fs::write(sub.join(".claude/CLAUDE.md"), "cwd").expect("write cwd CLAUDE.md");
+
+    let files = discover_all_instruction_files_with_home(&sub, Some(AgentKindSimple::Claude), None);
+
+    let ancestor_path = root.join(".claude/CLAUDE.md");
+    let cwd_path = sub.join(".claude/CLAUDE.md");
+
+    assert!(
+        files.iter().any(|f| f.path == ancestor_path && f.active),
+        "Claude should discover ancestor .claude/CLAUDE.md as active when no .git is present. Got: {:?}",
+        files.iter().map(|f| &f.path).collect::<Vec<_>>()
+    );
+    assert!(
+        files.iter().any(|f| f.path == cwd_path && f.active),
+        "Claude should still discover cwd .claude/CLAUDE.md. Got: {:?}",
+        files.iter().map(|f| &f.path).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn discover_walks_past_git_root_for_claude() {
+    // Per Anthropic docs, Claude Code walks all the way up to /, not just to git root.
+    //
+    // Layout:
+    //   tmp/CLAUDE.md          <- above git root (must be discovered for Claude)
+    //   tmp/proj/.git
+    //   tmp/proj/CLAUDE.md
+    //   tmp/proj/sub/CLAUDE.md <- cwd
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+
+    fs::write(root.join("CLAUDE.md"), "above-git").expect("write above-git CLAUDE.md");
+
+    let proj = root.join("proj");
+    fs::create_dir_all(&proj).expect("create proj");
+    fs::write(proj.join(".git"), "gitdir").expect("write .git");
+    fs::write(proj.join("CLAUDE.md"), "proj").expect("write proj CLAUDE.md");
+
+    let sub = proj.join("sub");
+    fs::create_dir_all(&sub).expect("create sub");
+    fs::write(sub.join("CLAUDE.md"), "sub").expect("write sub CLAUDE.md");
+
+    let files = discover_all_instruction_files_with_home(&sub, Some(AgentKindSimple::Claude), None);
+
+    let above_git = root.join("CLAUDE.md");
+    assert!(
+        files.iter().any(|f| f.path == above_git && f.active),
+        "Claude should discover CLAUDE.md above the git root. Got: {:?}",
+        files.iter().map(|f| &f.path).collect::<Vec<_>>()
+    );
+    assert!(
+        files
+            .iter()
+            .any(|f| f.path == proj.join("CLAUDE.md") && f.active),
+        "Claude should still discover CLAUDE.md at git root."
+    );
+    assert!(
+        files
+            .iter()
+            .any(|f| f.path == sub.join("CLAUDE.md") && f.active),
+        "Claude should still discover CLAUDE.md at cwd."
+    );
+}
+
+#[test]
+fn discover_codex_stays_at_git_root() {
+    // Codex CLI semantics: walk stops at the git root. AGENTS.md above git root
+    // must NOT appear in the result.
+    //
+    // Layout:
+    //   tmp/AGENTS.md           <- above git root (must NOT appear)
+    //   tmp/proj/.git
+    //   tmp/proj/AGENTS.md
+    //   tmp/proj/sub/AGENTS.md  <- cwd
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+
+    fs::write(root.join("AGENTS.md"), "above-git").expect("write above-git AGENTS.md");
+
+    let proj = root.join("proj");
+    fs::create_dir_all(&proj).expect("create proj");
+    fs::write(proj.join(".git"), "gitdir").expect("write .git");
+    fs::write(proj.join("AGENTS.md"), "proj").expect("write proj AGENTS.md");
+
+    let sub = proj.join("sub");
+    fs::create_dir_all(&sub).expect("create sub");
+    fs::write(sub.join("AGENTS.md"), "sub").expect("write sub AGENTS.md");
+
+    let files = discover_all_instruction_files_with_home(&sub, Some(AgentKindSimple::Codex), None);
+
+    let above_git = root.join("AGENTS.md");
+    assert!(
+        !files.iter().any(|f| f.path == above_git),
+        "Codex should NOT discover AGENTS.md above the git root. Got: {:?}",
+        files.iter().map(|f| &f.path).collect::<Vec<_>>()
+    );
+    assert!(
+        files
+            .iter()
+            .any(|f| f.path == proj.join("AGENTS.md") && f.active),
+        "Codex should discover AGENTS.md at git root."
+    );
+    assert!(
+        files
+            .iter()
+            .any(|f| f.path == sub.join("AGENTS.md") && f.active),
+        "Codex should discover AGENTS.md at cwd."
+    );
+}
+
+#[test]
+fn discover_codex_no_git_stays_at_cwd() {
+    // Codex semantics with no .git anywhere: only cwd is searched (current behavior).
+    //
+    // Layout (no .git anywhere):
+    //   tmp/AGENTS.md           <- ancestor (must NOT appear)
+    //   tmp/sub/AGENTS.md       <- cwd
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+
+    fs::write(root.join("AGENTS.md"), "ancestor").expect("write ancestor AGENTS.md");
+
+    let sub = root.join("sub");
+    fs::create_dir_all(&sub).expect("create sub");
+    fs::write(sub.join("AGENTS.md"), "cwd").expect("write cwd AGENTS.md");
+
+    let files = discover_all_instruction_files_with_home(&sub, Some(AgentKindSimple::Codex), None);
+
+    let ancestor = root.join("AGENTS.md");
+    assert!(
+        !files.iter().any(|f| f.path == ancestor),
+        "Codex with no git root should NOT walk ancestors. Got: {:?}",
+        files.iter().map(|f| &f.path).collect::<Vec<_>>()
+    );
+    assert!(
+        files
+            .iter()
+            .any(|f| f.path == sub.join("AGENTS.md") && f.active),
+        "Codex should discover AGENTS.md at cwd."
+    );
+}
+
+#[test]
+fn discover_gemini_stays_at_git_root() {
+    // Gemini CLI semantics: walk stops at git root. GEMINI.md above git root
+    // must NOT appear in the result.
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+
+    fs::write(root.join("GEMINI.md"), "above-git").expect("write above-git GEMINI.md");
+
+    let proj = root.join("proj");
+    fs::create_dir_all(&proj).expect("create proj");
+    fs::write(proj.join(".git"), "gitdir").expect("write .git");
+    fs::write(proj.join("GEMINI.md"), "proj").expect("write proj GEMINI.md");
+
+    let sub = proj.join("sub");
+    fs::create_dir_all(&sub).expect("create sub");
+    fs::write(sub.join("GEMINI.md"), "sub").expect("write sub GEMINI.md");
+
+    let files = discover_all_instruction_files_with_home(&sub, Some(AgentKindSimple::Gemini), None);
+
+    let above_git = root.join("GEMINI.md");
+    assert!(
+        !files.iter().any(|f| f.path == above_git),
+        "Gemini should NOT discover GEMINI.md above the git root. Got: {:?}",
+        files.iter().map(|f| &f.path).collect::<Vec<_>>()
+    );
+    assert!(
+        files
+            .iter()
+            .any(|f| f.path == proj.join("GEMINI.md") && f.active),
+        "Gemini should discover GEMINI.md at git root."
+    );
+    assert!(
+        files
+            .iter()
+            .any(|f| f.path == sub.join("GEMINI.md") && f.active),
+        "Gemini should discover GEMINI.md at cwd."
+    );
+}
+
+#[test]
+fn discover_unknown_agent_no_git_stays_at_cwd() {
+    // Unknown agent with no .git: only cwd is searched (current behavior preserved).
+    let tmp = TempDir::new().expect("tempdir");
+    let root = tmp.path();
+
+    fs::write(root.join("CLAUDE.md"), "ancestor").expect("write ancestor CLAUDE.md");
+
+    let sub = root.join("sub");
+    fs::create_dir_all(&sub).expect("create sub");
+    fs::write(sub.join("CLAUDE.md"), "cwd").expect("write cwd CLAUDE.md");
+
+    let files = discover_all_instruction_files_with_home(&sub, None, None);
+
+    let ancestor = root.join("CLAUDE.md");
+    assert!(
+        !files.iter().any(|f| f.path == ancestor),
+        "Unknown agent with no git root should NOT walk ancestors. Got: {:?}",
+        files.iter().map(|f| &f.path).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn discover_dedupes_home_config_against_ancestor_walk() {
+    // When cwd is inside $HOME, the Claude ancestor walk also visits $HOME and would
+    // discover ~/.claude/CLAUDE.md a second time. The result must contain the home
+    // CLAUDE.md exactly once.
+    let tmp = TempDir::new().expect("tempdir");
+    let fake_home = tmp.path().join("home");
+    fs::create_dir_all(fake_home.join(".claude")).expect("create fake_home/.claude");
+    fs::write(fake_home.join(".claude/CLAUDE.md"), "user").expect("write user CLAUDE.md");
+
+    // cwd is a child of fake_home with no .git anywhere
+    let cwd = fake_home.join("work").join("proj");
+    fs::create_dir_all(&cwd).expect("create cwd");
+
+    let files = discover_all_instruction_files_with_home(
+        &cwd,
+        Some(AgentKindSimple::Claude),
+        Some(&fake_home),
+    );
+
+    let home_claude = fake_home.join(".claude/CLAUDE.md");
+    let matches: Vec<&InstructionFile> = files.iter().filter(|f| f.path == home_claude).collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "Home CLAUDE.md must appear exactly once even when cwd is inside $HOME. Got: {:?}",
+        files.iter().map(|f| &f.path).collect::<Vec<_>>()
+    );
+    assert!(
+        matches[0].active,
+        "Deduplicated home CLAUDE.md should still be active for Claude. Got: {:?}",
+        matches[0]
+    );
+}
+
+// =========================================================================
+// Managed policy CLAUDE.md discovery
+// =========================================================================
+
+#[test]
+fn discover_finds_managed_policy_claude_md_for_claude_agent() {
+    // Anthropic ships a "managed policy" CLAUDE.md location (e.g. /etc/claude-code/CLAUDE.md
+    // on Linux) that Claude Code loads in addition to user/project files. The info box
+    // should reflect it.
+    //
+    // To keep the test platform-independent and avoid touching system paths, we use the
+    // injection-based variant of the discovery function that takes an explicit policy dir.
+    let tmp = TempDir::new().expect("tempdir");
+    let policy_dir = tmp.path().join("policy");
+    fs::create_dir_all(&policy_dir).expect("create policy dir");
+    fs::write(policy_dir.join("CLAUDE.md"), "managed policy").expect("write policy CLAUDE.md");
+
+    let cwd = tmp.path().join("work");
+    fs::create_dir_all(&cwd).expect("create cwd");
+
+    let files = discover_all_instruction_files_with_paths(
+        &cwd,
+        Some(AgentKindSimple::Claude),
+        None,
+        Some(&policy_dir),
+    );
+
+    let policy_path = policy_dir.join("CLAUDE.md");
+    let policy_file = files
+        .iter()
+        .find(|f| f.path == policy_path)
+        .expect("Should discover managed-policy CLAUDE.md");
+    assert!(
+        policy_file.active,
+        "Managed-policy CLAUDE.md should be active for Claude. Got: {policy_file:?}"
+    );
+}
+
+#[test]
+fn discover_managed_policy_inactive_for_codex() {
+    // Managed policy CLAUDE.md is a Claude-specific concept. For Codex it should not
+    // be reported as active.
+    let tmp = TempDir::new().expect("tempdir");
+    let policy_dir = tmp.path().join("policy");
+    fs::create_dir_all(&policy_dir).expect("create policy dir");
+    fs::write(policy_dir.join("CLAUDE.md"), "managed policy").expect("write policy CLAUDE.md");
+
+    let cwd = tmp.path().join("work");
+    fs::create_dir_all(&cwd).expect("create cwd");
+
+    let files = discover_all_instruction_files_with_paths(
+        &cwd,
+        Some(AgentKindSimple::Codex),
+        None,
+        Some(&policy_dir),
+    );
+
+    // The policy file may either be omitted from the list entirely or included as inactive.
+    // The invariant we care about is that it is never active for non-Claude agents.
+    let policy_path = policy_dir.join("CLAUDE.md");
+    let active_policy_files: Vec<&InstructionFile> = files
+        .iter()
+        .filter(|f| f.path == policy_path && f.active)
+        .collect();
+    assert!(
+        active_policy_files.is_empty(),
+        "Managed-policy CLAUDE.md must NOT be active for Codex agent. Got: {active_policy_files:?}"
+    );
+}
+
+#[test]
+fn discover_managed_policy_inactive_for_gemini() {
+    let tmp = TempDir::new().expect("tempdir");
+    let policy_dir = tmp.path().join("policy");
+    fs::create_dir_all(&policy_dir).expect("create policy dir");
+    fs::write(policy_dir.join("CLAUDE.md"), "managed policy").expect("write policy CLAUDE.md");
+
+    let cwd = tmp.path().join("work");
+    fs::create_dir_all(&cwd).expect("create cwd");
+
+    let files = discover_all_instruction_files_with_paths(
+        &cwd,
+        Some(AgentKindSimple::Gemini),
+        None,
+        Some(&policy_dir),
+    );
+
+    let policy_path = policy_dir.join("CLAUDE.md");
+    let active_policy_files: Vec<&InstructionFile> = files
+        .iter()
+        .filter(|f| f.path == policy_path && f.active)
+        .collect();
+    assert!(
+        active_policy_files.is_empty(),
+        "Managed-policy CLAUDE.md must NOT be active for Gemini agent. Got: {active_policy_files:?}"
+    );
+}


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- Make instruction-file discovery agent-aware so the startup info box (and `/status`, `/memory`) lists what each agent actually loads. Claude now walks the full ancestor chain to filesystem root per the [official Claude Code memory loader](https://code.claude.com/docs/en/memory); Codex and Gemini keep their git-root cutoffs.
- Add discovery of the platform-specific managed-policy CLAUDE.md (e.g. `/etc/claude-code/CLAUDE.md` on Linux) for Claude only.
- Add path-based deduplication so files reachable through multiple passes (ancestor walk, home config, managed policy) appear exactly once.

Fixes the user-reported bug where cwd `/tmp/bar/baz` with `.claude/CLAUDE.md` files in both `/tmp/bar/baz/.claude/` and `/tmp/bar/.claude/` only displayed the cwd one.

## Test Plan
- [x] `cargo test -p nori-tui` (1209 tests, 0 failed)
- [x] `cargo test -p tui-pty-e2e` (all green)
- [x] `just fix -p nori-tui` (no warnings)
- [x] TUI puppeteering with elizacp confirms no panic and prompt accepts input
- [ ] CI green

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets