### PR TITLE
feat(resume): Add transcript-backed resume command

### DIFF
--- a/nori-rs/acp/docs.md
+++ b/nori-rs/acp/docs.md
@@ -673,6 +673,8 @@ Key methods:
 - `list_session_metadata()`: List first-line-only session metadata for a specific project
 - `find_sessions_for_cwd()`: Find sessions for current working directory
 - `find_session_metadata_for_cwd()`: Find first-line-only session metadata for current working directory
+- `find_session_metadata_by_id()`: Find first-line-only session metadata by transcript session ID across all projects
+- `list_resumable_session_metadata()`: List first-line-only session metadata for startup resume, optionally scoped to a cwd and/or agent
 - `load_transcript()`: Load complete transcript with all entries
 - `load_session_meta()`: Load just session metadata (for quick listing)
 - `load_first_user_preview()`: Stream lines until the first user entry, bounded for picker preview loading
@@ -680,12 +682,12 @@ Key methods:
 
 **Forward/backward compatibility:** `load_transcript_from_path()` gracefully skips JSONL lines that fail to deserialize after the first line (session metadata). This means transcripts remain loadable across schema changes -- older binaries skip unknown entry types written by newer versions, and newer binaries skip removed entry types from older transcripts (e.g., the removed `turn_lifecycle` variant). The first line must always be valid `SessionMeta`; a deserialization failure there is a hard error. Skipped lines are logged at `tracing::debug` level. `load_session_meta_from_path()` is unaffected since it only reads the first line.
 
-Large transcript paths avoid full-file reads when building `/resume` picker rows. `SessionMetadata` intentionally contains only fields available from the `session_meta` line so callers can filter and display initial rows without counting or parsing the transcript body. Preview and turn-count helpers are separate streaming operations used after the picker is visible.
+Large transcript paths avoid full-file reads when building `/resume` and startup `nori resume` picker rows. `SessionMetadata` intentionally contains only fields available from the `session_meta` line so callers can filter and display initial rows without counting or parsing the transcript body. Preview and turn-count helpers are separate streaming operations used after picker rows are visible.
 
 **ACP Integration:**
 
 The `AcpBackend` automatically:
-1. Creates a `TranscriptRecorder` on spawn or resume (with graceful fallback if creation fails), persisting `acp_session_id` for session resume support
+1. Creates a `TranscriptRecorder` on spawn or resume (with graceful fallback if creation fails), persisting `acp_session_id` for session resume support. When recorder creation succeeds, the backend uses the transcript session ID as the conversation ID so exit hints such as `nori resume <session-id>` point at the saved transcript.
 2. Records user messages when `Op::UserInput` is processed
 3. Accumulates assistant text during the turn and records when turn completes
 4. Records normalized ACP session events via `record_client_event()` in the update and approval handlers

--- a/nori-rs/acp/src/backend/session.rs
+++ b/nori-rs/acp/src/backend/session.rs
@@ -262,7 +262,6 @@ impl AcpBackend {
         ));
         let idle_timer_abort = Arc::new(Mutex::new(None));
         let (approval_policy_tx, approval_policy_rx) = watch::channel(config.approval_policy);
-        let conversation_id = ConversationId::new();
         let (history_log_id, history_entry_count) =
             crate::message_history::history_metadata(&config.nori_home).await;
 
@@ -281,6 +280,10 @@ impl AcpBackend {
                 None
             }
         };
+        let conversation_id = transcript_recorder
+            .as_ref()
+            .and_then(|recorder| ConversationId::from_string(recorder.session_id()).ok())
+            .unwrap_or_default();
 
         let backend = Self {
             connection,

--- a/nori-rs/acp/src/backend/spawn_and_relay.rs
+++ b/nori-rs/acp/src/backend/spawn_and_relay.rs
@@ -122,9 +122,6 @@ impl AcpBackend {
         // Create watch channel for dynamic approval policy updates
         let (approval_policy_tx, approval_policy_rx) = watch::channel(config.approval_policy);
 
-        // Create conversation ID for this session
-        let conversation_id = ConversationId::new();
-
         // Get history metadata
         let (history_log_id, history_entry_count) =
             crate::message_history::history_metadata(&config.nori_home).await;
@@ -145,6 +142,10 @@ impl AcpBackend {
                 None
             }
         };
+        let conversation_id = transcript_recorder
+            .as_ref()
+            .and_then(|recorder| ConversationId::from_string(recorder.session_id()).ok())
+            .unwrap_or_default();
 
         let backend = Self {
             connection,

--- a/nori-rs/acp/src/transcript/loader.rs
+++ b/nori-rs/acp/src/transcript/loader.rs
@@ -313,6 +313,46 @@ impl TranscriptLoader {
         self.list_session_metadata(&project_id.id).await
     }
 
+    /// Find one session by its transcript session id across all known projects.
+    pub async fn find_session_metadata_by_id(
+        &self,
+        session_id: &str,
+    ) -> io::Result<Option<SessionMetadata>> {
+        for project in self.list_projects().await? {
+            let sessions = self.list_session_metadata(&project.id).await?;
+            if let Some(session) = sessions
+                .into_iter()
+                .find(|session| session.session_id == session_id)
+            {
+                return Ok(Some(session));
+            }
+        }
+        Ok(None)
+    }
+
+    /// List transcript session metadata for startup resume flows.
+    pub async fn list_resumable_session_metadata(
+        &self,
+        cwd: Option<&Path>,
+        agent_filter: Option<&str>,
+    ) -> io::Result<Vec<SessionMetadata>> {
+        let mut sessions = if let Some(cwd) = cwd {
+            self.find_session_metadata_for_cwd(cwd).await?
+        } else {
+            let mut sessions = Vec::new();
+            for project in self.list_projects().await? {
+                sessions.extend(self.list_session_metadata(&project.id).await?);
+            }
+            sessions
+        };
+
+        if let Some(agent_filter) = agent_filter {
+            sessions.retain(|session| session.agent.as_deref() == Some(agent_filter));
+        }
+        sessions.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        Ok(sessions)
+    }
+
     /// Load a complete transcript for display.
     pub async fn load_transcript(
         &self,
@@ -1019,6 +1059,64 @@ mod tests {
         assert_eq!(sessions[0].session_id, session_id);
         assert_eq!(sessions[0].project_id, project_id);
         assert_eq!(sessions[0].agent.as_deref(), Some("codex"));
+    }
+
+    #[tokio::test]
+    async fn find_session_metadata_by_id_finds_sessions_across_projects() {
+        let temp_dir = TempDir::new().unwrap();
+        let nori_home = temp_dir.path();
+        let first_cwd = nori_home.join("first");
+        let second_cwd = nori_home.join("second");
+        tokio::fs::create_dir_all(&first_cwd).await.unwrap();
+        tokio::fs::create_dir_all(&second_cwd).await.unwrap();
+
+        let first_recorder = TranscriptRecorder::new(
+            nori_home,
+            &first_cwd,
+            Some("claude-code".to_string()),
+            "0.1.0",
+            None,
+        )
+        .await
+        .unwrap();
+        first_recorder.shutdown().await.unwrap();
+
+        let second_recorder = TranscriptRecorder::new(
+            nori_home,
+            &second_cwd,
+            Some("codex".to_string()),
+            "0.1.0",
+            None,
+        )
+        .await
+        .unwrap();
+        let second_session_id = second_recorder.session_id().to_string();
+        let second_project_id = second_recorder.project_id().to_string();
+        second_recorder.shutdown().await.unwrap();
+
+        let loader = TranscriptLoader::new(nori_home.to_path_buf());
+        let found = loader
+            .find_session_metadata_by_id(&second_session_id)
+            .await
+            .unwrap()
+            .expect("session should be found");
+
+        assert_eq!(found.session_id, second_session_id);
+        assert_eq!(found.project_id, second_project_id);
+        assert_eq!(found.agent.as_deref(), Some("codex"));
+    }
+
+    #[tokio::test]
+    async fn find_session_metadata_by_id_returns_none_for_missing_session() {
+        let temp_dir = TempDir::new().unwrap();
+        let loader = TranscriptLoader::new(temp_dir.path().to_path_buf());
+
+        let found = loader
+            .find_session_metadata_by_id("missing-session")
+            .await
+            .unwrap();
+
+        assert!(found.is_none());
     }
 
     #[tokio::test]

--- a/nori-rs/cli/docs.md
+++ b/nori-rs/cli/docs.md
@@ -26,9 +26,17 @@ This crate is the primary entry point that ties together the core crates:
 **WindowsCommand**: Windows sandbox testing with:
 - `--full-auto` - Restricted token sandbox with cwd/TMPDIR write access
 
+**ResumeCommand**: Starts the TUI from a saved transcript session:
+- `nori resume` - Opens the startup session picker for the current working directory
+- `nori resume <session-id>` - Resumes a saved session by transcript session ID
+- `nori resume --last` - Resumes the newest saved session for the current working directory
+- `nori resume --all` - Lets picker/last selection search all transcript projects instead of only the current working directory
+- TUI flags such as `--agent`, `--profile`, `--sandbox`, prompts, images, `-c`, and working-directory overrides can be passed after `resume`; they are merged into the normal interactive CLI configuration before `nori_tui::run_main()`
+
 ```rust
 match subcommand {
     None => nori_tui::run_main(...),           // Interactive TUI
+    Some(Subcommand::Resume(cmd)) => nori_tui::run_main(...),
     Some(Subcommand::Login(cli)) => run_login_*(...),
     Some(Subcommand::Sandbox(args)) => debug_sandbox::run_*(...),
     Some(Subcommand::Skillsets(cmd)) => run_skillsets_command(...),
@@ -101,6 +109,16 @@ These allow testing sandbox behavior without running the full TUI. All commands 
 1. Subcommand-specific flags (highest)
 2. Root-level `-c` overrides
 3. Config file (lowest)
+
+For `nori resume`, subcommand-scoped interactive flags are copied into the same `TuiCli` structure used by a fresh interactive launch. If both root-level and resume-scoped flags are present, the resume-scoped flag wins for that field while preserving unrelated root-level settings.
+
+**Startup Resume:**
+
+`nori resume` is the top-level counterpart to the in-TUI `/resume` command. It resolves saved sessions through Nori's transcript metadata instead of external provider rollout files:
+- `nori resume <session-id>` searches all transcript projects by session ID.
+- `nori resume --last` selects the newest saved session, scoped to the current working directory unless `--all` is present.
+- `nori resume` without an ID opens a picker, scoped to the current working directory unless `--all` is present.
+- If the saved session metadata records an agent, that recorded agent is used automatically. Passing a different `--agent` is a startup error so the command never resumes a session with the wrong agent.
 
 **Process Hardening:**
 

--- a/nori-rs/cli/src/main.rs
+++ b/nori-rs/cli/src/main.rs
@@ -85,12 +85,33 @@ enum Subcommand {
 
     /// Generate shell completion scripts.
     Completions(CompletionsCommand),
+
+    /// Resume a previous interactive session (picker by default; use --last to continue the most recent).
+    Resume(ResumeCommand),
 }
 
 #[derive(Debug, Parser)]
 struct CompletionsCommand {
     /// The shell to generate completions for.
     shell: clap_complete::Shell,
+}
+
+#[derive(Debug, Parser)]
+struct ResumeCommand {
+    /// Session id (UUID). If omitted, use --last or choose from the picker.
+    #[arg(value_name = "SESSION_ID")]
+    session_id: Option<String>,
+
+    /// Continue the most recent session without showing the picker.
+    #[arg(long = "last", default_value_t = false)]
+    last: bool,
+
+    /// Show all sessions instead of filtering to the current working directory.
+    #[arg(long = "all", default_value_t = false)]
+    all: bool,
+
+    #[clap(flatten)]
+    config_overrides: TuiCli,
 }
 
 #[derive(Debug, Parser)]
@@ -457,6 +478,23 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
         Some(Subcommand::Skillsets(cmd)) => {
             run_skillsets_command(cmd)?;
         }
+        Some(Subcommand::Resume(ResumeCommand {
+            session_id,
+            last,
+            all,
+            config_overrides,
+        })) => {
+            interactive = finalize_resume_interactive(
+                interactive,
+                root_config_overrides.clone(),
+                session_id,
+                last,
+                all,
+                config_overrides,
+            );
+            let exit_info = nori_tui::run_main(interactive, codex_linux_sandbox_exe).await?;
+            handle_app_exit(exit_info)?;
+        }
         Some(Subcommand::Execpolicy(ExecpolicyCommand { sub })) => match sub {
             ExecpolicySubcommand::Check(cmd) => run_execpolicycheck(cmd)?,
         },
@@ -489,12 +527,91 @@ fn prepend_config_flags(
         .splice(0..0, cli_config_overrides.raw_overrides);
 }
 
+fn finalize_resume_interactive(
+    mut interactive: TuiCli,
+    root_config_overrides: CliConfigOverrides,
+    session_id: Option<String>,
+    last: bool,
+    show_all: bool,
+    resume_cli: TuiCli,
+) -> TuiCli {
+    interactive.resume_picker = session_id.is_none() && !last;
+    interactive.resume_last = last;
+    interactive.resume_session_id = session_id;
+    interactive.resume_show_all = show_all;
+    merge_interactive_cli_flags(&mut interactive, resume_cli);
+    prepend_config_flags(&mut interactive.config_overrides, root_config_overrides);
+    interactive
+}
+
+fn merge_interactive_cli_flags(interactive: &mut TuiCli, subcommand_cli: TuiCli) {
+    if let Some(prompt) = subcommand_cli.prompt {
+        interactive.prompt = Some(prompt.replace("\r\n", "\n").replace('\r', "\n"));
+    }
+    if !subcommand_cli.images.is_empty() {
+        interactive.images = subcommand_cli.images;
+    }
+    if let Some(agent) = subcommand_cli.agent {
+        interactive.agent = Some(agent);
+    }
+    if let Some(profile) = subcommand_cli.config_profile {
+        interactive.config_profile = Some(profile);
+    }
+    if subcommand_cli.dangerously_bypass_approvals_and_sandbox {
+        interactive.dangerously_bypass_approvals_and_sandbox = true;
+    }
+    if let Some(cwd) = subcommand_cli.cwd {
+        interactive.cwd = Some(cwd);
+    }
+    if !subcommand_cli.add_dir.is_empty() {
+        interactive.add_dir.extend(subcommand_cli.add_dir);
+    }
+    if subcommand_cli.skip_welcome {
+        interactive.skip_welcome = true;
+    }
+    if subcommand_cli.skip_trust_directory {
+        interactive.skip_trust_directory = true;
+    }
+    interactive
+        .config_overrides
+        .raw_overrides
+        .extend(subcommand_cli.config_overrides.raw_overrides);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use codex_core::protocol::TokenUsage;
     use codex_protocol::ConversationId;
     use pretty_assertions::assert_eq;
+
+    fn finalize_resume_from_args(args: &[&str]) -> TuiCli {
+        let cli = MultitoolCli::try_parse_from(args).expect("parse");
+        let MultitoolCli {
+            interactive,
+            config_overrides: root_overrides,
+            subcommand,
+        } = cli;
+
+        let Subcommand::Resume(ResumeCommand {
+            session_id,
+            last,
+            all,
+            config_overrides: resume_cli,
+        }) = subcommand.expect("resume present")
+        else {
+            unreachable!()
+        };
+
+        finalize_resume_interactive(
+            interactive,
+            root_overrides,
+            session_id,
+            last,
+            all,
+            resume_cli,
+        )
+    }
 
     fn sample_exit_info(conversation: Option<&str>) -> AppExitInfo {
         let token_usage = TokenUsage {
@@ -542,6 +659,83 @@ mod tests {
         let lines = format_exit_messages(exit_info, true);
         assert_eq!(lines.len(), 2);
         assert!(lines[1].contains("\u{1b}[36m"));
+    }
+
+    #[test]
+    fn resume_picker_logic_none_and_not_last() {
+        let interactive = finalize_resume_from_args(["nori", "resume"].as_ref());
+        assert!(interactive.resume_picker);
+        assert!(!interactive.resume_last);
+        assert_eq!(interactive.resume_session_id, None);
+        assert!(!interactive.resume_show_all);
+    }
+
+    #[test]
+    fn resume_picker_logic_last() {
+        let interactive = finalize_resume_from_args(["nori", "resume", "--last"].as_ref());
+        assert!(!interactive.resume_picker);
+        assert!(interactive.resume_last);
+        assert_eq!(interactive.resume_session_id, None);
+    }
+
+    #[test]
+    fn resume_picker_logic_with_session_id() {
+        let interactive = finalize_resume_from_args(["nori", "resume", "session-123"].as_ref());
+        assert!(!interactive.resume_picker);
+        assert!(!interactive.resume_last);
+        assert_eq!(
+            interactive.resume_session_id.as_deref(),
+            Some("session-123")
+        );
+    }
+
+    #[test]
+    fn resume_all_flag_sets_show_all() {
+        let interactive = finalize_resume_from_args(["nori", "resume", "--all"].as_ref());
+        assert!(interactive.resume_picker);
+        assert!(interactive.resume_show_all);
+    }
+
+    #[test]
+    fn resume_merges_resume_scoped_interactive_flags() {
+        let interactive = finalize_resume_from_args(
+            [
+                "nori",
+                "resume",
+                "session-123",
+                "--agent",
+                "codex",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "-C",
+                "/tmp",
+                "-i",
+                "/tmp/a.png,/tmp/b.png",
+                "--skip-welcome",
+                "--skip-trust-directory",
+            ]
+            .as_ref(),
+        );
+
+        assert_eq!(interactive.agent.as_deref(), Some("codex"));
+        assert!(interactive.dangerously_bypass_approvals_and_sandbox);
+        assert_eq!(
+            interactive.cwd.as_deref(),
+            Some(std::path::Path::new("/tmp"))
+        );
+        assert!(
+            interactive
+                .images
+                .iter()
+                .any(|path| path == std::path::Path::new("/tmp/a.png"))
+        );
+        assert!(
+            interactive
+                .images
+                .iter()
+                .any(|path| path == std::path::Path::new("/tmp/b.png"))
+        );
+        assert!(interactive.skip_welcome);
+        assert!(interactive.skip_trust_directory);
     }
 
     /// Binary name should be "nori" in help output

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -718,6 +718,34 @@ Rendering behavior:
 
 The async flow uses three AppEvents: `ShowViewonlySessionPicker` -> `LoadViewonlyTranscript` -> `DisplayViewonlyTranscript`.
 
+**Startup Session Resume (`nori resume`):**
+
+The top-level `nori resume` subcommand enters the TUI with an existing transcript session already selected. This path is handled before `App::run()` constructs the chat widget:
+
+```
+nori resume [session-id]
+    |
+    v
+run_main() -> run_ratatui_app()
+    |  (resolves metadata by ID, --last, or startup picker)
+    v
+ResumeSelection::Resume(ResumeTarget)
+    |  (loads full Transcript, extracts acp_session_id as Option<String>)
+    v
+ChatWidget::new_resumed_acp(init, acp_session_id, transcript)
+    |
+    v
+spawn_acp_agent_resume() -> AcpBackend::resume_session()
+```
+
+Selection behavior:
+- `nori resume <session-id>` searches all transcript projects for that exact session ID.
+- `nori resume --last` chooses the newest transcript for the current working directory; `--all` removes the cwd filter.
+- `nori resume` opens `resume_picker/`, which lists metadata-only transcript rows and returns a `ResumeTarget`.
+- `--agent` is optional. When omitted, the recorded `session_meta.agent` is used. When present, it must match the recorded agent or startup fails with a clear error.
+
+The startup picker in `@/nori-rs/tui/src/resume_picker/` is transcript-backed. It uses `TranscriptLoader::list_resumable_session_metadata()` and keeps rows lightweight by reading only `session_meta` lines before selection. It does not perform provider-specific rollout discovery.
+
 **Session Resume (`/resume`):**
 
 The `/resume` command allows reconnecting to a previous ACP session. It uses the ACP agent's `session/load` RPC when available, and otherwise falls back to a fresh ACP session plus normalized replay derived from the saved transcript (see `@/nori-rs/acp/docs.md`).

--- a/nori-rs/tui/src/app/mod.rs
+++ b/nori-rs/tui/src/app/mod.rs
@@ -82,7 +82,7 @@ fn session_summary(
 
     let usage_line = FinalOutput::from(token_usage).to_string();
     let resume_command =
-        conversation_id.map(|conversation_id| format!("codex resume {conversation_id}"));
+        conversation_id.map(|conversation_id| format!("nori resume {conversation_id}"));
     Some(SessionSummary {
         usage_line,
         resume_command,
@@ -293,13 +293,6 @@ impl App {
     ) -> Result<AppExitInfo> {
         use tokio_stream::StreamExt;
 
-        if matches!(resume_selection, ResumeSelection::Resume(_)) {
-            tracing::warn!(
-                "Startup resume via --resume is not supported with ACP backend. \
-                 Use the /resume command within a session instead."
-            );
-        }
-
         let (app_event_tx, mut app_event_rx) = unbounded_channel();
         let app_event_tx = AppEventSender::new(app_event_tx);
 
@@ -341,7 +334,17 @@ impl App {
                 deferred_spawn: needs_deferred_spawn,
                 fork_context: None,
             };
-            ChatWidget::new(init)
+            match resume_selection {
+                ResumeSelection::Resume(target) => {
+                    let loader = nori_acp::transcript::TranscriptLoader::new(target.nori_home);
+                    let transcript = loader
+                        .load_transcript(&target.project_id, &target.session_id)
+                        .await?;
+                    let acp_session_id = transcript.meta.acp_session_id.clone();
+                    ChatWidget::new_resumed_acp(init, acp_session_id, transcript)
+                }
+                ResumeSelection::StartFresh | ResumeSelection::Exit => ChatWidget::new(init),
+            }
         };
 
         chat_widget.maybe_prompt_windows_sandbox_enable();

--- a/nori-rs/tui/src/app/tests.rs
+++ b/nori-rs/tui/src/app/tests.rs
@@ -411,7 +411,7 @@ fn session_summary_includes_resume_hint() {
     );
     assert_eq!(
         summary.resume_command,
-        Some("codex resume 123e4567-e89b-12d3-a456-426614174000".to_string())
+        Some("nori resume 123e4567-e89b-12d3-a456-426614174000".to_string())
     );
 }
 

--- a/nori-rs/tui/src/cli.rs
+++ b/nori-rs/tui/src/cli.rs
@@ -14,8 +14,8 @@ pub struct Cli {
     #[arg(long = "image", short = 'i', value_name = "FILE", value_delimiter = ',', num_args = 1..)]
     pub images: Vec<PathBuf>,
 
-    // Internal controls set by the top-level `codex resume` subcommand.
-    // These are not exposed as user flags on the base `codex` command.
+    // Internal controls set by the top-level `nori resume` subcommand.
+    // These are not exposed as user flags on the base `nori` command.
     #[clap(skip)]
     pub resume_picker: bool,
 
@@ -23,7 +23,7 @@ pub struct Cli {
     pub resume_last: bool,
 
     /// Internal: resume a specific recorded session by id (UUID). Set by the
-    /// top-level `codex resume <SESSION_ID>` wrapper; not exposed as a public flag.
+    /// top-level `nori resume <SESSION_ID>` wrapper; not exposed as a public flag.
     #[clap(skip)]
     pub resume_session_id: Option<String>,
 

--- a/nori-rs/tui/src/lib.rs
+++ b/nori-rs/tui/src/lib.rs
@@ -9,16 +9,15 @@ pub use app::AppExitInfo;
 use codex_app_server_protocol::AuthMode;
 use codex_core::AuthManager;
 use codex_core::CodexAuth;
-use codex_core::INTERACTIVE_SESSION_SOURCES;
-use codex_core::RolloutRecorder;
 use codex_core::auth::enforce_login_restrictions;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
 use codex_core::config::find_codex_home;
-use codex_core::find_conversation_path_by_id_str;
 use codex_core::get_platform_sandbox;
 use codex_core::protocol::AskForApproval;
 use codex_protocol::config_types::SandboxMode;
+use nori_acp::transcript::SessionMetadata;
+use nori_acp::transcript::TranscriptLoader;
 #[cfg(feature = "otel")]
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use std::fs::OpenOptions;
@@ -477,7 +476,7 @@ async fn run_ratatui_app(
 
     // Auto-worktree "ask" mode: show a TUI popup asking the user.
     // If they confirm, create the worktree and reload config with the new cwd.
-    let config = if pending_worktree_ask {
+    let mut config = if pending_worktree_ask {
         let effective_cwd = config.cwd.clone();
         let user_wants_worktree = nori::worktree_ask::run_worktree_ask_popup(&mut tui).await?;
         if user_wants_worktree {
@@ -500,52 +499,64 @@ async fn run_ratatui_app(
         config
     };
 
+    let resume_agent_filter = cli.agent.as_deref();
+    let transcript_loader = TranscriptLoader::new(config.codex_home.clone());
+
     // Determine resume behavior: explicit id, then resume last, then picker.
     let resume_selection = if let Some(id_str) = cli.resume_session_id.as_deref() {
-        match find_conversation_path_by_id_str(&config.codex_home, id_str).await? {
-            Some(path) => resume_picker::ResumeSelection::Resume(path),
-            None => {
-                error!("Error finding conversation path: {id_str}");
-                restore();
-                session_log::log_session_end();
-                let _ = tui.terminal.clear();
-                if let Err(err) = writeln!(
-                    std::io::stdout(),
-                    "No saved session found with ID {id_str}. Run `codex resume` without an ID to choose from existing sessions."
-                ) {
-                    error!("Failed to write resume error message: {err}");
+        match transcript_loader
+            .find_session_metadata_by_id(id_str)
+            .await?
+        {
+            Some(metadata) => match resume_target_from_metadata(
+                config.codex_home.clone(),
+                metadata,
+                resume_agent_filter,
+            ) {
+                Ok(target) => resume_picker::ResumeSelection::Resume(target),
+                Err(message) => {
+                    return resume_startup_error(&mut tui, message);
                 }
-                return Ok(AppExitInfo {
-                    token_usage: codex_core::protocol::TokenUsage::default(),
-                    conversation_id: None,
-                    update_action: None,
-                });
+            },
+            None => {
+                return resume_startup_error(
+                    &mut tui,
+                    format!(
+                        "No saved session found with ID {id_str}. Run `nori resume` without an ID to choose from existing sessions."
+                    ),
+                );
             }
         }
     } else if cli.resume_last {
-        let provider_filter = vec![config.model_provider_id.clone()];
-        match RolloutRecorder::list_conversations(
-            &config.codex_home,
-            1,
-            None,
-            INTERACTIVE_SESSION_SOURCES,
-            Some(provider_filter.as_slice()),
-            &config.model_provider_id,
-        )
-        .await
+        let filter_cwd = if cli.resume_show_all {
+            None
+        } else {
+            Some(config.cwd.as_path())
+        };
+        match transcript_loader
+            .list_resumable_session_metadata(filter_cwd, resume_agent_filter)
+            .await
         {
-            Ok(page) => page
-                .items
-                .first()
-                .map(|it| resume_picker::ResumeSelection::Resume(it.path.clone()))
-                .unwrap_or(resume_picker::ResumeSelection::StartFresh),
+            Ok(sessions) => match sessions.into_iter().next() {
+                Some(metadata) => match resume_target_from_metadata(
+                    config.codex_home.clone(),
+                    metadata,
+                    resume_agent_filter,
+                ) {
+                    Ok(target) => resume_picker::ResumeSelection::Resume(target),
+                    Err(message) => {
+                        return resume_startup_error(&mut tui, message);
+                    }
+                },
+                None => resume_picker::ResumeSelection::StartFresh,
+            },
             Err(_) => resume_picker::ResumeSelection::StartFresh,
         }
     } else if cli.resume_picker {
         match resume_picker::run_resume_picker(
             &mut tui,
             &config.codex_home,
-            &config.model_provider_id,
+            resume_agent_filter,
             cli.resume_show_all,
         )
         .await?
@@ -564,6 +575,12 @@ async fn run_ratatui_app(
     } else {
         resume_picker::ResumeSelection::StartFresh
     };
+
+    if let resume_picker::ResumeSelection::Resume(target) = &resume_selection
+        && let Some(agent) = target.agent.as_ref()
+    {
+        config.model = agent.clone();
+    }
 
     let Cli { prompt, images, .. } = cli;
 
@@ -584,6 +601,44 @@ async fn run_ratatui_app(
     session_log::log_session_end();
     // ignore error when collecting usage – report underlying error instead
     app_result
+}
+
+fn resume_target_from_metadata(
+    nori_home: PathBuf,
+    metadata: SessionMetadata,
+    requested_agent: Option<&str>,
+) -> std::result::Result<resume_picker::ResumeTarget, String> {
+    if let (Some(requested_agent), Some(recorded_agent)) =
+        (requested_agent, metadata.agent.as_deref())
+        && requested_agent != recorded_agent
+    {
+        return Err(format!(
+            "Session {} was recorded with agent `{recorded_agent}`, but `--agent {requested_agent}` was requested.",
+            metadata.session_id
+        ));
+    }
+
+    Ok(resume_picker::ResumeTarget {
+        nori_home,
+        project_id: metadata.project_id,
+        session_id: metadata.session_id,
+        agent: metadata.agent,
+    })
+}
+
+fn resume_startup_error(tui: &mut Tui, message: String) -> color_eyre::Result<AppExitInfo> {
+    error!("{message}");
+    restore();
+    session_log::log_session_end();
+    let _ = tui.terminal.clear();
+    if let Err(err) = writeln!(std::io::stdout(), "{message}") {
+        error!("Failed to write resume error message: {err}");
+    }
+    Ok(AppExitInfo {
+        token_usage: codex_core::protocol::TokenUsage::default(),
+        conversation_id: None,
+        update_action: None,
+    })
 }
 
 #[expect(
@@ -682,6 +737,41 @@ mod tests {
     use codex_core::config::ProjectConfig;
     use serial_test::serial;
     use tempfile::TempDir;
+
+    fn session_metadata(agent: Option<&str>) -> SessionMetadata {
+        SessionMetadata {
+            session_id: "session-123".to_string(),
+            project_id: "project-123".to_string(),
+            started_at: "2025-01-01T00:00:00Z".to_string(),
+            cwd: PathBuf::from("/tmp/project"),
+            agent: agent.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn resume_target_uses_recorded_agent_when_agent_not_requested() {
+        let target = resume_target_from_metadata(
+            PathBuf::from("/tmp/nori-home"),
+            session_metadata(Some("codex")),
+            None,
+        )
+        .expect("recorded agent should be accepted");
+
+        assert_eq!(target.agent.as_deref(), Some("codex"));
+    }
+
+    #[test]
+    fn resume_target_rejects_requested_agent_mismatch() {
+        let error = resume_target_from_metadata(
+            PathBuf::from("/tmp/nori-home"),
+            session_metadata(Some("codex")),
+            Some("claude-code"),
+        )
+        .expect_err("mismatched agent should be rejected");
+
+        assert!(error.contains("recorded with agent `codex`"));
+        assert!(error.contains("--agent claude-code"));
+    }
 
     #[test]
     #[serial]

--- a/nori-rs/tui/src/resume_picker/helpers.rs
+++ b/nori-rs/tui/src/resume_picker/helpers.rs
@@ -1,46 +1,31 @@
 use super::*;
 
-pub(super) fn rows_from_items(items: Vec<ConversationItem>) -> Vec<Row> {
-    items.into_iter().map(|item| head_to_row(&item)).collect()
+pub(super) fn rows_from_items(items: Vec<SessionMetadata>, nori_home: PathBuf) -> Vec<Row> {
+    items
+        .into_iter()
+        .map(|item| metadata_to_row(item, nori_home.clone()))
+        .collect()
 }
 
-fn head_to_row(item: &ConversationItem) -> Row {
-    let created_at = item
-        .created_at
-        .as_deref()
-        .and_then(parse_timestamp_str)
-        .or_else(|| item.head.first().and_then(extract_timestamp));
-    let updated_at = item
-        .updated_at
-        .as_deref()
-        .and_then(parse_timestamp_str)
-        .or(created_at);
-
-    let (cwd, git_branch) = extract_session_meta_from_head(&item.head);
-    let preview = preview_from_head(&item.head)
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| String::from("(no message yet)"));
+fn metadata_to_row(item: SessionMetadata, nori_home: PathBuf) -> Row {
+    let created_at = parse_timestamp_str(&item.started_at);
+    let updated_at = created_at;
+    let cwd = Some(item.cwd.clone());
+    let preview = item.session_id.clone();
 
     Row {
-        path: item.path.clone(),
+        target: ResumeTarget {
+            nori_home,
+            project_id: item.project_id,
+            session_id: item.session_id,
+            agent: item.agent,
+        },
         preview,
         created_at,
         updated_at,
         cwd,
-        git_branch,
+        git_branch: None,
     }
-}
-
-fn extract_session_meta_from_head(head: &[serde_json::Value]) -> (Option<PathBuf>, Option<String>) {
-    for value in head {
-        if let Ok(meta_line) = serde_json::from_value::<SessionMetaLine>(value.clone()) {
-            let cwd = Some(meta_line.meta.cwd);
-            let git_branch = meta_line.git.and_then(|git| git.branch);
-            return (cwd, git_branch);
-        }
-    }
-    (None, None)
 }
 
 pub(super) fn paths_match(a: &Path, b: &Path) -> bool {
@@ -54,23 +39,6 @@ fn parse_timestamp_str(ts: &str) -> Option<DateTime<Utc>> {
     chrono::DateTime::parse_from_rfc3339(ts)
         .map(|dt| dt.with_timezone(&Utc))
         .ok()
-}
-
-fn extract_timestamp(value: &serde_json::Value) -> Option<DateTime<Utc>> {
-    value
-        .get("timestamp")
-        .and_then(|v| v.as_str())
-        .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
-        .map(|dt| dt.with_timezone(&Utc))
-}
-
-pub(super) fn preview_from_head(head: &[serde_json::Value]) -> Option<String> {
-    head.iter()
-        .filter_map(|value| serde_json::from_value::<ResponseItem>(value.clone()).ok())
-        .find_map(|item| match codex_core::parse_turn_item(&item) {
-            Some(TurnItem::UserMessage(user)) => Some(user.message()),
-            _ => None,
-        })
 }
 
 pub(super) fn human_time_ago(ts: DateTime<Utc>) -> String {

--- a/nori-rs/tui/src/resume_picker/mod.rs
+++ b/nori-rs/tui/src/resume_picker/mod.rs
@@ -5,16 +5,13 @@ use std::sync::Arc;
 
 use chrono::DateTime;
 use chrono::Utc;
-use codex_core::ConversationItem;
-use codex_core::ConversationsPage;
 use codex_core::Cursor;
-use codex_core::INTERACTIVE_SESSION_SOURCES;
-use codex_core::RolloutRecorder;
-use codex_protocol::items::TurnItem;
 use color_eyre::eyre::Result;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyEventKind;
+use nori_acp::transcript::SessionMetadata;
+use nori_acp::transcript::TranscriptLoader;
 use ratatui::layout::Constraint;
 use ratatui::layout::Layout;
 use ratatui::layout::Rect;
@@ -32,8 +29,6 @@ use crate::text_formatting::truncate_text;
 use crate::tui::FrameRequester;
 use crate::tui::Tui;
 use crate::tui::TuiEvent;
-use codex_protocol::models::ResponseItem;
-use codex_protocol::protocol::SessionMetaLine;
 
 mod helpers;
 mod rendering;
@@ -41,27 +36,29 @@ mod state;
 #[cfg(test)]
 mod tests;
 
-const PAGE_SIZE: usize = 25;
 const LOAD_NEAR_THRESHOLD: usize = 5;
+
+#[derive(Debug, Clone)]
+pub struct ResumeTarget {
+    pub nori_home: PathBuf,
+    pub project_id: String,
+    pub session_id: String,
+    pub agent: Option<String>,
+}
 
 #[derive(Debug, Clone)]
 pub enum ResumeSelection {
     StartFresh,
-    /// Previously used for HTTP-backend resume. The PathBuf is still
-    /// constructed by the resume picker but no longer consumed by
-    /// `App::run()` because ACP resume goes through a different path.
-    #[allow(dead_code)]
-    Resume(PathBuf),
+    Resume(ResumeTarget),
     Exit,
 }
 
 #[derive(Clone)]
 struct PageLoadRequest {
-    pub(super) codex_home: PathBuf,
-    pub(super) cursor: Option<Cursor>,
+    pub(super) nori_home: PathBuf,
     pub(super) request_token: usize,
     pub(super) search_token: Option<usize>,
-    pub(super) default_provider: String,
+    pub(super) agent_filter: Option<String>,
 }
 
 type PageLoader = Arc<dyn Fn(PageLoadRequest) + Send + Sync>;
@@ -70,23 +67,30 @@ enum BackgroundEvent {
     PageLoaded {
         request_token: usize,
         search_token: Option<usize>,
-        page: std::io::Result<ConversationsPage>,
+        page: std::io::Result<TranscriptPage>,
     },
 }
 
-/// Interactive session picker that lists recorded rollout files with simple
+struct TranscriptPage {
+    items: Vec<SessionMetadata>,
+    next_cursor: Option<Cursor>,
+    num_scanned_files: usize,
+    reached_scan_cap: bool,
+}
+
+/// Interactive session picker that lists recorded Nori transcript sessions with simple
 /// search and pagination. Shows the first user input as the preview, relative
 /// time (e.g., "5 seconds ago"), and the absolute path.
 pub async fn run_resume_picker(
     tui: &mut Tui,
-    codex_home: &Path,
-    default_provider: &str,
+    nori_home: &Path,
+    agent_filter: Option<&str>,
     show_all: bool,
 ) -> Result<ResumeSelection> {
     let alt = AltScreenGuard::enter(tui);
     let (bg_tx, bg_rx) = mpsc::unbounded_channel();
 
-    let default_provider = default_provider.to_string();
+    let agent_filter = agent_filter.map(str::to_string);
     let filter_cwd = if show_all {
         None
     } else {
@@ -97,16 +101,9 @@ pub async fn run_resume_picker(
     let page_loader: PageLoader = Arc::new(move |request: PageLoadRequest| {
         let tx = loader_tx.clone();
         tokio::spawn(async move {
-            let provider_filter = vec![request.default_provider.clone()];
-            let page = RolloutRecorder::list_conversations(
-                &request.codex_home,
-                PAGE_SIZE,
-                request.cursor.as_ref(),
-                INTERACTIVE_SESSION_SOURCES,
-                Some(provider_filter.as_slice()),
-                request.default_provider.as_str(),
-            )
-            .await;
+            let page =
+                load_transcript_page(&request.nori_home, None, request.agent_filter.as_deref())
+                    .await;
             let _ = tx.send(BackgroundEvent::PageLoaded {
                 request_token: request.request_token,
                 search_token: request.search_token,
@@ -116,10 +113,10 @@ pub async fn run_resume_picker(
     });
 
     let mut state = PickerState::new(
-        codex_home.to_path_buf(),
+        nori_home.to_path_buf(),
         alt.tui.frame_requester(),
         page_loader,
-        default_provider.clone(),
+        agent_filter.clone(),
         show_all,
         filter_cwd,
     );
@@ -163,6 +160,23 @@ pub async fn run_resume_picker(
     Ok(ResumeSelection::StartFresh)
 }
 
+async fn load_transcript_page(
+    nori_home: &Path,
+    cwd: Option<&Path>,
+    agent_filter: Option<&str>,
+) -> std::io::Result<TranscriptPage> {
+    let loader = TranscriptLoader::new(nori_home.to_path_buf());
+    let items = loader
+        .list_resumable_session_metadata(cwd, agent_filter)
+        .await?;
+    Ok(TranscriptPage {
+        num_scanned_files: items.len(),
+        items,
+        next_cursor: None,
+        reached_scan_cap: false,
+    })
+}
+
 /// RAII guard that ensures we leave the alt-screen on scope exit.
 struct AltScreenGuard<'a> {
     tui: &'a mut Tui,
@@ -182,7 +196,7 @@ impl Drop for AltScreenGuard<'_> {
 }
 
 struct PickerState {
-    pub(super) codex_home: PathBuf,
+    pub(super) nori_home: PathBuf,
     pub(super) requester: FrameRequester,
     pub(super) pagination: PaginationState,
     pub(super) all_rows: Vec<Row>,
@@ -196,7 +210,7 @@ struct PickerState {
     pub(super) next_search_token: usize,
     pub(super) page_loader: PageLoader,
     pub(super) view_rows: Option<usize>,
-    pub(super) default_provider: String,
+    pub(super) agent_filter: Option<String>,
     pub(super) show_all: bool,
     pub(super) filter_cwd: Option<PathBuf>,
 }
@@ -252,7 +266,7 @@ impl SearchState {
 
 #[derive(Clone)]
 struct Row {
-    pub(super) path: PathBuf,
+    pub(super) target: ResumeTarget,
     pub(super) preview: String,
     pub(super) created_at: Option<DateTime<Utc>>,
     pub(super) updated_at: Option<DateTime<Utc>>,

--- a/nori-rs/tui/src/resume_picker/snapshots/nori_tui__resume_picker__tests__resume_picker_table.snap
+++ b/nori-rs/tui/src/resume_picker/snapshots/nori_tui__resume_picker__tests__resume_picker_table.snap
@@ -3,6 +3,5 @@ source: tui/src/resume_picker/tests.rs
 expression: snapshot
 ---
   Updated         Branch  CWD  Conversation
-  42 seconds ago  -       -    Fix resume picker timestamps
-> 35 minutes ago  -       -    Investigate lazy pagination cap
-  2 hours ago     -       -    Explain the codebase
+  42 seconds ago  -       -    session-a
+> 35 minutes ago  -       -    session-b

--- a/nori-rs/tui/src/resume_picker/state.rs
+++ b/nori-rs/tui/src/resume_picker/state.rs
@@ -2,15 +2,15 @@ use super::*;
 
 impl PickerState {
     pub(super) fn new(
-        codex_home: PathBuf,
+        nori_home: PathBuf,
         requester: FrameRequester,
         page_loader: PageLoader,
-        default_provider: String,
+        agent_filter: Option<String>,
         show_all: bool,
         filter_cwd: Option<PathBuf>,
     ) -> Self {
         Self {
-            codex_home,
+            nori_home,
             requester,
             pagination: PaginationState {
                 next_cursor: None,
@@ -29,7 +29,7 @@ impl PickerState {
             next_search_token: 0,
             page_loader,
             view_rows: None,
-            default_provider,
+            agent_filter,
             show_all,
             filter_cwd,
         }
@@ -51,7 +51,7 @@ impl PickerState {
             }
             KeyCode::Enter => {
                 if let Some(row) = self.filtered_rows.get(self.selected) {
-                    return Ok(Some(ResumeSelection::Resume(row.path.clone())));
+                    return Ok(Some(ResumeSelection::Resume(row.target.clone())));
                 }
             }
             KeyCode::Up => {
@@ -110,14 +110,10 @@ impl PickerState {
     }
 
     pub(super) async fn load_initial_page(&mut self) -> Result<()> {
-        let provider_filter = vec![self.default_provider.clone()];
-        let page = RolloutRecorder::list_conversations(
-            &self.codex_home,
-            PAGE_SIZE,
-            None,
-            INTERACTIVE_SESSION_SOURCES,
-            Some(provider_filter.as_slice()),
-            self.default_provider.as_str(),
+        let page = load_transcript_page(
+            &self.nori_home,
+            self.filter_cwd.as_deref(),
+            self.agent_filter.as_deref(),
         )
         .await?;
         self.reset_pagination();
@@ -161,7 +157,7 @@ impl PickerState {
         self.pagination.loading = LoadingState::Idle;
     }
 
-    pub(super) fn ingest_page(&mut self, page: ConversationsPage) {
+    pub(super) fn ingest_page(&mut self, page: TranscriptPage) {
         if let Some(cursor) = page.next_cursor.clone() {
             self.pagination.next_cursor = Some(cursor);
         } else {
@@ -175,9 +171,16 @@ impl PickerState {
             self.pagination.reached_scan_cap = true;
         }
 
-        let rows = helpers::rows_from_items(page.items);
+        let rows = helpers::rows_from_items(page.items, self.nori_home.clone());
         for row in rows {
-            if self.seen_paths.insert(row.path.clone()) {
+            let path = self
+                .nori_home
+                .join("transcripts")
+                .join("by-project")
+                .join(&row.target.project_id)
+                .join("sessions")
+                .join(format!("{}.jsonl", row.target.session_id));
+            if self.seen_paths.insert(path) {
                 self.all_rows.push(row);
             }
         }
@@ -337,9 +340,9 @@ impl PickerState {
         if self.pagination.loading.is_pending() {
             return;
         }
-        let Some(cursor) = self.pagination.next_cursor.clone() else {
+        if self.pagination.next_cursor.is_none() {
             return;
-        };
+        }
         let request_token = self.allocate_request_token();
         let search_token = match trigger {
             LoadTrigger::Scroll => None,
@@ -352,11 +355,10 @@ impl PickerState {
         self.request_frame();
 
         (self.page_loader)(PageLoadRequest {
-            codex_home: self.codex_home.clone(),
-            cursor: Some(cursor),
+            nori_home: self.nori_home.clone(),
             request_token,
             search_token,
-            default_provider: self.default_provider.clone(),
+            agent_filter: self.agent_filter.clone(),
         });
     }
 

--- a/nori-rs/tui/src/resume_picker/tests.rs
+++ b/nori-rs/tui/src/resume_picker/tests.rs
@@ -4,53 +4,59 @@ use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyModifiers;
 use insta::assert_snapshot;
-use serde_json::json;
 use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::Mutex;
 
-fn head_with_ts_and_user_text(ts: &str, texts: &[&str]) -> Vec<serde_json::Value> {
-    vec![
-        json!({ "timestamp": ts }),
-        json!({
-            "type": "message",
-            "role": "user",
-            "content": texts
-                .iter()
-                .map(|t| json!({ "type": "input_text", "text": *t }))
-                .collect::<Vec<_>>()
-        }),
-    ]
-}
-
-fn make_item(path: &str, ts: &str, preview: &str) -> ConversationItem {
-    ConversationItem {
-        path: PathBuf::from(path),
-        head: head_with_ts_and_user_text(ts, &[preview]),
-        tail: Vec::new(),
-        created_at: Some(ts.to_string()),
-        updated_at: Some(ts.to_string()),
+fn metadata(session_id: &str, project_id: &str, cwd: &str, agent: &str) -> SessionMetadata {
+    SessionMetadata {
+        session_id: session_id.to_string(),
+        project_id: project_id.to_string(),
+        started_at: "2025-01-01T00:00:00Z".to_string(),
+        cwd: PathBuf::from(cwd),
+        agent: Some(agent.to_string()),
     }
 }
 
-fn cursor_from_str(repr: &str) -> Cursor {
-    serde_json::from_str::<Cursor>(&format!("\"{repr}\""))
-        .expect("cursor format should deserialize")
+fn row(session_id: &str, cwd: Option<PathBuf>) -> Row {
+    Row {
+        target: ResumeTarget {
+            nori_home: PathBuf::from("/tmp/nori-home"),
+            project_id: "project".to_string(),
+            session_id: session_id.to_string(),
+            agent: Some("codex".to_string()),
+        },
+        preview: session_id.to_string(),
+        created_at: None,
+        updated_at: None,
+        cwd,
+        git_branch: None,
+    }
 }
 
-fn page(
-    items: Vec<ConversationItem>,
-    next_cursor: Option<Cursor>,
-    num_scanned_files: usize,
-    reached_scan_cap: bool,
-) -> ConversationsPage {
-    ConversationsPage {
+fn page(items: Vec<SessionMetadata>) -> TranscriptPage {
+    TranscriptPage {
         items,
-        next_cursor,
-        num_scanned_files,
-        reached_scan_cap,
+        next_cursor: None,
+        num_scanned_files: 0,
+        reached_scan_cap: false,
     }
+}
+
+fn state_with_rows(rows: Vec<Row>, show_all: bool, filter_cwd: Option<PathBuf>) -> PickerState {
+    let loader: PageLoader = Arc::new(|_| {});
+    let mut state = PickerState::new(
+        PathBuf::from("/tmp/nori-home"),
+        FrameRequester::test_dummy(),
+        loader,
+        None,
+        show_all,
+        filter_cwd,
+    );
+    state.all_rows = rows.clone();
+    state.filtered_rows = rows;
+    state.apply_filter();
+    state
 }
 
 fn block_on_future<F: Future<Output = T>, T>(future: F) -> T {
@@ -62,98 +68,116 @@ fn block_on_future<F: Future<Output = T>, T>(future: F) -> T {
 }
 
 #[test]
-fn preview_uses_first_message_input_text() {
-    let head = vec![
-        json!({ "timestamp": "2025-01-01T00:00:00Z" }),
-        json!({
-            "type": "message",
-            "role": "user",
-            "content": [
-                { "type": "input_text", "text": "# AGENTS.md instructions for project\n\n<INSTRUCTIONS>\nhi\n</INSTRUCTIONS>" },
-            ]
-        }),
-        json!({
-            "type": "message",
-            "role": "user",
-            "content": [
-                { "type": "input_text", "text": "<environment_context>...</environment_context>" },
-            ]
-        }),
-        json!({
-            "type": "message",
-            "role": "user",
-            "content": [
-                { "type": "input_text", "text": "real question" },
-                { "type": "input_image", "image_url": "ignored" }
-            ]
-        }),
-        json!({
-            "type": "message",
-            "role": "user",
-            "content": [ { "type": "input_text", "text": "later text" } ]
-        }),
-    ];
-    let preview = helpers::preview_from_head(&head);
-    assert_eq!(preview.as_deref(), Some("real question"));
-}
-
-#[test]
-fn rows_from_items_preserves_backend_order() {
-    // Construct two items with different timestamps and real user text.
-    let a = ConversationItem {
-        path: PathBuf::from("/tmp/a.jsonl"),
-        head: head_with_ts_and_user_text("2025-01-01T00:00:00Z", &["A"]),
-        tail: Vec::new(),
-        created_at: Some("2025-01-01T00:00:00Z".into()),
-        updated_at: Some("2025-01-01T00:00:00Z".into()),
-    };
-    let b = ConversationItem {
-        path: PathBuf::from("/tmp/b.jsonl"),
-        head: head_with_ts_and_user_text("2025-01-02T00:00:00Z", &["B"]),
-        tail: Vec::new(),
-        created_at: Some("2025-01-02T00:00:00Z".into()),
-        updated_at: Some("2025-01-02T00:00:00Z".into()),
-    };
-    let rows = helpers::rows_from_items(vec![a, b]);
-    assert_eq!(rows.len(), 2);
-    // Preserve the given order even if timestamps differ; backend already provides newest-first.
-    assert!(rows[0].preview.contains('A'));
-    assert!(rows[1].preview.contains('B'));
-}
-
-#[test]
-fn row_uses_tail_timestamp_for_updated_at() {
-    let head = head_with_ts_and_user_text("2025-01-01T00:00:00Z", &["Hello"]);
-    let tail = vec![json!({
-        "timestamp": "2025-01-01T01:00:00Z",
-        "type": "message",
-        "role": "assistant",
-        "content": [
-            {
-                "type": "output_text",
-                "text": "hi",
-            }
+fn rows_from_metadata_preserves_session_targets() {
+    let rows = helpers::rows_from_items(
+        vec![
+            metadata("session-a", "project-a", "/tmp/a", "claude-code"),
+            metadata("session-b", "project-b", "/tmp/b", "codex"),
         ],
-    })];
-    let item = ConversationItem {
-        path: PathBuf::from("/tmp/a.jsonl"),
-        head,
-        tail,
-        created_at: Some("2025-01-01T00:00:00Z".into()),
-        updated_at: Some("2025-01-01T01:00:00Z".into()),
-    };
+        PathBuf::from("/tmp/nori-home"),
+    );
 
-    let rows = helpers::rows_from_items(vec![item]);
-    let row = &rows[0];
-    let expected_created = chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
-    let expected_updated = chrono::DateTime::parse_from_rfc3339("2025-01-01T01:00:00Z")
-        .unwrap()
-        .with_timezone(&Utc);
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].target.session_id, "session-a");
+    assert_eq!(rows[0].target.project_id, "project-a");
+    assert_eq!(rows[0].target.agent.as_deref(), Some("claude-code"));
+    assert_eq!(rows[1].target.session_id, "session-b");
+}
 
-    assert_eq!(row.created_at, Some(expected_created));
-    assert_eq!(row.updated_at, Some(expected_updated));
+#[test]
+fn ingest_page_deduplicates_by_transcript_target() {
+    let mut state = state_with_rows(Vec::new(), true, None);
+    state.ingest_page(page(vec![
+        metadata("session-a", "project-a", "/tmp/a", "codex"),
+        metadata("session-a", "project-a", "/tmp/a", "codex"),
+        metadata("session-b", "project-a", "/tmp/a", "codex"),
+    ]));
+
+    let sessions: Vec<_> = state
+        .filtered_rows
+        .iter()
+        .map(|row| row.target.session_id.as_str())
+        .collect();
+    assert_eq!(sessions, vec!["session-a", "session-b"]);
+}
+
+#[test]
+fn cwd_filter_hides_other_projects_unless_show_all() {
+    let rows = vec![
+        row("same", Some(PathBuf::from("/tmp/project"))),
+        row("other", Some(PathBuf::from("/tmp/other"))),
+    ];
+
+    let filtered = state_with_rows(rows.clone(), false, Some(PathBuf::from("/tmp/project")));
+    assert_eq!(filtered.filtered_rows.len(), 1);
+    assert_eq!(filtered.filtered_rows[0].target.session_id, "same");
+
+    let show_all = state_with_rows(rows, true, Some(PathBuf::from("/tmp/project")));
+    assert_eq!(show_all.filtered_rows.len(), 2);
+}
+
+#[test]
+fn search_filters_by_session_id() {
+    let mut state = state_with_rows(
+        vec![row("session-alpha", None), row("session-beta", None)],
+        true,
+        None,
+    );
+
+    state.set_query("beta".to_string());
+
+    assert_eq!(state.filtered_rows.len(), 1);
+    assert_eq!(state.filtered_rows[0].target.session_id, "session-beta");
+}
+
+#[test]
+fn enter_selects_resume_target() {
+    let mut state = state_with_rows(
+        vec![row("session-alpha", None), row("session-beta", None)],
+        true,
+        None,
+    );
+    state.selected = 1;
+
+    let selection = block_on_future(async {
+        state
+            .handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+            .await
+            .unwrap()
+    });
+
+    match selection {
+        Some(ResumeSelection::Resume(target)) => {
+            assert_eq!(target.session_id, "session-beta");
+            assert_eq!(target.agent.as_deref(), Some("codex"));
+        }
+        other => panic!("expected resume selection, got {other:?}"),
+    }
+}
+
+#[test]
+fn page_navigation_uses_view_rows() {
+    let rows: Vec<_> = (0..20)
+        .map(|idx| row(&format!("session-{idx}"), None))
+        .collect();
+    let mut state = state_with_rows(rows, true, None);
+    state.update_view_rows(5);
+
+    block_on_future(async {
+        state
+            .handle_key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE))
+            .await
+            .unwrap();
+    });
+    assert_eq!(state.selected, 5);
+
+    block_on_future(async {
+        state
+            .handle_key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE))
+            .await
+            .unwrap();
+    });
+    assert_eq!(state.selected, 0);
 }
 
 #[test]
@@ -163,54 +187,33 @@ fn resume_table_snapshot() {
     use ratatui::layout::Constraint;
     use ratatui::layout::Layout;
 
-    let loader: PageLoader = Arc::new(|_| {});
-    let mut state = PickerState::new(
-        PathBuf::from("/tmp"),
-        FrameRequester::test_dummy(),
-        loader,
-        String::from("openai"),
-        true,
-        None,
-    );
-
     let now = Utc::now();
     let rows = vec![
         Row {
-            path: PathBuf::from("/tmp/a.jsonl"),
-            preview: String::from("Fix resume picker timestamps"),
+            preview: String::from("session-a"),
             created_at: Some(now - Duration::minutes(16)),
             updated_at: Some(now - Duration::seconds(42)),
             cwd: None,
             git_branch: None,
+            ..row("session-a", None)
         },
         Row {
-            path: PathBuf::from("/tmp/b.jsonl"),
-            preview: String::from("Investigate lazy pagination cap"),
+            preview: String::from("session-b"),
             created_at: Some(now - Duration::hours(1)),
             updated_at: Some(now - Duration::minutes(35)),
             cwd: None,
             git_branch: None,
-        },
-        Row {
-            path: PathBuf::from("/tmp/c.jsonl"),
-            preview: String::from("Explain the codebase"),
-            created_at: Some(now - Duration::hours(2)),
-            updated_at: Some(now - Duration::hours(2)),
-            cwd: None,
-            git_branch: None,
+            ..row("session-b", None)
         },
     ];
-    state.all_rows = rows.clone();
-    state.filtered_rows = rows;
-    state.view_rows = Some(3);
+    let mut state = state_with_rows(rows, true, None);
+    state.view_rows = Some(2);
     state.selected = 1;
-    state.scroll_top = 0;
-    state.update_view_rows(3);
 
     let metrics = rendering::calculate_column_metrics(&state.filtered_rows, state.show_all);
 
     let width: u16 = 80;
-    let height: u16 = 6;
+    let height: u16 = 5;
     let backend = VT100Backend::new(width, height);
     let mut terminal = Terminal::with_options(backend).expect("terminal");
     terminal.set_viewport_area(Rect::new(0, 0, width, height));
@@ -226,307 +229,4 @@ fn resume_table_snapshot() {
 
     let snapshot = terminal.backend().to_string();
     assert_snapshot!("resume_picker_table", snapshot);
-}
-
-#[test]
-fn pageless_scrolling_deduplicates_and_keeps_order() {
-    let loader: PageLoader = Arc::new(|_| {});
-    let mut state = PickerState::new(
-        PathBuf::from("/tmp"),
-        FrameRequester::test_dummy(),
-        loader,
-        String::from("openai"),
-        true,
-        None,
-    );
-
-    state.reset_pagination();
-    state.ingest_page(page(
-        vec![
-            make_item("/tmp/a.jsonl", "2025-01-03T00:00:00Z", "third"),
-            make_item("/tmp/b.jsonl", "2025-01-02T00:00:00Z", "second"),
-        ],
-        Some(cursor_from_str(
-            "2025-01-02T00-00-00|00000000-0000-0000-0000-000000000000",
-        )),
-        2,
-        false,
-    ));
-
-    state.ingest_page(page(
-        vec![
-            make_item("/tmp/a.jsonl", "2025-01-03T00:00:00Z", "duplicate"),
-            make_item("/tmp/c.jsonl", "2025-01-01T00:00:00Z", "first"),
-        ],
-        Some(cursor_from_str(
-            "2025-01-01T00-00-00|00000000-0000-0000-0000-000000000001",
-        )),
-        2,
-        false,
-    ));
-
-    state.ingest_page(page(
-        vec![make_item(
-            "/tmp/d.jsonl",
-            "2024-12-31T23:00:00Z",
-            "very old",
-        )],
-        None,
-        1,
-        false,
-    ));
-
-    let previews: Vec<_> = state
-        .filtered_rows
-        .iter()
-        .map(|row| row.preview.as_str())
-        .collect();
-    assert_eq!(previews, vec!["third", "second", "first", "very old"]);
-
-    let unique_paths = state
-        .filtered_rows
-        .iter()
-        .map(|row| row.path.clone())
-        .collect::<std::collections::HashSet<_>>();
-    assert_eq!(unique_paths.len(), 4);
-}
-
-#[test]
-fn ensure_minimum_rows_prefetches_when_underfilled() {
-    let recorded_requests: Arc<Mutex<Vec<PageLoadRequest>>> = Arc::new(Mutex::new(Vec::new()));
-    let request_sink = recorded_requests.clone();
-    let loader: PageLoader = Arc::new(move |req: PageLoadRequest| {
-        request_sink.lock().unwrap().push(req);
-    });
-
-    let mut state = PickerState::new(
-        PathBuf::from("/tmp"),
-        FrameRequester::test_dummy(),
-        loader,
-        String::from("openai"),
-        true,
-        None,
-    );
-    state.reset_pagination();
-    state.ingest_page(page(
-        vec![
-            make_item("/tmp/a.jsonl", "2025-01-01T00:00:00Z", "one"),
-            make_item("/tmp/b.jsonl", "2025-01-02T00:00:00Z", "two"),
-        ],
-        Some(cursor_from_str(
-            "2025-01-03T00-00-00|00000000-0000-0000-0000-000000000000",
-        )),
-        2,
-        false,
-    ));
-
-    assert!(recorded_requests.lock().unwrap().is_empty());
-    state.ensure_minimum_rows_for_view(10);
-    let guard = recorded_requests.lock().unwrap();
-    assert_eq!(guard.len(), 1);
-    assert!(guard[0].search_token.is_none());
-}
-
-#[test]
-fn page_navigation_uses_view_rows() {
-    let loader: PageLoader = Arc::new(|_| {});
-    let mut state = PickerState::new(
-        PathBuf::from("/tmp"),
-        FrameRequester::test_dummy(),
-        loader,
-        String::from("openai"),
-        true,
-        None,
-    );
-
-    let mut items = Vec::new();
-    for idx in 0..20 {
-        let ts = format!("2025-01-{:02}T00:00:00Z", idx + 1);
-        let preview = format!("item-{idx}");
-        let path = format!("/tmp/item-{idx}.jsonl");
-        items.push(make_item(&path, &ts, &preview));
-    }
-
-    state.reset_pagination();
-    state.ingest_page(page(items, None, 20, false));
-    state.update_view_rows(5);
-
-    assert_eq!(state.selected, 0);
-    block_on_future(async {
-        state
-            .handle_key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE))
-            .await
-            .unwrap();
-    });
-    assert_eq!(state.selected, 5);
-
-    block_on_future(async {
-        state
-            .handle_key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE))
-            .await
-            .unwrap();
-    });
-    assert_eq!(state.selected, 10);
-
-    block_on_future(async {
-        state
-            .handle_key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE))
-            .await
-            .unwrap();
-    });
-    assert_eq!(state.selected, 5);
-}
-
-#[test]
-fn up_at_bottom_does_not_scroll_when_visible() {
-    let loader: PageLoader = Arc::new(|_| {});
-    let mut state = PickerState::new(
-        PathBuf::from("/tmp"),
-        FrameRequester::test_dummy(),
-        loader,
-        String::from("openai"),
-        true,
-        None,
-    );
-
-    let mut items = Vec::new();
-    for idx in 0..10 {
-        let ts = format!("2025-02-{:02}T00:00:00Z", idx + 1);
-        let preview = format!("item-{idx}");
-        let path = format!("/tmp/item-{idx}.jsonl");
-        items.push(make_item(&path, &ts, &preview));
-    }
-
-    state.reset_pagination();
-    state.ingest_page(page(items, None, 10, false));
-    state.update_view_rows(5);
-
-    state.selected = state.filtered_rows.len().saturating_sub(1);
-    state.ensure_selected_visible();
-
-    let initial_top = state.scroll_top;
-    assert_eq!(initial_top, state.filtered_rows.len().saturating_sub(5));
-
-    block_on_future(async {
-        state
-            .handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE))
-            .await
-            .unwrap();
-    });
-
-    assert_eq!(state.scroll_top, initial_top);
-    assert_eq!(state.selected, state.filtered_rows.len().saturating_sub(2));
-}
-
-#[test]
-fn set_query_loads_until_match_and_respects_scan_cap() {
-    let recorded_requests: Arc<Mutex<Vec<PageLoadRequest>>> = Arc::new(Mutex::new(Vec::new()));
-    let request_sink = recorded_requests.clone();
-    let loader: PageLoader = Arc::new(move |req: PageLoadRequest| {
-        request_sink.lock().unwrap().push(req);
-    });
-
-    let mut state = PickerState::new(
-        PathBuf::from("/tmp"),
-        FrameRequester::test_dummy(),
-        loader,
-        String::from("openai"),
-        true,
-        None,
-    );
-    state.reset_pagination();
-    state.ingest_page(page(
-        vec![make_item(
-            "/tmp/start.jsonl",
-            "2025-01-01T00:00:00Z",
-            "alpha",
-        )],
-        Some(cursor_from_str(
-            "2025-01-02T00-00-00|00000000-0000-0000-0000-000000000000",
-        )),
-        1,
-        false,
-    ));
-    recorded_requests.lock().unwrap().clear();
-
-    state.set_query("target".to_string());
-    let first_request = {
-        let guard = recorded_requests.lock().unwrap();
-        assert_eq!(guard.len(), 1);
-        guard[0].clone()
-    };
-
-    state
-        .handle_background_event(BackgroundEvent::PageLoaded {
-            request_token: first_request.request_token,
-            search_token: first_request.search_token,
-            page: Ok(page(
-                vec![make_item("/tmp/beta.jsonl", "2025-01-02T00:00:00Z", "beta")],
-                Some(cursor_from_str(
-                    "2025-01-03T00-00-00|00000000-0000-0000-0000-000000000001",
-                )),
-                5,
-                false,
-            )),
-        })
-        .unwrap();
-
-    let second_request = {
-        let guard = recorded_requests.lock().unwrap();
-        assert_eq!(guard.len(), 2);
-        guard[1].clone()
-    };
-    assert!(state.search_state.is_active());
-    assert!(state.filtered_rows.is_empty());
-
-    state
-        .handle_background_event(BackgroundEvent::PageLoaded {
-            request_token: second_request.request_token,
-            search_token: second_request.search_token,
-            page: Ok(page(
-                vec![make_item(
-                    "/tmp/match.jsonl",
-                    "2025-01-03T00:00:00Z",
-                    "target log",
-                )],
-                Some(cursor_from_str(
-                    "2025-01-04T00-00-00|00000000-0000-0000-0000-000000000002",
-                )),
-                7,
-                false,
-            )),
-        })
-        .unwrap();
-
-    assert!(!state.filtered_rows.is_empty());
-    assert!(!state.search_state.is_active());
-
-    recorded_requests.lock().unwrap().clear();
-    state.set_query("missing".to_string());
-    let active_request = {
-        let guard = recorded_requests.lock().unwrap();
-        assert_eq!(guard.len(), 1);
-        guard[0].clone()
-    };
-
-    state
-        .handle_background_event(BackgroundEvent::PageLoaded {
-            request_token: second_request.request_token,
-            search_token: second_request.search_token,
-            page: Ok(page(Vec::new(), None, 0, false)),
-        })
-        .unwrap();
-    assert_eq!(recorded_requests.lock().unwrap().len(), 1);
-
-    state
-        .handle_background_event(BackgroundEvent::PageLoaded {
-            request_token: active_request.request_token,
-            search_token: active_request.search_token,
-            page: Ok(page(Vec::new(), None, 3, true)),
-        })
-        .unwrap();
-
-    assert!(state.filtered_rows.is_empty());
-    assert!(!state.search_state.is_active());
-    assert!(state.pagination.reached_scan_cap);
 }


### PR DESCRIPTION
## Summary
Generated with [Nori](https://noriagentic.com/)

- Adds `nori resume [session-id]`, `--last`, and `--all` startup flows backed by Nori transcript metadata.
- Resumes with the recorded agent by default and errors if a conflicting `--agent` is supplied.
- Aligns exit resume hints with transcript session IDs and updates resume picker/docs for the transcript-backed behavior.

## Test Plan
- [x] `cargo test -p nori-tui`
- [x] `cargo test -p nori-acp`
- [x] `cargo test -p nori-cli`
- [x] `cargo clippy -p nori-cli -p nori-tui -p nori-acp --all-features --tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `git diff --check`

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets