### PR TITLE
docs: Refresh README features

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/npm/l/nori-ai-cli)](https://github.com/tilework-tech/nori-cli/blob/main/LICENSE)
 [![npm downloads](https://img.shields.io/npm/dm/nori-ai-cli)](https://www.npmjs.com/package/nori-ai-cli)
 
-**One CLI, multiple AI providers.** Nori is a local AI coding agent that lets you switch between Claude, Gemini, and Codex. All from the same native CLI.
+**One CLI, multiple AI providers.** Nori is a local AI coding agent that lets you switch between Claude, Codex, Gemini, or any ACP compatible agent. All from the same native CLI.
 
 ![Nori TUI Screenshot](https://raw.githubusercontent.com/tilework-tech/nori-cli/refs/heads/main/assets/nori-cli_2026-01-13.png)
 
@@ -75,19 +75,20 @@ Want your AI agent to configure this automatically? Point it at the raw skill fi
 
 ## Features
 
-- **Multi-provider**: Anthropic's Claude Code, Google DeepMind's Gemini, and OpenAI's Codex
-- **Improved terminal interface**: Fast incremental renders in Ratatui, double buffered scrollback history, and built in Rust for performance
-- **Coming Soon!**
-  - **Sandboxed execution**: Commands run in OS-level security sandboxes
-  - **MCP integration**: Connect to Model Context Protocol servers for extended tools
-  - **Session persistence**: Save and resume conversations with `nori resume`
-  - **Multi-agent orchestration**: Alternate between multiple agent sessions
+- **Multi-provider**: Use Claude Code, Codex, Gemini, or your own ACP-compatible agent from the same CLI.
+- **Fast native interface**: Incremental Ratatui rendering, double-buffered scrollback history, and a Rust core keep long sessions responsive.
+- **Solid ACP client support**: Nori supports ACP session listing, loading, resume, context and usage metadata.
+- **Agent Integrations**: Your agents keep their configurations, whether that's slash commands, skills, and MCP server forwarding.
+- **Session continuity**: Pick up prior work with resume, and rewind agent changes with escape-to-undo.
+- **Project context**: Reference files with `@`, flip between an editor or a file picker, and keep useful context visible without leaving the terminal.
+
+See the [ACP roadmap](ROADMAP.md) for what is done, what is in progress, and what is planned next.
 
 ## Attribution
 
 Nori CLI is built on the great work within [OpenAI Codex CLI](https://github.com/openai/codex).
 
-Nori CLI is working with the great protocol led by [Zed Industries](https://github.com/agentclientprotocol/agent-client-protocol) for orchestrating agents.
+Nori CLI relies on the great contributions within the [ACP project](https://github.com/agentclientprotocol/agent-client-protocol), from Zed Editor, JetBrains, and others.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Refreshes the README feature list to describe current multi-provider, native interface, ACP, session continuity, and project-context support.
- Adds a link from the Features section to the ACP roadmap.
- Updates ACP attribution language to reference the broader ACP project.

## Test Plan

- [x] npm exec -- prettier --write README.md
- [x] git diff --check