### PR TITLE
feat(tui): Offer the ACP mode indicator in footer

### DIFF
--- a/nori-rs/acp/docs.md
+++ b/nori-rs/acp/docs.md
@@ -169,6 +169,8 @@ The `AcpBackendConfig` struct carries both `os_notifications` and `notify_after_
 
 The `[tui]` section also owns display-only preferences consumed by `@/nori-rs/tui/`. `custom_working_messages` defaults to `true`; setting it to `false` disables the rotating whimsical status header list and lets the TUI use a plain "Working" label while a task starts. The companion `custom_working_message_list` accepts an array of strings; when non-empty and `custom_working_messages` is `true`, the TUI samples from the user's list instead of the builtin whimsical messages. Both values are resolved onto `NoriConfig` in `loader.rs` and mirrored through `codex-core`'s config. The `/config` menu only toggles the boolean; the user list is TOML-only and the menu's "Custom Working Messages" entry advertises when a custom list is active.
 
+Footer visibility and placement are also config-owned. `[tui.footer_segments]` enables or disables named segments, including the ACP-only `mode_indicator` segment. `[tui.footer_layout]` controls where enabled segments render: `footer_left`, `footer_right`, and the four textarea corners. The default layout keeps legacy status segments on the footer's left side and puts `mode_indicator` on the footer's right side; partial layout overrides move listed segments out of their default placement to avoid duplicates.
+
 
 **Hotkey Configuration** (`config/types/mod.rs`):
 
@@ -288,7 +290,7 @@ ACP agents can expose runtime session configuration through `NewSessionResponse.
 This first implementation is deliberately live-session only:
 - `AcpBackend::config_options()` returns the current in-memory ACP config snapshot for TUI pickers.
 - `AcpBackend::set_config_option()` sends `session/set_config_option` for the current session and updates in-memory state from the response.
-- If the snapshot includes a select option categorized as `Mode` (or with id `mode`), the TUI derives the current mode label from the same live options, displays it on the composer, and uses `Shift-Tab` to cycle to the next value via `session/set_config_option`.
+- If the snapshot includes a select option categorized as `Mode` (or with id `mode`), the TUI derives the current mode label from the same live options, displays it through the normal `mode_indicator` footer segment, and uses `Shift-Tab` to cycle to the next value via `session/set_config_option`.
 - No config form is shown during `/agent` switching yet.
 - No ACP session config selections are persisted to `config.toml` yet.
 

--- a/nori-rs/acp/src/config/loader.rs
+++ b/nori-rs/acp/src/config/loader.rs
@@ -178,6 +178,9 @@ impl NoriConfig {
             footer_segment_config: super::types::FooterSegmentConfig::from_toml(
                 &toml.tui.footer_segments,
             ),
+            footer_layout_config: super::types::FooterLayoutConfig::from_toml(
+                &toml.tui.footer_layout,
+            ),
             nori_home,
             cwd,
             mcp_servers,

--- a/nori-rs/acp/src/config/mod.rs
+++ b/nori-rs/acp/src/config/mod.rs
@@ -18,6 +18,8 @@ pub use types::ApprovalPolicy;
 pub use types::AutoWorktree;
 pub use types::DEFAULT_AGENT;
 pub use types::FileManager;
+pub use types::FooterLayoutConfig;
+pub use types::FooterLayoutConfigToml;
 pub use types::FooterSegment;
 pub use types::FooterSegmentConfig;
 pub use types::FooterSegmentConfigToml;

--- a/nori-rs/acp/src/config/types/mod.rs
+++ b/nori-rs/acp/src/config/types/mod.rs
@@ -1146,6 +1146,8 @@ pub enum FooterSegment {
     NoriVersion,
     /// Token usage: "Tokens: 77K total (32K cached)"
     TokenUsage,
+    /// ACP mode indicator: "[ Plan ]"
+    ModeIndicator,
 }
 
 impl FooterSegment {
@@ -1162,6 +1164,7 @@ impl FooterSegment {
             Self::NoriProfile => "Skillset",
             Self::NoriVersion => "Skillset Version",
             Self::TokenUsage => "Token Usage",
+            Self::ModeIndicator => "Mode Indicator",
         }
     }
 
@@ -1178,6 +1181,7 @@ impl FooterSegment {
             Self::NoriProfile => "nori_profile",
             Self::NoriVersion => "nori_version",
             Self::TokenUsage => "token_usage",
+            Self::ModeIndicator => "mode_indicator",
         }
     }
 
@@ -1194,6 +1198,7 @@ impl FooterSegment {
             Self::NoriProfile,
             Self::NoriVersion,
             Self::TokenUsage,
+            Self::ModeIndicator,
         ]
     }
 
@@ -1234,6 +1239,8 @@ pub struct FooterSegmentConfigToml {
     pub nori_version: Option<bool>,
     /// Enable/disable token usage segment.
     pub token_usage: Option<bool>,
+    /// Enable/disable ACP mode indicator segment.
+    pub mode_indicator: Option<bool>,
 }
 
 /// Resolved footer segment configuration with defaults applied.
@@ -1259,6 +1266,8 @@ pub struct FooterSegmentConfig {
     pub nori_version: bool,
     /// Enable/disable token usage segment.
     pub token_usage: bool,
+    /// Enable/disable ACP mode indicator segment.
+    pub mode_indicator: bool,
 }
 
 impl Default for FooterSegmentConfig {
@@ -1274,6 +1283,7 @@ impl Default for FooterSegmentConfig {
             nori_profile: true,
             nori_version: true,
             token_usage: true,
+            mode_indicator: true,
         }
     }
 }
@@ -1292,6 +1302,7 @@ impl FooterSegmentConfig {
             nori_profile: toml.nori_profile.unwrap_or(true),
             nori_version: toml.nori_version.unwrap_or(true),
             token_usage: toml.token_usage.unwrap_or(true),
+            mode_indicator: toml.mode_indicator.unwrap_or(true),
         }
     }
 
@@ -1308,6 +1319,7 @@ impl FooterSegmentConfig {
             FooterSegment::NoriProfile => self.nori_profile,
             FooterSegment::NoriVersion => self.nori_version,
             FooterSegment::TokenUsage => self.token_usage,
+            FooterSegment::ModeIndicator => self.mode_indicator,
         }
     }
 
@@ -1324,6 +1336,7 @@ impl FooterSegmentConfig {
             FooterSegment::NoriProfile => self.nori_profile = enabled,
             FooterSegment::NoriVersion => self.nori_version = enabled,
             FooterSegment::TokenUsage => self.token_usage = enabled,
+            FooterSegment::ModeIndicator => self.mode_indicator = enabled,
         }
     }
 
@@ -1333,6 +1346,106 @@ impl FooterSegmentConfig {
             .iter()
             .map(|s| (*s, self.is_enabled(*s)))
             .collect()
+    }
+}
+
+/// TOML-deserializable footer segment placement settings.
+///
+/// Each field replaces that placement when present. Listed segments are moved
+/// out of other default placements so a partial override like
+/// `textarea_top_right = ["mode_indicator"]` moves the mode indicator instead
+/// of duplicating it.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FooterLayoutConfigToml {
+    pub footer_left: Option<Vec<FooterSegment>>,
+    pub footer_right: Option<Vec<FooterSegment>>,
+    pub textarea_top_left: Option<Vec<FooterSegment>>,
+    pub textarea_top_right: Option<Vec<FooterSegment>>,
+    pub textarea_bottom_left: Option<Vec<FooterSegment>>,
+    pub textarea_bottom_right: Option<Vec<FooterSegment>>,
+}
+
+/// Resolved footer segment placement configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FooterLayoutConfig {
+    pub footer_left: Vec<FooterSegment>,
+    pub footer_right: Vec<FooterSegment>,
+    pub textarea_top_left: Vec<FooterSegment>,
+    pub textarea_top_right: Vec<FooterSegment>,
+    pub textarea_bottom_left: Vec<FooterSegment>,
+    pub textarea_bottom_right: Vec<FooterSegment>,
+}
+
+impl Default for FooterLayoutConfig {
+    fn default() -> Self {
+        Self {
+            footer_left: vec![
+                FooterSegment::PromptSummary,
+                FooterSegment::VimMode,
+                FooterSegment::GitBranch,
+                FooterSegment::WorktreeName,
+                FooterSegment::GitStats,
+                FooterSegment::Context,
+                FooterSegment::ApprovalMode,
+                FooterSegment::NoriProfile,
+                FooterSegment::NoriVersion,
+                FooterSegment::TokenUsage,
+            ],
+            footer_right: vec![FooterSegment::ModeIndicator],
+            textarea_top_left: Vec::new(),
+            textarea_top_right: Vec::new(),
+            textarea_bottom_left: Vec::new(),
+            textarea_bottom_right: Vec::new(),
+        }
+    }
+}
+
+impl FooterLayoutConfig {
+    pub fn from_toml(toml: &FooterLayoutConfigToml) -> Self {
+        let mut config = Self::default();
+
+        if let Some(segments) = &toml.footer_left {
+            config.remove_segments(segments);
+            config.footer_left = segments.clone();
+        }
+        if let Some(segments) = &toml.footer_right {
+            config.remove_segments(segments);
+            config.footer_right = segments.clone();
+        }
+        if let Some(segments) = &toml.textarea_top_left {
+            config.remove_segments(segments);
+            config.textarea_top_left = segments.clone();
+        }
+        if let Some(segments) = &toml.textarea_top_right {
+            config.remove_segments(segments);
+            config.textarea_top_right = segments.clone();
+        }
+        if let Some(segments) = &toml.textarea_bottom_left {
+            config.remove_segments(segments);
+            config.textarea_bottom_left = segments.clone();
+        }
+        if let Some(segments) = &toml.textarea_bottom_right {
+            config.remove_segments(segments);
+            config.textarea_bottom_right = segments.clone();
+        }
+
+        config
+    }
+
+    fn remove_segments(&mut self, segments: &[FooterSegment]) {
+        self.footer_left
+            .retain(|segment| !segments.contains(segment));
+        self.footer_right
+            .retain(|segment| !segments.contains(segment));
+        self.textarea_top_left
+            .retain(|segment| !segments.contains(segment));
+        self.textarea_top_right
+            .retain(|segment| !segments.contains(segment));
+        self.textarea_bottom_left
+            .retain(|segment| !segments.contains(segment));
+        self.textarea_bottom_right
+            .retain(|segment| !segments.contains(segment));
     }
 }
 
@@ -1366,6 +1479,10 @@ pub struct TuiConfigToml {
     /// Footer segment visibility settings.
     #[serde(default)]
     pub footer_segments: FooterSegmentConfigToml,
+
+    /// Footer segment placement settings.
+    #[serde(default)]
+    pub footer_layout: FooterLayoutConfigToml,
 
     /// Timeout for custom prompt script execution.
     pub script_timeout: Option<ScriptTimeout>,
@@ -1580,6 +1697,9 @@ pub struct NoriConfig {
     /// Footer segment visibility configuration.
     pub footer_segment_config: FooterSegmentConfig,
 
+    /// Footer segment placement configuration.
+    pub footer_layout_config: FooterLayoutConfig,
+
     /// Nori home directory (~/.nori/cli)
     pub nori_home: PathBuf,
 
@@ -1672,6 +1792,7 @@ impl Default for NoriConfig {
             custom_working_messages: true,
             custom_working_message_list: Vec::new(),
             footer_segment_config: FooterSegmentConfig::default(),
+            footer_layout_config: FooterLayoutConfig::default(),
             nori_home: PathBuf::from(".nori/cli"),
             cwd: std::env::current_dir().unwrap_or_default(),
             mcp_servers: HashMap::new(),

--- a/nori-rs/acp/src/config/types/tests.rs
+++ b/nori-rs/acp/src/config/types/tests.rs
@@ -863,6 +863,8 @@ fn test_footer_segment_deserialize_all_variants() {
 
     let w: Wrapper = toml::from_str(r#"segment = "token_usage""#).unwrap();
     assert_eq!(w.segment, FooterSegment::TokenUsage);
+    let w: Wrapper = toml::from_str(r#"segment = "mode_indicator""#).unwrap();
+    assert_eq!(w.segment, FooterSegment::ModeIndicator);
 }
 
 #[test]
@@ -899,6 +901,10 @@ fn test_footer_segment_display_name() {
         "Skillset Version"
     );
     assert_eq!(FooterSegment::TokenUsage.display_name(), "Token Usage");
+    assert_eq!(
+        FooterSegment::ModeIndicator.display_name(),
+        "Mode Indicator"
+    );
 }
 
 #[test]
@@ -917,6 +923,7 @@ fn test_footer_segment_all_variants() {
             FooterSegment::NoriProfile,
             FooterSegment::NoriVersion,
             FooterSegment::TokenUsage,
+            FooterSegment::ModeIndicator,
         ]
     );
 }
@@ -963,14 +970,52 @@ fn test_footer_segment_config_from_toml_some_disabled() {
         prompt_summary: Some(false),
         git_branch: Some(false),
         token_usage: Some(false),
+        mode_indicator: Some(false),
         ..Default::default()
     };
     let config = FooterSegmentConfig::from_toml(&toml);
     assert!(!config.is_enabled(FooterSegment::PromptSummary));
     assert!(!config.is_enabled(FooterSegment::GitBranch));
     assert!(!config.is_enabled(FooterSegment::TokenUsage));
+    assert!(!config.is_enabled(FooterSegment::ModeIndicator));
     assert!(config.is_enabled(FooterSegment::Context));
     assert!(config.is_enabled(FooterSegment::ApprovalMode));
+}
+
+#[test]
+fn test_footer_layout_default_puts_mode_in_footer_right() {
+    assert_eq!(
+        FooterLayoutConfig::default().footer_right,
+        vec![FooterSegment::ModeIndicator]
+    );
+    assert!(
+        FooterLayoutConfig::default()
+            .footer_left
+            .contains(&FooterSegment::GitBranch)
+    );
+    assert!(
+        !FooterLayoutConfig::default()
+            .footer_left
+            .contains(&FooterSegment::ModeIndicator)
+    );
+}
+
+#[test]
+fn test_footer_layout_toml_moves_segment_to_textarea_corner() {
+    let config: TuiConfigToml = toml::from_str(
+        r#"
+[footer_layout]
+textarea_top_right = ["mode_indicator"]
+"#,
+    )
+    .unwrap();
+
+    let layout = FooterLayoutConfig::from_toml(&config.footer_layout);
+    assert_eq!(
+        layout.textarea_top_right,
+        vec![FooterSegment::ModeIndicator]
+    );
+    assert!(layout.footer_right.is_empty());
 }
 
 #[test]
@@ -980,11 +1025,13 @@ fn test_tui_config_toml_with_footer_segments() {
 [footer_segments]
 git_branch = false
 token_usage = false
+mode_indicator = false
 "#,
     )
     .unwrap();
     assert_eq!(config.footer_segments.git_branch, Some(false));
     assert_eq!(config.footer_segments.token_usage, Some(false));
+    assert_eq!(config.footer_segments.mode_indicator, Some(false));
     assert_eq!(config.footer_segments.context, None);
 }
 
@@ -1001,6 +1048,9 @@ vertical_footer = true
 prompt_summary = false
 vim_mode = false
 nori_profile = true
+
+[tui.footer_layout]
+textarea_top_right = ["mode_indicator"]
 "#,
     )
     .unwrap();
@@ -1008,6 +1058,10 @@ nori_profile = true
     assert_eq!(config.tui.footer_segments.vim_mode, Some(false));
     assert_eq!(config.tui.footer_segments.nori_profile, Some(true));
     assert_eq!(config.tui.footer_segments.git_branch, None);
+    assert_eq!(
+        config.tui.footer_layout.textarea_top_right,
+        Some(vec![FooterSegment::ModeIndicator])
+    );
 }
 
 // ========================================================================

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -199,9 +199,9 @@ The config persists a boolean `pinned_plan_drawer` in `[tui]` of `config.toml`. 
 
 The Nori-specific agent picker UI lives in `nori/agent_picker.rs`, allowing users to select between available ACP agents. It also exposes the ACP wire JSONL recorder as a same-line footer hint: `Shift-Tab` toggles `[acp_proxy].enabled` through the app config persistence path, updates the open picker and slash-command status text, and applies to future ACP child subprocesses. Existing running ACP subprocesses keep the proxy setting they were spawned with.
 
-**ACP Session Config Mode Shortcut** (`nori/session_config_mode.rs`, `chatwidget/session_config_mode.rs`, `bottom_pane/chat_composer/mod.rs`):
+**ACP Session Config Mode Shortcut** (`nori/session_config_mode.rs`, `chatwidget/session_config_mode.rs`, `bottom_pane/footer.rs`):
 
-When an ACP agent exposes a select-style session config option categorized as `Mode` (or using id `mode`), the TUI derives a compact mode snapshot from the same live `config_options` data used by `/config`. The current mode label is rendered at the top right of the composer. While the composer has focus and no popup is active, `Shift-Tab` fetches the current ACP session config snapshot from the agent handle, chooses the next mode value in the agent-provided option order (including grouped options), and applies it through `session/set_config_option`. The UI then refreshes the composer label through `AppEvent::AcpModeConfigSnapshot`. This remains live-session only and does not persist mode selections to `config.toml`.
+When an ACP agent exposes a select-style session config option categorized as `Mode` (or using id `mode`), the TUI derives a compact mode snapshot from the same live `config_options` data used by `/config`. The current mode label flows into the normal footer segment pipeline as the `mode_indicator` segment, rendered as compact bracketed text such as `[ Plan ]`. By default, the segment appears in the right side of the footer line and is skipped entirely when the selected agent does not expose mode options. While the composer has focus and no popup is active, `Shift-Tab` fetches the current ACP session config snapshot from the agent handle, chooses the next mode value in the agent-provided option order (including grouped options), and applies it through `session/set_config_option`. The UI then refreshes the footer segment through `AppEvent::AcpModeConfigSnapshot`. This remains live-session only and does not persist mode selections to `config.toml`.
 
 **System Info Collection** (`system_info.rs`):
 
@@ -669,6 +669,7 @@ The footer displays configurable segments, each of which can be enabled/disabled
 | Nori Profile | `nori_profile` | "Skillset: name" for one active skillset, "Skillsets: a, b" for multiple, hidden when none are active. Uses `active_skillsets` from `SystemInfo` (populated by `nori-skillsets list-active`). |
 | Nori Version | `nori_version` | "Skillsets v<version>" |
 | Token Usage | `token_usage` | "Tokens: 123K total (32K cached)" when running within an agent environment |
+| Mode Indicator | `mode_indicator` | "[ Plan ]" style ACP mode label, shown only when the active ACP agent exposes a mode config option |
 
 Example config.toml to disable specific segments:
 ```toml
@@ -677,12 +678,20 @@ token_usage = false
 git_stats = false
 ```
 
-All segments are enabled by default. The order of segments in the footer is fixed (cannot be reordered via config).
+All segments are enabled by default, though individual segments still render only when their backing data exists.
+
+Segment placement is configurable through `[tui.footer_layout]`. Missing layout fields use defaults: legacy status segments render on `footer_left`, and `mode_indicator` renders on `footer_right`. A field that is present replaces that placement; listed segments are moved out of other default placements so a partial override can move one segment without duplicating it. The layout supports `footer_left`, `footer_right`, `textarea_top_left`, `textarea_top_right`, `textarea_bottom_left`, and `textarea_bottom_right`.
+
+Example config.toml to move the mode indicator into the textarea's top-right corner:
+```toml
+[tui.footer_layout]
+textarea_top_right = ["mode_indicator"]
+```
 
 Token data flows from `TranscriptLocation.token_breakdown` (provided by `nori_acp::discover_transcript_for_agent_with_message()`) through `FooterProps` to the footer renderer. The breakdown includes separate input, output, and cached token counts for accurate usage reporting.
 Footer context usage is sourced in priority order: ACP `SessionUpdateInfo { kind: Usage, usage: Some(..) }` updates drive the footer when available, while `TranscriptLocation.token_breakdown` remains the provider-specific fallback for older sessions or agents that do not emit ACP usage updates.
 
-The prompt summary flows from the ACP backend as an `EventMsg::PromptSummary` event, handled by `ChatWidget::on_prompt_summary()`, which propagates it down: `ChatWidget` -> `BottomPane::set_prompt_summary()` -> `ChatComposer::set_prompt_summary()` -> `FooterProps.prompt_summary` -> `footer_segments()` renderer.
+The prompt summary flows from the ACP backend as an `EventMsg::PromptSummary` event, handled by `ChatWidget::on_prompt_summary()`, which propagates it down: `ChatWidget` -> `BottomPane::set_prompt_summary()` -> `ChatComposer::set_prompt_summary()` -> `FooterProps.prompt_summary` -> `segments_for()` renderer.
 
 The TUI detects the repo root for auto-worktree branch renaming by inspecting the cwd path structure: when `auto_worktree.is_enabled()` (true for both `Automatic` and `Ask` variants) and the cwd's parent directory is named `.worktrees`, the grandparent is treated as the repo root. This value is passed as `auto_worktree_repo_root` in `AcpBackendConfig` (see `chatwidget/agent.rs`). The branch rename is fire-and-forget; the working directory does not change during a session, so the TUI does not need to handle directory changes.
 

--- a/nori-rs/tui/src/app/mod.rs
+++ b/nori-rs/tui/src/app/mod.rs
@@ -214,6 +214,7 @@ pub(crate) struct App {
     /// Config is stored here so we can recreate ChatWidgets as needed.
     pub(crate) config: Config,
     pub(crate) vertical_footer: bool,
+    pub(crate) footer_layout_config: nori_acp::config::FooterLayoutConfig,
     pub(crate) active_profile: Option<String>,
 
     pub(crate) file_search: FileSearchManager,
@@ -340,6 +341,7 @@ impl App {
                 auth_manager: auth_manager.clone(),
                 vertical_footer,
                 footer_segment_config: nori_config.footer_segment_config.clone(),
+                footer_layout_config: nori_config.footer_layout_config.clone(),
                 expected_agent: None,
                 deferred_spawn: needs_deferred_spawn,
                 fork_context: None,
@@ -391,6 +393,7 @@ impl App {
             hotkey_config: nori_acp::config::HotkeyConfig::default(),
             vim_mode: nori_acp::config::VimEnterBehavior::Off,
             footer_segment_config: nori_config.footer_segment_config.clone(),
+            footer_layout_config: nori_config.footer_layout_config.clone(),
             plan_drawer_mode: crate::chatwidget::PlanDrawerMode::Off,
             system_info_tx,
             worktree_warning_shown: false,
@@ -526,6 +529,7 @@ impl App {
             auth_manager: self.auth_manager.clone(),
             vertical_footer: self.vertical_footer,
             footer_segment_config: self.footer_segment_config.clone(),
+            footer_layout_config: self.footer_layout_config.clone(),
             expected_agent,
             deferred_spawn,
             fork_context,

--- a/nori-rs/tui/src/app/tests.rs
+++ b/nori-rs/tui/src/app/tests.rs
@@ -37,6 +37,7 @@ fn make_test_app() -> App {
         auth_manager,
         config,
         vertical_footer: false,
+        footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
         active_profile: None,
         file_search,
         transcript_cells: Vec::new(),
@@ -82,6 +83,7 @@ fn make_test_app_with_channels() -> (
             auth_manager,
             config,
             vertical_footer: false,
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
             active_profile: None,
             file_search,
             transcript_cells: Vec::new(),
@@ -266,6 +268,30 @@ fn chat_widget_init_carries_footer_segment_config() {
             "segment {segment:?}"
         );
     }
+}
+
+#[cfg(feature = "nori-config")]
+#[test]
+fn chat_widget_init_carries_footer_layout_config() {
+    let mut app = make_test_app();
+    let footer_layout_config = nori_acp::config::FooterLayoutConfig::from_toml(
+        &nori_acp::config::FooterLayoutConfigToml {
+            textarea_top_right: Some(vec![nori_acp::config::FooterSegment::ModeIndicator]),
+            ..Default::default()
+        },
+    );
+    app.footer_layout_config = footer_layout_config.clone();
+
+    let init = app.chat_widget_init(
+        crate::tui::FrameRequester::test_dummy(),
+        None,
+        Vec::new(),
+        None,
+        false,
+        None,
+    );
+
+    assert_eq!(init.footer_layout_config, footer_layout_config);
 }
 
 #[cfg(feature = "nori-config")]

--- a/nori-rs/tui/src/bottom_pane/chat_composer/mod.rs
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/mod.rs
@@ -27,6 +27,7 @@ use super::footer::esc_hint_mode;
 use super::footer::footer_height;
 use super::footer::render_footer;
 use super::footer::reset_mode_after_activity;
+use super::footer::textarea_corner_segments;
 use super::footer::toggle_shortcut_mode;
 use super::history_search_popup::HistorySearchPopup;
 use super::paste_burst::CharDecision;
@@ -68,8 +69,6 @@ use std::time::Instant;
 /// If the pasted content exceeds this number of characters, replace it with a
 /// placeholder in the UI.
 const LARGE_PASTE_CHAR_THRESHOLD: usize = 1000;
-const ACP_MODE_LABEL_TEXT_WIDTH: usize = 20;
-
 /// Result returned when the user interacts with the text area.
 #[derive(Debug, PartialEq)]
 pub enum InputResult {
@@ -130,6 +129,7 @@ pub(crate) struct ChatComposer {
     vertical_footer: bool,
     prompt_summary: Option<String>,
     footer_segment_config: nori_acp::config::FooterSegmentConfig,
+    footer_layout_config: nori_acp::config::FooterLayoutConfig,
 }
 
 /// Popup state – at most one can be visible at any time.
@@ -190,6 +190,7 @@ impl ChatComposer {
             vertical_footer: false,
             prompt_summary: None,
             footer_segment_config: nori_acp::config::FooterSegmentConfig::default(),
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
         };
         // Apply configuration via the setter to keep side-effects centralized.
         this.set_disable_paste_burst(disable_paste_burst);
@@ -216,6 +217,13 @@ impl ChatComposer {
         config: nori_acp::config::FooterSegmentConfig,
     ) {
         self.footer_segment_config = config;
+    }
+
+    pub(crate) fn set_footer_layout_config(
+        &mut self,
+        config: nori_acp::config::FooterLayoutConfig,
+    ) {
+        self.footer_layout_config = config;
     }
 
     #[cfg(test)]
@@ -512,17 +520,11 @@ impl Renderable for ChatComposer {
         }
         let style = user_message_style();
         Block::default().style(style).render_ref(composer_rect, buf);
-        if let Some(mode_label) = &self.acp_mode_label {
-            let label = format_acp_mode_label(mode_label);
-            let label_width = label.chars().count() as u16;
-            if composer_rect.width > label_width + 2 {
-                let x = composer_rect
-                    .right()
-                    .saturating_sub(label_width)
-                    .saturating_sub(1);
-                buf.set_span(x, composer_rect.y, &label.dim(), label_width);
-            }
-        }
+        render_textarea_corner_segments(
+            composer_rect,
+            buf,
+            textarea_corner_segments(&self.footer_props()),
+        );
         if !textarea_rect.is_empty() {
             buf.set_span(
                 textarea_rect.x - LIVE_PREFIX_COLS,
@@ -541,20 +543,47 @@ impl Renderable for ChatComposer {
     }
 }
 
-fn format_acp_mode_label(mode_label: &str) -> String {
-    let label_len = mode_label.chars().count();
-    let text = if label_len > ACP_MODE_LABEL_TEXT_WIDTH {
-        let mut truncated = mode_label
-            .chars()
-            .take(ACP_MODE_LABEL_TEXT_WIDTH - 1)
-            .collect::<String>();
-        truncated.push('…');
-        truncated
-    } else {
-        mode_label.to_string()
-    };
+fn render_textarea_corner_segments(
+    composer_rect: Rect,
+    buf: &mut Buffer,
+    segments: super::footer::TextareaCornerSegments,
+) {
+    if composer_rect.is_empty() {
+        return;
+    }
 
-    format!("[ {text:<ACP_MODE_LABEL_TEXT_WIDTH$} ]")
+    render_left_corner(composer_rect.x + 1, composer_rect.y, buf, segments.top_left);
+    render_right_corner(
+        composer_rect.right().saturating_sub(1),
+        composer_rect.y,
+        buf,
+        segments.top_right,
+    );
+
+    let bottom_y = composer_rect.bottom().saturating_sub(1);
+    render_left_corner(composer_rect.x + 1, bottom_y, buf, segments.bottom_left);
+    render_right_corner(
+        composer_rect.right().saturating_sub(1),
+        bottom_y,
+        buf,
+        segments.bottom_right,
+    );
+}
+
+fn render_left_corner(x: u16, y: u16, buf: &mut Buffer, line: Line<'static>) {
+    let width = line.width() as u16;
+    if width > 0 {
+        line.render(Rect::new(x, y, width, 1), buf);
+    }
+}
+
+fn render_right_corner(right_edge: u16, y: u16, buf: &mut Buffer, line: Line<'static>) {
+    let width = line.width() as u16;
+    if width == 0 {
+        return;
+    }
+    let x = right_edge.saturating_sub(width).saturating_add(1);
+    line.render(Rect::new(x, y, width, 1), buf);
 }
 
 fn prompt_selection_action(

--- a/nori-rs/tui/src/bottom_pane/chat_composer/rendering.rs
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/rendering.rs
@@ -128,6 +128,8 @@ impl ChatComposer {
                 .as_ref()
                 .and_then(|s| s.worktree_name.clone()),
             footer_segment_config: self.footer_segment_config.clone(),
+            footer_layout_config: self.footer_layout_config.clone(),
+            acp_mode_label: self.acp_mode_label.clone(),
         }
     }
 

--- a/nori-rs/tui/src/bottom_pane/chat_composer/tests/part2.rs
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/tests/part2.rs
@@ -146,23 +146,23 @@ fn slash_popup_model_first_for_mo_logic() {
 }
 
 #[test]
-fn composer_renders_acp_mode_label_at_top_right() {
-    snapshot_composer_state("composer_acp_mode_label", false, |composer| {
+fn composer_renders_acp_mode_label_in_footer_by_default() {
+    snapshot_composer_state("composer_acp_mode_footer_default", false, |composer| {
         composer.set_acp_mode_label(Some("Plan".to_string()));
     });
 }
 
 #[test]
-fn acp_mode_label_is_fixed_width_and_truncated() {
-    assert_eq!(format_acp_mode_label("Plan"), "[ Plan                 ]");
-    assert_eq!(
-        format_acp_mode_label("Bypass Permissions"),
-        "[ Bypass Permissions   ]"
-    );
-    assert_eq!(
-        format_acp_mode_label("Very Long Alternate Mode"),
-        "[ Very Long Alternate… ]"
-    );
+fn composer_can_render_mode_segment_in_textarea_top_right() {
+    snapshot_composer_state("composer_acp_mode_textarea_top_right", false, |composer| {
+        composer.set_footer_layout_config(nori_acp::config::FooterLayoutConfig::from_toml(
+            &nori_acp::config::FooterLayoutConfigToml {
+                textarea_top_right: Some(vec![nori_acp::config::FooterSegment::ModeIndicator]),
+                ..Default::default()
+            },
+        ));
+        composer.set_acp_mode_label(Some("Plan".to_string()));
+    });
 }
 
 #[test]

--- a/nori-rs/tui/src/bottom_pane/chat_composer/tests/snapshots/nori_tui__bottom_pane__chat_composer__tests__composer_acp_mode_footer_default.snap
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/tests/snapshots/nori_tui__bottom_pane__chat_composer__tests__composer_acp_mode_footer_default.snap
@@ -2,7 +2,7 @@
 source: tui/src/bottom_pane/chat_composer/tests/mod.rs
 expression: terminal.backend()
 ---
-"                                                                           [ Plan                 ] "
+"                                                                                                    "
 "› Ask Nori to do anything                                                                           "
 "                                                                                                    "
 "                                                                                                    "
@@ -10,4 +10,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  ? for shortcuts                                                                                   "
+"  ? for shortcuts                                                                           [ Plan ]"

--- a/nori-rs/tui/src/bottom_pane/chat_composer/tests/snapshots/nori_tui__bottom_pane__chat_composer__tests__composer_acp_mode_textarea_top_right.snap
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/tests/snapshots/nori_tui__bottom_pane__chat_composer__tests__composer_acp_mode_textarea_top_right.snap
@@ -1,0 +1,13 @@
+---
+source: tui/src/bottom_pane/chat_composer/tests/mod.rs
+expression: terminal.backend()
+---
+"                                                                                            [ Plan ]"
+"› Ask Nori to do anything                                                                           "
+"                                                                                                    "
+"                                                                                                    "
+"                                                                                                    "
+"                                                                                                    "
+"                                                                                                    "
+"                                                                                                    "
+"  ? for shortcuts                                                                                   "

--- a/nori-rs/tui/src/bottom_pane/footer.rs
+++ b/nori-rs/tui/src/bottom_pane/footer.rs
@@ -1,11 +1,11 @@
 use crate::bottom_pane::textarea::VimModeState;
 use crate::key_hint;
 use crate::key_hint::KeyBinding;
-use crate::render::line_utils::prefix_lines;
 use crate::system_info::NoriVersionSource;
 use crate::ui_consts::FOOTER_INDENT_COLS;
 use codex_protocol::num_format::format_si_suffix;
 use crossterm::event::KeyCode;
+use nori_acp::config::FooterLayoutConfig;
 use nori_acp::config::FooterSegment;
 use nori_acp::config::FooterSegmentConfig;
 use ratatui::buffer::Buffer;
@@ -13,7 +13,6 @@ use ratatui::layout::Rect;
 use ratatui::style::Stylize;
 use ratatui::text::Line;
 use ratatui::text::Span;
-use ratatui::widgets::Paragraph;
 use ratatui::widgets::Widget;
 
 #[derive(Clone, Debug)]
@@ -54,6 +53,10 @@ pub(crate) struct FooterProps {
     pub(crate) worktree_name: Option<String>,
     /// Configuration for which footer segments to show.
     pub(crate) footer_segment_config: FooterSegmentConfig,
+    /// Configuration for where footer segments render.
+    pub(crate) footer_layout_config: FooterLayoutConfig,
+    /// ACP agent mode label to display when the agent exposes a mode option.
+    pub(crate) acp_mode_label: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -99,54 +102,148 @@ pub(crate) fn footer_height(props: &FooterProps) -> u16 {
 }
 
 pub(crate) fn render_footer(area: Rect, buf: &mut Buffer, props: &FooterProps) {
-    Paragraph::new(prefix_lines(
-        footer_lines(props),
-        " ".repeat(FOOTER_INDENT_COLS).into(),
-        " ".repeat(FOOTER_INDENT_COLS).into(),
-    ))
-    .render(area, buf);
+    for (line_index, row) in footer_rows(props).into_iter().enumerate() {
+        let Ok(line_offset) = u16::try_from(line_index) else {
+            break;
+        };
+        if line_offset >= area.height {
+            break;
+        }
+
+        let row_area = Rect {
+            x: area.x,
+            y: area.y + line_offset,
+            width: area.width,
+            height: 1,
+        };
+        render_footer_row(row_area, buf, row);
+    }
 }
 
 fn footer_lines(props: &FooterProps) -> Vec<Line<'static>> {
+    footer_rows(props)
+        .into_iter()
+        .map(FooterRow::joined)
+        .collect()
+}
+
+#[derive(Clone, Debug, Default)]
+struct FooterRow {
+    left: Line<'static>,
+    right: Line<'static>,
+}
+
+impl FooterRow {
+    fn left(left: Line<'static>) -> Self {
+        Self {
+            left,
+            right: Line::from(""),
+        }
+    }
+
+    fn joined(self) -> Line<'static> {
+        if self.right.spans.is_empty() {
+            self.left
+        } else if self.left.spans.is_empty() {
+            self.right
+        } else {
+            let mut line = self.left;
+            line.push_span(" · ".dim());
+            line.extend(self.right.spans);
+            line
+        }
+    }
+}
+
+fn render_footer_row(area: Rect, buf: &mut Buffer, row: FooterRow) {
+    if area.is_empty() {
+        return;
+    }
+
+    let footer_indent = u16::try_from(FOOTER_INDENT_COLS).unwrap_or(0);
+    let left_area = Rect {
+        x: area.x + footer_indent,
+        y: area.y,
+        width: area.width.saturating_sub(footer_indent),
+        height: 1,
+    };
+    row.left.render(left_area, buf);
+
+    let right_width = row.right.width() as u16;
+    if right_width == 0 {
+        return;
+    }
+
+    let right_area = Rect {
+        x: area.right().saturating_sub(right_width),
+        y: area.y,
+        width: right_width.min(area.width),
+        height: 1,
+    };
+    row.right.render(right_area, buf);
+}
+
+fn footer_rows(props: &FooterProps) -> Vec<FooterRow> {
     // Show the context indicator on the left, appended after the primary hint
     // (e.g., "? for shortcuts"). Keep it visible even when typing (i.e., when
     // the shortcut hint is hidden). Hide it only for the multi-line
     // ShortcutOverlay.
     match props.mode {
-        FooterMode::CtrlCReminder => vec![ctrl_c_reminder_line(CtrlCReminderState {
-            is_task_running: props.is_task_running,
-        })],
+        FooterMode::CtrlCReminder => {
+            vec![FooterRow::left(ctrl_c_reminder_line(CtrlCReminderState {
+                is_task_running: props.is_task_running,
+            }))]
+        }
         FooterMode::ShortcutSummary => {
-            let segments = footer_segments(props);
+            let footer_segments = footer_segment_groups(props);
             if props.vertical_footer {
-                let mut lines = segments;
-                lines.push(shortcuts_hint_line());
-                lines
+                let mut rows = footer_segments
+                    .left
+                    .into_iter()
+                    .chain(footer_segments.right)
+                    .map(FooterRow::left)
+                    .collect::<Vec<_>>();
+                rows.push(FooterRow::left(shortcuts_hint_line()));
+                rows
             } else {
-                let mut line = join_footer_segments(&segments);
+                let mut line = join_footer_segments(&footer_segments.left);
                 // Only add separator if there's already content
                 if !line.spans.is_empty() {
                     line.push_span(" · ".dim());
                 }
                 line.extend(shortcuts_hint_line().spans);
-                vec![line]
+                vec![FooterRow {
+                    left: line,
+                    right: join_footer_segments(&footer_segments.right),
+                }]
             }
         }
         FooterMode::ShortcutOverlay => shortcut_overlay_lines(ShortcutsState {
             use_shift_enter_hint: props.use_shift_enter_hint,
             esc_backtrack_hint: props.esc_backtrack_hint,
-        }),
-        FooterMode::EscHint => vec![esc_hint_line(props.esc_backtrack_hint)],
+        })
+        .into_iter()
+        .map(FooterRow::left)
+        .collect(),
+        FooterMode::EscHint => vec![FooterRow::left(esc_hint_line(props.esc_backtrack_hint))],
         FooterMode::ContextOnly => {
-            let segments = footer_segments(props);
+            let footer_segments = footer_segment_groups(props);
             if props.vertical_footer {
+                let segments = footer_segments
+                    .left
+                    .into_iter()
+                    .chain(footer_segments.right)
+                    .collect::<Vec<_>>();
                 if segments.is_empty() {
-                    vec![Line::from("")]
+                    vec![FooterRow::left(Line::from(""))]
                 } else {
-                    segments
+                    segments.into_iter().map(FooterRow::left).collect()
                 }
             } else {
-                vec![build_footer_line(props)]
+                vec![FooterRow {
+                    left: join_footer_segments(&footer_segments.left),
+                    right: join_footer_segments(&footer_segments.right),
+                }]
             }
         }
     }
@@ -281,10 +378,6 @@ fn build_columns(entries: Vec<Line<'static>>) -> Vec<Line<'static>> {
         .collect()
 }
 
-fn build_footer_line(props: &FooterProps) -> Line<'static> {
-    join_footer_segments(&footer_segments(props))
-}
-
 fn shortcuts_hint_line() -> Line<'static> {
     Line::from(vec![
         key_hint::plain(KeyCode::Char('?')).into(),
@@ -292,168 +385,192 @@ fn shortcuts_hint_line() -> Line<'static> {
     ])
 }
 
-fn footer_segments(props: &FooterProps) -> Vec<Line<'static>> {
-    let mut segments = Vec::new();
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TextareaCornerSegments {
+    pub(crate) top_left: Line<'static>,
+    pub(crate) top_right: Line<'static>,
+    pub(crate) bottom_left: Line<'static>,
+    pub(crate) bottom_right: Line<'static>,
+}
+
+pub(crate) fn textarea_corner_segments(props: &FooterProps) -> TextareaCornerSegments {
+    TextareaCornerSegments {
+        top_left: join_footer_segments(&segments_for(
+            props,
+            &props.footer_layout_config.textarea_top_left,
+        )),
+        top_right: join_footer_segments(&segments_for(
+            props,
+            &props.footer_layout_config.textarea_top_right,
+        )),
+        bottom_left: join_footer_segments(&segments_for(
+            props,
+            &props.footer_layout_config.textarea_bottom_left,
+        )),
+        bottom_right: join_footer_segments(&segments_for(
+            props,
+            &props.footer_layout_config.textarea_bottom_right,
+        )),
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct FooterSegmentGroups {
+    left: Vec<Line<'static>>,
+    right: Vec<Line<'static>>,
+}
+
+fn footer_segment_groups(props: &FooterProps) -> FooterSegmentGroups {
+    FooterSegmentGroups {
+        left: segments_for(props, &props.footer_layout_config.footer_left),
+        right: segments_for(props, &props.footer_layout_config.footer_right),
+    }
+}
+
+fn segments_for(props: &FooterProps, segment_order: &[FooterSegment]) -> Vec<Line<'static>> {
+    segment_order
+        .iter()
+        .filter_map(|segment| footer_segment(props, *segment))
+        .collect()
+}
+
+fn footer_segment(props: &FooterProps, segment: FooterSegment) -> Option<Line<'static>> {
     let config = &props.footer_segment_config;
 
-    // Add prompt summary if available and enabled: "Task: <summary>" (dim)
-    if config.is_enabled(FooterSegment::PromptSummary)
-        && let Some(summary) = &props.prompt_summary
-    {
-        segments.push(Line::from(vec![
-            "Task: ".dim(),
-            Span::from(summary.clone()).dim(),
-        ]));
+    if !config.is_enabled(segment) {
+        return None;
     }
 
-    // Add vim mode indicator if vim mode is enabled and segment is enabled
-    if config.is_enabled(FooterSegment::VimMode)
-        && let Some(vim_state) = props.vim_mode_state
-    {
-        let (label, style_fn): (&str, fn(Span<'static>) -> Span<'static>) = match vim_state {
-            VimModeState::Normal => ("NORMAL", |s| s.light_blue().bold()),
-            VimModeState::Insert => ("INSERT", |s| s.green()),
-        };
-        segments.push(Line::from(vec![style_fn(Span::from(label))]));
-    }
-
-    // Add git branch if available and enabled: "⎇ branch-name"
-    // Yellow for main repo, light red (orange-ish) for worktree
-    if config.is_enabled(FooterSegment::GitBranch)
-        && let Some(branch) = &props.git_branch
-    {
-        let line = if props.is_worktree {
-            // Light red for worktree (distinguishable from yellow, works with ANSI)
-            #[allow(clippy::disallowed_methods)]
-            Line::from(vec![
-                Span::from("⎇ ").light_red(),
-                Span::from(branch.clone()).light_red(),
-            ])
-        } else {
-            // Yellow for main repo
-            #[allow(clippy::disallowed_methods)]
-            Line::from(vec![
-                Span::from("⎇ ").yellow(),
-                Span::from(branch.clone()).yellow(),
-            ])
-        };
-        segments.push(line);
-    }
-
-    // Add worktree directory name if available and enabled: "Worktree: name" (light red)
-    if config.is_enabled(FooterSegment::WorktreeName)
-        && let Some(name) = &props.worktree_name
-    {
-        #[allow(clippy::disallowed_methods)]
-        segments.push(Line::from(vec![
-            Span::from("Worktree: ").light_red(),
-            Span::from(name.clone()).light_red(),
-        ]));
-    }
-
-    // Add git stats if available and enabled: "+10 -3" plus "!" for untracked files.
-    if config.is_enabled(FooterSegment::GitStats) {
-        let mut spans = Vec::new();
-        if let (Some(added), Some(removed)) = (props.git_lines_added, props.git_lines_removed)
-            && (added > 0 || removed > 0)
-        {
-            spans.extend([
-                Span::from(format!("+{added}")).green(),
-                Span::from(" ").dim(),
-                Span::from(format!("-{removed}")).red(),
-            ]);
-        }
-        if props.git_has_untracked {
-            if !spans.is_empty() {
-                spans.push(Span::from(" ").dim());
+    match segment {
+        FooterSegment::PromptSummary => props
+            .prompt_summary
+            .as_ref()
+            .map(|summary| Line::from(vec!["Task: ".dim(), Span::from(summary.clone()).dim()])),
+        FooterSegment::VimMode => props.vim_mode_state.map(|vim_state| {
+            let (label, style_fn): (&str, fn(Span<'static>) -> Span<'static>) = match vim_state {
+                VimModeState::Normal => ("NORMAL", |s| s.light_blue().bold()),
+                VimModeState::Insert => ("INSERT", |s| s.green()),
+            };
+            Line::from(vec![style_fn(Span::from(label))])
+        }),
+        FooterSegment::GitBranch => props.git_branch.as_ref().map(|branch| {
+            if props.is_worktree {
+                #[allow(clippy::disallowed_methods)]
+                Line::from(vec![
+                    Span::from("⎇ ").light_red(),
+                    Span::from(branch.clone()).light_red(),
+                ])
+            } else {
+                #[allow(clippy::disallowed_methods)]
+                Line::from(vec![
+                    Span::from("⎇ ").yellow(),
+                    Span::from(branch.clone()).yellow(),
+                ])
             }
-            spans.push(Span::from("!").red().bold());
-        }
+        }),
+        FooterSegment::WorktreeName => props.worktree_name.as_ref().map(|name| {
+            #[allow(clippy::disallowed_methods)]
+            Line::from(vec![
+                Span::from("Worktree: ").light_red(),
+                Span::from(name.clone()).light_red(),
+            ])
+        }),
+        FooterSegment::GitStats => git_stats_segment(props),
+        FooterSegment::Context => context_segment(props),
+        FooterSegment::ApprovalMode => props.approval_mode_label.as_ref().map(|label| {
+            Line::from(vec![
+                Span::from("Approvals: ").magenta(),
+                Span::from(label.clone()).magenta(),
+            ])
+        }),
+        FooterSegment::NoriProfile => nori_profile_segment(props),
+        FooterSegment::NoriVersion => props.nori_version.as_ref().map(|version| {
+            let label = props
+                .nori_version_source
+                .map(NoriVersionSource::label)
+                .unwrap_or("Skillsets");
+            Line::from(vec![
+                Span::from(format!("{label} v")).green(),
+                Span::from(version.clone()).green(),
+            ])
+        }),
+        FooterSegment::TokenUsage => token_usage_segment(props),
+        FooterSegment::ModeIndicator => props
+            .acp_mode_label
+            .as_ref()
+            .map(|label| Line::from(format!("[ {label} ]")).dim()),
+    }
+}
+
+fn git_stats_segment(props: &FooterProps) -> Option<Line<'static>> {
+    let mut spans = Vec::new();
+    if let (Some(added), Some(removed)) = (props.git_lines_added, props.git_lines_removed)
+        && (added > 0 || removed > 0)
+    {
+        spans.extend([
+            Span::from(format!("+{added}")).green(),
+            Span::from(" ").dim(),
+            Span::from(format!("-{removed}")).red(),
+        ]);
+    }
+    if props.git_has_untracked {
         if !spans.is_empty() {
-            segments.push(Line::from(spans));
+            spans.push(Span::from(" ").dim());
         }
+        spans.push(Span::from("!").red().bold());
+    }
+    (!spans.is_empty()).then(|| Line::from(spans))
+}
+
+fn context_segment(props: &FooterProps) -> Option<Line<'static>> {
+    let formatted_tokens = props
+        .context_tokens
+        .filter(|&tokens| tokens > 0)
+        .map(format_si_suffix);
+    let context_text = match (props.context_window_percent, formatted_tokens) {
+        (Some(pct), Some(tokens)) => Some(format!("Context {pct}% ({tokens})")),
+        (Some(pct), None) => Some(format!("Context {pct}%")),
+        (None, Some(tokens)) => Some(format!("Context {tokens}")),
+        (None, None) => None,
+    };
+    context_text.map(Line::from)
+}
+
+fn nori_profile_segment(props: &FooterProps) -> Option<Line<'static>> {
+    if props.active_skillsets.is_empty() {
+        return None;
+    }
+    let label = if props.active_skillsets.len() == 1 {
+        "Skillset: "
+    } else {
+        "Skillsets: "
+    };
+    Some(Line::from(vec![
+        Span::from(label).cyan(),
+        Span::from(props.active_skillsets.join(", ")).cyan(),
+    ]))
+}
+
+fn token_usage_segment(props: &FooterProps) -> Option<Line<'static>> {
+    let input = props.input_tokens.unwrap_or(0);
+    let output = props.output_tokens.unwrap_or(0);
+    let cached = props.cached_tokens.unwrap_or(0);
+    let total = input.saturating_add(output).saturating_add(cached);
+    if total == 0 {
+        return None;
     }
 
-    // Add context window info if available and enabled: "Context 27% (34K)".
-    if config.is_enabled(FooterSegment::Context) {
-        let formatted_tokens = props
-            .context_tokens
-            .filter(|&tokens| tokens > 0)
-            .map(format_si_suffix);
-        let context_text = match (props.context_window_percent, formatted_tokens) {
-            (Some(pct), Some(tokens)) => Some(format!("Context {pct}% ({tokens})")),
-            (Some(pct), None) => Some(format!("Context {pct}%")),
-            (None, Some(tokens)) => Some(format!("Context {tokens}")),
-            (None, None) => None,
-        };
-        if let Some(context_text) = context_text {
-            segments.push(Line::from(context_text));
-        }
+    let total_fmt = format_si_suffix(total);
+    let mut spans = vec![
+        "Tokens: ".dim(),
+        Span::from(format!("{total_fmt} total")).dim(),
+    ];
+    if cached > 0 {
+        let cached_fmt = format_si_suffix(cached);
+        spans.push(Span::from(format!(" ({cached_fmt} cached)")).dim());
     }
 
-    // Add approval mode if available and enabled: "Approvals: Agent" (magenta)
-    if config.is_enabled(FooterSegment::ApprovalMode)
-        && let Some(label) = &props.approval_mode_label
-    {
-        segments.push(Line::from(vec![
-            Span::from("Approvals: ").magenta(),
-            Span::from(label.clone()).magenta(),
-        ]));
-    }
-
-    // Add active skillsets if available and enabled: "Skillset: name" or "Skillsets: a, b" (cyan)
-    if config.is_enabled(FooterSegment::NoriProfile) && !props.active_skillsets.is_empty() {
-        let label = if props.active_skillsets.len() == 1 {
-            "Skillset: "
-        } else {
-            "Skillsets: "
-        };
-        segments.push(Line::from(vec![
-            Span::from(label).cyan(),
-            Span::from(props.active_skillsets.join(", ")).cyan(),
-        ]));
-    }
-
-    // Add nori version if available and enabled: "Skillsets v19.1.1" or "Profiles v19.1.1" (green)
-    if config.is_enabled(FooterSegment::NoriVersion)
-        && let Some(version) = &props.nori_version
-    {
-        let label = props
-            .nori_version_source
-            .map(NoriVersionSource::label)
-            .unwrap_or("Skillsets");
-        segments.push(Line::from(vec![
-            Span::from(format!("{label} v")).green(),
-            Span::from(version.clone()).green(),
-        ]));
-    }
-
-    // Add token usage if available and enabled: "Tokens: 77K total (32K cached)" (dim/gray)
-    // Total = input + output + cached (cached tokens are read from cache, so they
-    // count toward total tokens processed but are shown separately as "cached").
-    if config.is_enabled(FooterSegment::TokenUsage) {
-        let input = props.input_tokens.unwrap_or(0);
-        let output = props.output_tokens.unwrap_or(0);
-        let cached = props.cached_tokens.unwrap_or(0);
-        let total = input.saturating_add(output).saturating_add(cached);
-        if total > 0 {
-            let total_fmt = format_si_suffix(total);
-            let mut spans = vec![
-                "Tokens: ".dim(),
-                Span::from(format!("{total_fmt} total")).dim(),
-            ];
-
-            // Add cached portion if non-zero
-            if cached > 0 {
-                let cached_fmt = format_si_suffix(cached);
-                spans.push(Span::from(format!(" ({cached_fmt} cached)")).dim());
-            }
-
-            segments.push(Line::from(spans));
-        }
-    }
-
-    segments
+    Some(Line::from(spans))
 }
 
 fn join_footer_segments(segments: &[Line<'static>]) -> Line<'static> {
@@ -665,6 +782,8 @@ mod tests {
             prompt_summary: None,
             worktree_name: None,
             footer_segment_config: FooterSegmentConfig::default(),
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
+            acp_mode_label: None,
         }
     }
 
@@ -890,6 +1009,31 @@ mod tests {
                 ..default_props()
             },
         );
+    }
+
+    #[test]
+    fn footer_with_mode_indicator_uses_right_aligned_footer_segment() {
+        let rendered = render_footer_text(FooterProps {
+            git_branch: Some("main".to_string()),
+            acp_mode_label: Some("Plan".to_string()),
+            ..default_props()
+        });
+
+        let first_line = rendered.lines().next().unwrap_or_default();
+        assert!(first_line.ends_with("[ Plan ]"));
+        assert!(first_line.contains("⎇ main"));
+        assert!(!first_line.contains("Mode:"));
+    }
+
+    #[test]
+    fn footer_skips_mode_indicator_without_agent_mode() {
+        let rendered = render_footer_text(FooterProps {
+            git_branch: Some("main".to_string()),
+            ..default_props()
+        });
+
+        assert!(!rendered.contains("[ Plan ]"));
+        assert!(!rendered.contains("Mode"));
     }
 
     #[test]
@@ -1161,6 +1305,7 @@ mod tests {
             nori_profile: false,
             nori_version: false,
             token_usage: false,
+            mode_indicator: false,
         };
 
         snapshot_footer(

--- a/nori-rs/tui/src/bottom_pane/mod.rs
+++ b/nori-rs/tui/src/bottom_pane/mod.rs
@@ -101,6 +101,7 @@ pub(crate) struct BottomPaneParams {
     pub(crate) custom_working_message_list: Vec<String>,
     pub(crate) vertical_footer: bool,
     pub(crate) footer_segment_config: nori_acp::config::FooterSegmentConfig,
+    pub(crate) footer_layout_config: nori_acp::config::FooterLayoutConfig,
     pub(crate) agent_display_name: String,
     pub(crate) agent_slug: String,
 }
@@ -119,6 +120,7 @@ impl BottomPane {
             custom_working_message_list,
             vertical_footer,
             footer_segment_config,
+            footer_layout_config,
             agent_display_name,
             agent_slug,
         } = params;
@@ -131,6 +133,7 @@ impl BottomPane {
         );
         composer.set_vertical_footer(vertical_footer);
         composer.set_footer_segment_config(footer_segment_config);
+        composer.set_footer_layout_config(footer_layout_config);
 
         // In debug builds, allow synchronous system info collection for E2E tests
         // via NORI_SYNC_SYSTEM_INFO=1. In release builds, always use default to
@@ -877,6 +880,7 @@ mod tests {
             custom_working_message_list: Vec::new(),
             vertical_footer: false,
             footer_segment_config: nori_acp::config::FooterSegmentConfig::default(),
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
             agent_display_name: String::new(),
             agent_slug: String::new(),
         })
@@ -909,6 +913,7 @@ mod tests {
             custom_working_message_list: Vec::new(),
             vertical_footer: false,
             footer_segment_config: nori_acp::config::FooterSegmentConfig::default(),
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
             agent_display_name: String::new(),
             agent_slug: String::new(),
         });
@@ -936,6 +941,7 @@ mod tests {
             custom_working_message_list: Vec::new(),
             vertical_footer: false,
             footer_segment_config: nori_acp::config::FooterSegmentConfig::default(),
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
             agent_display_name: String::new(),
             agent_slug: String::new(),
         });
@@ -971,6 +977,7 @@ mod tests {
             custom_working_message_list: Vec::new(),
             vertical_footer: false,
             footer_segment_config: nori_acp::config::FooterSegmentConfig::default(),
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
             agent_display_name: "ElizACP".to_string(),
             agent_slug: "elizacp".to_string(),
         });
@@ -1014,6 +1021,7 @@ mod tests {
             custom_working_message_list: Vec::new(),
             vertical_footer: false,
             footer_segment_config: nori_acp::config::FooterSegmentConfig::default(),
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
             agent_display_name: String::new(),
             agent_slug: String::new(),
         });
@@ -1090,6 +1098,7 @@ mod tests {
             custom_working_message_list: Vec::new(),
             vertical_footer: false,
             footer_segment_config: nori_acp::config::FooterSegmentConfig::default(),
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
             agent_display_name: String::new(),
             agent_slug: String::new(),
         });
@@ -1124,6 +1133,7 @@ mod tests {
             custom_working_message_list: Vec::new(),
             vertical_footer: false,
             footer_segment_config: nori_acp::config::FooterSegmentConfig::default(),
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
             agent_display_name: String::new(),
             agent_slug: String::new(),
         });
@@ -1161,6 +1171,7 @@ mod tests {
             custom_working_message_list: Vec::new(),
             vertical_footer: false,
             footer_segment_config: nori_acp::config::FooterSegmentConfig::default(),
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
             agent_display_name: String::new(),
             agent_slug: String::new(),
         });
@@ -1194,6 +1205,7 @@ mod tests {
             custom_working_message_list: Vec::new(),
             vertical_footer: false,
             footer_segment_config: nori_acp::config::FooterSegmentConfig::default(),
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
             agent_display_name: String::new(),
             agent_slug: String::new(),
         });
@@ -1227,6 +1239,7 @@ mod tests {
             custom_working_message_list: Vec::new(),
             vertical_footer: false,
             footer_segment_config: nori_acp::config::FooterSegmentConfig::default(),
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
             agent_display_name: String::new(),
             agent_slug: String::new(),
         });

--- a/nori-rs/tui/src/chatwidget/constructors.rs
+++ b/nori-rs/tui/src/chatwidget/constructors.rs
@@ -13,6 +13,7 @@ impl ChatWidget {
             auth_manager,
             vertical_footer,
             footer_segment_config,
+            footer_layout_config,
             expected_agent,
             deferred_spawn,
             fork_context,
@@ -48,6 +49,7 @@ impl ChatWidget {
                 custom_working_message_list: config.custom_working_message_list.clone(),
                 vertical_footer,
                 footer_segment_config,
+                footer_layout_config,
                 agent_display_name: crate::nori::agent_picker::get_agent_info(&config.model)
                     .map(|info| info.display_name)
                     .unwrap_or_else(|| config.model.clone()),
@@ -135,6 +137,7 @@ impl ChatWidget {
             auth_manager,
             vertical_footer,
             footer_segment_config,
+            footer_layout_config,
             expected_agent,
             deferred_spawn: _,
             fork_context: _,
@@ -165,6 +168,7 @@ impl ChatWidget {
                 custom_working_message_list: config.custom_working_message_list.clone(),
                 vertical_footer,
                 footer_segment_config,
+                footer_layout_config,
                 agent_display_name: crate::nori::agent_picker::get_agent_info(&config.model)
                     .map(|info| info.display_name)
                     .unwrap_or_else(|| config.model.clone()),

--- a/nori-rs/tui/src/chatwidget/mod.rs
+++ b/nori-rs/tui/src/chatwidget/mod.rs
@@ -317,6 +317,7 @@ pub(crate) struct ChatWidgetInit {
     pub(crate) auth_manager: Arc<AuthManager>,
     pub(crate) vertical_footer: bool,
     pub(crate) footer_segment_config: nori_acp::config::FooterSegmentConfig,
+    pub(crate) footer_layout_config: nori_acp::config::FooterLayoutConfig,
     /// Expected agent name for this widget. When set, events from other agents
     /// (e.g., from a previous agent) are ignored until SessionConfigured arrives
     /// with a matching agent. This prevents race conditions when switching agents.

--- a/nori-rs/tui/src/chatwidget/tests/mod.rs
+++ b/nori-rs/tui/src/chatwidget/tests/mod.rs
@@ -262,6 +262,7 @@ pub(crate) fn make_chatwidget_manual() -> (
         custom_working_message_list: cfg.custom_working_message_list.clone(),
         vertical_footer: false,
         footer_segment_config: nori_acp::config::FooterSegmentConfig::default(),
+        footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
         agent_display_name: String::new(),
         agent_slug: String::new(),
     });

--- a/nori-rs/tui/src/chatwidget/tests/part1.rs
+++ b/nori-rs/tui/src/chatwidget/tests/part1.rs
@@ -99,6 +99,7 @@ async fn helpers_are_available_and_do_not_panic() {
         auth_manager,
         vertical_footer: false,
         footer_segment_config: nori_acp::config::FooterSegmentConfig::default(),
+        footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
         expected_agent: None,
         deferred_spawn: false,
         fork_context: None,

--- a/nori-rs/tui/src/nori/config_picker.rs
+++ b/nori-rs/tui/src/nori/config_picker.rs
@@ -661,6 +661,7 @@ mod tests {
             loop_count: None,
             auto_worktree: nori_acp::config::AutoWorktree::Off,
             footer_segment_config: FooterSegmentConfig::default(),
+            footer_layout_config: nori_acp::config::FooterLayoutConfig::default(),
             nori_home: PathBuf::from("/tmp/test-nori"),
             cwd: PathBuf::from("/tmp"),
             mcp_servers: std::collections::HashMap::new(),


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- Adds a configurable `[tui.footer_layout]` so footer segments can stay in the footer or move into textarea corners.
- Converts the ACP mode label into a normal `mode_indicator` footer segment, shown by default in the footer-right slot only when the agent exposes a mode option.
- Updates footer rendering, composer wiring, snapshots, and docs for the new layout behavior.

## Test Plan
- [x] `env -u RUSTC_WRAPPER cargo test -p nori-tui`
- [x] `env -u RUSTC_WRAPPER cargo build -p mock-acp-agent`
- [x] `env -u RUSTC_WRAPPER cargo test -p nori-acp`
- [x] `env -u RUSTC_WRAPPER cargo build --bin nori`
- [x] `env -u RUSTC_WRAPPER cargo test -p tui-pty-e2e`
- [x] `env -u RUSTC_WRAPPER just fmt`
- [x] `env -u RUSTC_WRAPPER just fix -p nori-tui`
- [x] `env -u RUSTC_WRAPPER just fix -p nori-acp`
- [x] `git diff --check`
- [x] TUI tmux smoke test with ElizACP config: launch, assert prompt, send input, assert prompt remains responsive

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets