### PR TITLE
feat(tui): Compact composer placeholder hints

### DIFF
--- a/nori-rs/tui-pty-e2e/src/lib.rs
+++ b/nori-rs/tui-pty-e2e/src/lib.rs
@@ -1024,12 +1024,11 @@ pub fn normalize_for_snapshot(contents: String) -> String {
         .lines()
         .map(|line| {
             if line.trim_start().starts_with("› ")
-                && (line.trim_start().starts_with("› Find and fix a bug")
-                    || line.trim_start().starts_with("› Explain this codebase")
-                    || line.trim_start().starts_with("› Write tests for")
-                    || line.trim_start().starts_with("› Improve documentation")
-                    || line.trim_start().starts_with("› Summarize recent commits")
-                    || line.trim_start().starts_with("› Implement {feature}")
+                && (line.trim_start().starts_with("› ? for shortcuts")
+                    || line.trim_start().starts_with("› / for slash command menu")
+                    || line.trim_start().starts_with("› $ for skill listing")
+                    || line.trim_start().starts_with("› ! for shell commands")
+                    || line.trim_start().starts_with("› @ for file mentions")
                     || line.contains("@filename"))
             {
                 "› [DEFAULT_PROMPT]".to_string()
@@ -1272,6 +1271,20 @@ mod tests {
             normalize_for_input_snapshot(input_similar.to_string()),
             input_similar
         );
+    }
+
+    #[test]
+    fn test_normalize_prompt_capability_placeholders() {
+        for placeholder in [
+            "? for shortcuts",
+            "/ for slash command menu",
+            "$ for skill listing",
+            "! for shell commands",
+            "@ for file mentions",
+        ] {
+            let input = format!("› {placeholder}\n");
+            assert_eq!(normalize_for_input_snapshot(input), "› [DEFAULT_PROMPT]\n");
+        }
     }
 
     #[test]

--- a/nori-rs/tui-pty-e2e/tests/input_handling.rs
+++ b/nori-rs/tui-pty-e2e/tests/input_handling.rs
@@ -12,7 +12,7 @@ use tui_pty_e2e::normalize_for_input_snapshot;
 #[cfg(target_os = "linux")]
 fn test_ctrl_c_clears_input() {
     let mut session = TuiSession::spawn(24, 80).unwrap();
-    session.wait_for_text("? for shortcuts", TIMEOUT).unwrap();
+    session.wait_for_text("›", TIMEOUT).unwrap();
 
     // Type some text
     session.send_str("draft message").unwrap();
@@ -37,7 +37,7 @@ fn test_ctrl_c_clears_input() {
 #[cfg(target_os = "linux")]
 fn test_backspace() {
     let mut session = TuiSession::spawn(24, 80).unwrap();
-    session.wait_for_text("? for shortcuts", TIMEOUT).unwrap();
+    session.wait_for_text("›", TIMEOUT).unwrap();
 
     session.send_str("Hello").unwrap();
     session.wait_for_text("Hello", TIMEOUT).unwrap();

--- a/nori-rs/tui-pty-e2e/tests/live_acp.rs
+++ b/nori-rs/tui-pty-e2e/tests/live_acp.rs
@@ -35,7 +35,7 @@ fn test_gemini_acp_live_response() {
         TuiSession::spawn_with_config(24, 80, config).expect("Failed to spawn with gemini-acp");
 
     session
-        .wait_for_text("? for shortcuts", LIVE_TIMEOUT)
+        .wait_for_text("›", LIVE_TIMEOUT)
         .expect("TUI should start successfully");
 
     // Send a simple prompt
@@ -81,7 +81,7 @@ fn test_claude_acp_live_response() {
         TuiSession::spawn_with_config(24, 80, config).expect("Failed to spawn with claude-acp");
 
     session
-        .wait_for_text("? for shortcuts", LIVE_TIMEOUT)
+        .wait_for_text("›", LIVE_TIMEOUT)
         .expect("TUI should start successfully");
 
     // Send a simple prompt

--- a/nori-rs/tui-pty-e2e/tests/live_custom_agent.rs
+++ b/nori-rs/tui-pty-e2e/tests/live_custom_agent.rs
@@ -74,7 +74,7 @@ fn test_elizacp_custom_agent_startup_and_response() {
 
     // Wait for the TUI to start and show the prompt
     session
-        .wait_for_text("? for shortcuts", LIVE_TIMEOUT)
+        .wait_for_text("›", LIVE_TIMEOUT)
         .expect("TUI should start successfully with elizacp agent");
 
     // Send a simple message
@@ -126,7 +126,7 @@ fn test_elizacp_custom_agent_display_name() {
 
     // Wait for startup
     session
-        .wait_for_text("? for shortcuts", LIVE_TIMEOUT)
+        .wait_for_text("›", LIVE_TIMEOUT)
         .expect("TUI should start successfully");
 
     let contents = session.screen_contents();

--- a/nori-rs/tui-pty-e2e/tests/nori_footer.rs
+++ b/nori-rs/tui-pty-e2e/tests/nori_footer.rs
@@ -16,17 +16,17 @@ fn test_footer_displays_git_branch() {
     .expect("Failed to spawn");
 
     // Wait for the TUI to start
-    session.wait_for_text("? for shortcuts", TIMEOUT).unwrap();
+    session.wait_for_text("›", TIMEOUT).unwrap();
     session.wait_for_text("Approvals", TIMEOUT).unwrap();
 
     std::thread::sleep(TIMEOUT_PRESNAPSHOT);
     let contents = session.screen_contents();
 
     // The footer should contain git branch info (master, since we use git init -b master)
-    // Check for the branch symbol and "? for shortcuts" which should always be present
+    // and approval mode.
     assert!(
-        contents.contains("⎇") && contents.contains("? for shortcuts"),
-        "Footer should contain git branch symbol and shortcuts hint. Contents: {}",
+        contents.contains("⎇") && contents.contains("Approvals"),
+        "Footer should contain git branch symbol and approval mode. Contents: {}",
         contents
     );
 
@@ -49,7 +49,7 @@ fn test_footer_without_git_repo() {
     .expect("Failed to spawn");
 
     // Wait for the TUI to start
-    session.wait_for_text("? for shortcuts", TIMEOUT).unwrap();
+    session.wait_for_text("›", TIMEOUT).unwrap();
     session.wait_for_text("Approvals", TIMEOUT).unwrap();
 
     std::thread::sleep(TIMEOUT_PRESNAPSHOT);
@@ -62,10 +62,10 @@ fn test_footer_without_git_repo() {
         contents
     );
 
-    // But it should still show shortcuts
+    // But it should still show the configured non-git footer segments.
     assert!(
-        contents.contains("? for shortcuts"),
-        "Footer should still show shortcuts hint. Contents: {}",
+        contents.contains("Approvals"),
+        "Footer should still show approval mode. Contents: {}",
         contents
     );
 }
@@ -74,7 +74,7 @@ fn test_footer_without_git_repo() {
 #[cfg(target_os = "linux")]
 fn test_footer_full_startup_with_all_info() {
     // This test verifies the complete footer display similar to startup.rs tests
-    // It should show: git branch, nori profile, nori version, git diff stats, and shortcuts
+    // It should show: git branch, nori profile, nori version, and git diff stats
 
     use std::os::unix::fs::PermissionsExt;
 
@@ -117,7 +117,7 @@ git_stats = true
         .expect("TUI did not start");
 
     // Wait for footer to render
-    session.wait_for_text("? for shortcuts", TIMEOUT).unwrap();
+    session.wait_for_text("›", TIMEOUT).unwrap();
     session.wait_for_text("Approvals", TIMEOUT).unwrap();
 
     std::thread::sleep(TIMEOUT_PRESNAPSHOT);
@@ -139,13 +139,6 @@ git_stats = true
     assert!(
         contents.contains("Skillsets v19.1.1") || contents.contains("Skillsets v0"), // v0 if mock didn't work
         "Footer should contain Nori version. Contents: {}",
-        contents
-    );
-
-    // Verify shortcuts hint is always present
-    assert!(
-        contents.contains("? for shortcuts"),
-        "Footer should show shortcuts hint. Contents: {}",
         contents
     );
 
@@ -187,7 +180,7 @@ vertical_footer = true
         TuiSession::spawn_with_config(24, 60, SessionConfig::new().with_config_toml(config_toml))
             .expect("Failed to spawn");
 
-    session.wait_for_text("? for shortcuts", TIMEOUT).unwrap();
+    session.wait_for_text("›", TIMEOUT).unwrap();
     session.wait_for_text("Approvals", TIMEOUT).unwrap();
 
     std::thread::sleep(TIMEOUT_PRESNAPSHOT);
@@ -198,25 +191,25 @@ vertical_footer = true
         .iter()
         .position(|line| line.contains("⎇") && line.contains("master"))
         .expect("Footer should contain git branch line");
-    let shortcuts_line_idx = lines
+    let approvals_line_idx = lines
         .iter()
-        .position(|line| line.contains("? for shortcuts"))
-        .expect("Footer should contain shortcuts line");
+        .position(|line| line.contains("Approvals"))
+        .expect("Footer should contain approvals line");
 
     assert_ne!(
-        branch_line_idx, shortcuts_line_idx,
-        "Branch and shortcuts should render on separate lines in vertical footer. Contents: {contents}"
+        branch_line_idx, approvals_line_idx,
+        "Branch and approvals should render on separate lines in vertical footer. Contents: {contents}"
     );
 
     let branch_line = lines[branch_line_idx];
-    let shortcuts_line = lines[shortcuts_line_idx];
+    let approvals_line = lines[approvals_line_idx];
     assert!(
         !branch_line.contains('·'),
         "Branch line should not include separators in vertical footer. Line: {branch_line}"
     );
     assert!(
-        !shortcuts_line.contains('·'),
-        "Shortcuts line should not include separators in vertical footer. Line: {shortcuts_line}"
+        !approvals_line.contains('·'),
+        "Approvals line should not include separators in vertical footer. Line: {approvals_line}"
     );
 
     assert_snapshot!("vertical_footer", normalize_for_input_snapshot(contents));
@@ -243,7 +236,7 @@ approval_mode = false
             .expect("Failed to spawn");
 
     // Wait for the TUI to fully start (session header contains "Nori CLI")
-    session.wait_for_text("? for shortcuts", TIMEOUT).unwrap();
+    session.wait_for_text("›", TIMEOUT).unwrap();
     session
         .wait_for_text("Nori CLI", TIMEOUT)
         .expect("Session header should appear");
@@ -267,13 +260,6 @@ approval_mode = false
     assert!(
         !contents.contains("Approvals"),
         "Footer should NOT contain Approvals when disabled. Contents: {}",
-        contents
-    );
-
-    // Shortcuts hint should still be present (always shown)
-    assert!(
-        contents.contains("? for shortcuts"),
-        "Footer should still show shortcuts hint. Contents: {}",
         contents
     );
 

--- a/nori-rs/tui-pty-e2e/tests/prompt_flow.rs
+++ b/nori-rs/tui-pty-e2e/tests/prompt_flow.rs
@@ -12,7 +12,7 @@ use tui_pty_e2e::normalize_for_input_snapshot;
 fn test_submit_prompt_default_response() {
     let mut session = TuiSession::spawn(18, 80).expect("Failed to spawn");
 
-    session.wait_for_text("? for shortcuts", TIMEOUT).unwrap();
+    session.wait_for_text("›", TIMEOUT).unwrap();
 
     // Type prompt
     session.send_str("Hello").unwrap();
@@ -47,7 +47,7 @@ fn test_submit_prompt_custom_response() {
 
     let mut session = TuiSession::spawn_with_config(18, 80, config).expect("Failed to spawn");
 
-    session.wait_for_text("? for shortcuts", TIMEOUT).unwrap();
+    session.wait_for_text("›", TIMEOUT).unwrap();
 
     session.send_str("test prompt").unwrap();
     std::thread::sleep(TIMEOUT_INPUT);
@@ -68,7 +68,7 @@ fn test_submit_prompt_custom_response() {
 #[test]
 fn test_multiline_input() {
     let mut session = TuiSession::spawn(30, 80).unwrap();
-    session.wait_for_text("? for shortcuts", TIMEOUT).unwrap();
+    session.wait_for_text("›", TIMEOUT).unwrap();
 
     // Type multiline prompt
     session.send_str("Line 1\nLine 2\nLine 3").unwrap();

--- a/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_generic_tool_call_resolved_name.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_generic_tool_call_resolved_name.snap
@@ -13,4 +13,4 @@ expression: normalize_for_input_snapshot(contents)
 
 › [DEFAULT_PROMPT]
 
-  ⎇ master · Approvals: Agent · ? for shortcuts
+  ⎇ master · Approvals: Agent

--- a/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_multi_call_exploring.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_multi_call_exploring.snap
@@ -22,4 +22,4 @@ expression: normalize_for_input_snapshot(contents)
 
 › [DEFAULT_PROMPT]
 
-  ⎇ master · Approvals: Agent · ? for shortcuts
+  ⎇ master · Approvals: Agent

--- a/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_no_orphan_tool_cells.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_no_orphan_tool_cells.snap
@@ -19,4 +19,4 @@ expression: normalize_for_input_snapshot(contents)
 
 › [DEFAULT_PROMPT]
 
-  ⎇ master · Approvals: Agent · ? for shortcuts
+  ⎇ master · Approvals: Agent

--- a/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_stuck_tool_calls_agent_message_renders.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_stuck_tool_calls_agent_message_renders.snap
@@ -13,4 +13,4 @@ expression: normalize_for_input_snapshot(contents)
 
 › [DEFAULT_PROMPT]
 
-  ⎇ master · Approvals: Agent · ? for shortcuts
+  ⎇ master · Approvals: Agent

--- a/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_tool_call_echo.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_tool_call_echo.snap
@@ -15,4 +15,4 @@ expression: normalize_for_input_snapshot(contents)
 
 › [DEFAULT_PROMPT]
 
-  ⎇ master · Approvals: Agent · ? for shortcuts
+  ⎇ master · Approvals: Agent

--- a/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_tool_call_no_duplicates.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_tool_call_no_duplicates.snap
@@ -18,4 +18,4 @@ expression: normalize_for_input_snapshot(contents)
 
 › [DEFAULT_PROMPT]
 
-  ⎇ master · Approvals: Agent · ? for shortcuts
+  ⎇ master · Approvals: Agent

--- a/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_tool_call_read.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_tool_call_read.snap
@@ -15,4 +15,4 @@ expression: normalize_for_input_snapshot(session.screen_contents())
 
 › [DEFAULT_PROMPT]
 
-  ⎇ master · Approvals: Agent · ? for shortcuts
+  ⎇ master · Approvals: Agent

--- a/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_tool_calls_during_final_stream.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_tool_calls_during_final_stream.snap
@@ -22,4 +22,4 @@ expression: normalize_for_input_snapshot(contents)
 
 › [DEFAULT_PROMPT]
 
-  ⎇ master · Approvals: Agent · ? for shortcuts
+  ⎇ master · Approvals: Agent

--- a/nori-rs/tui-pty-e2e/tests/snapshots/input_handling__history_navigation_up_down.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/input_handling__history_navigation_up_down.snap
@@ -8,4 +8,4 @@ expression: normalize_for_input_snapshot(session.screen_contents())
 
 › [DEFAULT_PROMPT]
 
-  ⎇ master · Approvals: Agent · ? for shortcuts
+  ⎇ master · Approvals: Agent

--- a/nori-rs/tui-pty-e2e/tests/snapshots/nori_footer__full_footer.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/nori_footer__full_footer.snap
@@ -4,4 +4,4 @@ expression: normalize_for_input_snapshot(contents)
 ---
 › [DEFAULT_PROMPT]
 
-  ⎇ master · ! · Approvals: Agent · Skillset: test-skillset · Skillsets v0.9.99 · ? for shortcuts
+  ⎇ master · ! · Approvals: Agent · Skillset: test-skillset · Skillsets v0.9.99

--- a/nori-rs/tui-pty-e2e/tests/snapshots/nori_footer__vertical_footer.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/nori_footer__vertical_footer.snap
@@ -8,4 +8,3 @@ enhancements
 
   ⎇ master
   Approvals: Read Only
-  ? for shortcuts

--- a/nori-rs/tui-pty-e2e/tests/snapshots/prompt_flow__custom_response.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/prompt_flow__custom_response.snap
@@ -8,4 +8,4 @@ expression: normalize_for_input_snapshot(session.screen_contents())
 
 › [DEFAULT_PROMPT]
 
-  ⎇ master · Approvals: Agent · ? for shortcuts
+  ⎇ master · Approvals: Agent

--- a/nori-rs/tui-pty-e2e/tests/snapshots/prompt_flow__prompt_submitted.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/prompt_flow__prompt_submitted.snap
@@ -8,4 +8,4 @@ expression: normalize_for_input_snapshot(session.screen_contents())
 
 › [DEFAULT_PROMPT]
 
-  Approvals: Agent · ? for shortcuts
+  Approvals: Agent

--- a/nori-rs/tui-pty-e2e/tests/snapshots/streaming__submit_input.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/streaming__submit_input.snap
@@ -8,4 +8,4 @@ expression: normalize_for_input_snapshot(session.screen_contents())
 
 › [DEFAULT_PROMPT]
 
-  ⎇ master · Approvals: Agent · ? for shortcuts
+  ⎇ master · Approvals: Agent

--- a/nori-rs/tui-pty-e2e/tests/snapshots/transcript_persistence__transcript_viewonly_display.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/transcript_persistence__transcript_viewonly_display.snap
@@ -18,4 +18,4 @@ expression: "tui_pty_e2e::normalize_for_input_snapshot(session.screen_contents()
 
 › [DEFAULT_PROMPT]
 
-  ⎇ master · Approvals: Agent · ? for shortcuts
+  ⎇ master · Approvals: Agent

--- a/nori-rs/tui-pty-e2e/tests/startup.rs
+++ b/nori-rs/tui-pty-e2e/tests/startup.rs
@@ -7,6 +7,18 @@ use tui_pty_e2e::TIMEOUT_PRESNAPSHOT;
 use tui_pty_e2e::TuiSession;
 use tui_pty_e2e::normalize_for_input_snapshot;
 
+fn has_prompt_mode_placeholder(contents: &str) -> bool {
+    [
+        "? for shortcuts",
+        "/ for slash command menu",
+        "$ for skill listing",
+        "! for shell commands",
+        "@ for file mentions",
+    ]
+    .iter()
+    .any(|placeholder| contents.contains(placeholder))
+}
+
 #[test]
 // Testing that ACP mode with a nonexistent model shows the error in the TUI
 // and opens the agent picker for recovery, instead of fatally exiting.
@@ -73,10 +85,9 @@ fn test_startup_with_dimensions() {
     let mut session =
         TuiSession::spawn_with_config(10, 120, SessionConfig::default()).expect("Failed to spawn");
 
-    // Wait for prompt - in a 10-row terminal, the header may scroll off
-    // so we wait for footer elements that are always visible
+    // Wait for prompt - in a 10-row terminal, the header may scroll off.
     session
-        .wait_for_text("? for shortcuts", TIMEOUT)
+        .wait_for_text("›", TIMEOUT)
         .expect("Prompt did not appear");
     std::thread::sleep(TIMEOUT_PRESNAPSHOT);
 
@@ -138,8 +149,8 @@ fn test_trust_screen_is_skipped_with_default_config() {
 
     // Should show the main prompt directly (skipping onboarding)
     assert!(
-        contents.contains("›") && contents.contains("? for shortcuts"),
-        "Should show main prompt with help indicator, got: {}",
+        contents.contains("›") && has_prompt_mode_placeholder(&contents),
+        "Should show main prompt with a prompt-mode placeholder, got: {}",
         contents
     );
 }
@@ -269,11 +280,12 @@ fn test_trust_directory_saves_to_config() {
         .send_key(Key::Char('y'))
         .expect("Failed to send 'y' key");
 
-    // Step 5: Wait for the main prompt to appear (onboarding complete)
-    // We wait for "?" which only appears in the main prompt,
-    // not "›" which also appears as a selection marker in the trust screen
+    // Step 5: Wait for the main prompt to appear (onboarding complete).
     session
-        .wait_for_text("? for shortcuts", TIMEOUT)
+        .wait_for(
+            |contents| contents.contains("›") && contents.contains("Approvals"),
+            TIMEOUT,
+        )
         .expect("Main prompt did not appear after trust selection");
 
     // Give a moment for config to be written

--- a/nori-rs/tui-pty-e2e/tests/streaming.rs
+++ b/nori-rs/tui-pty-e2e/tests/streaming.rs
@@ -25,7 +25,7 @@ fn test_submit_text() {
     session.send_key(Key::Enter).unwrap();
 
     std::thread::sleep(TIMEOUT_INPUT);
-    session.wait_for_text("? for shortcuts", TIMEOUT).unwrap();
+    session.wait_for_text("›", TIMEOUT).unwrap();
 
     std::thread::sleep(TIMEOUT_PRESNAPSHOT);
     std::thread::sleep(TIMEOUT_PRESNAPSHOT);

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -667,6 +667,10 @@ All entries are loaded once when the popup opens; filtering is performed client-
 
 Vim mode is inherited from the composer's current vim state. When vim mode is enabled, the popup starts in Insert mode (for typing search queries) and supports Esc to enter Normal mode (j/k navigation), then a second Esc to close.
 
+**Composer Placeholder Hints:**
+
+When the composer is empty, `ChatWidget` seeds its placeholder from concise capability hints instead of task examples: `?` for the shortcuts overlay, `/` for the slash command menu, `$` for skill listing, `!` for shell commands, and `@` for file mentions. The always-visible `? for shortcuts` footer hint is intentionally omitted; pressing `?` as the first composer character still opens the full shortcut overlay below the prompt, and typing `/` still opens the slash command popup.
+
 **Status Line Footer:**
 
 The footer displays configurable segments, each of which can be enabled/disabled via `/settings` -> "Footer Segments" or via `[tui.footer_segments]` in config.toml:

--- a/nori-rs/tui/src/bottom_pane/chat_composer/tests/part1.rs
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/tests/part1.rs
@@ -2,16 +2,10 @@ use super::*;
 use pretty_assertions::assert_eq;
 
 #[test]
-fn footer_hint_row_is_separated_from_composer() {
+fn shortcut_hint_is_placeholder_only_until_shortcut_overlay_opens() {
     let (tx, _rx) = unbounded_channel::<AppEvent>();
     let sender = AppEventSender::new(tx);
-    let composer = ChatComposer::new(
-        true,
-        sender,
-        false,
-        "Ask Nori to do anything".to_string(),
-        false,
-    );
+    let composer = ChatComposer::new(true, sender, false, "? for shortcuts".to_string(), false);
 
     let area = Rect::new(0, 0, 40, 6);
     let mut buf = Buffer::empty(area);
@@ -25,33 +19,49 @@ fn footer_hint_row_is_separated_from_composer() {
         row
     };
 
-    let mut hint_row: Option<(u16, String)> = None;
-    for y in 0..area.height {
-        let row = row_to_string(y);
-        if row.contains("? for shortcuts") {
-            hint_row = Some((y, row));
-            break;
-        }
-    }
-
-    let (hint_row_idx, hint_row_contents) =
-        hint_row.expect("expected footer hint row to be rendered");
-    assert_eq!(
-        hint_row_idx,
-        area.height - 1,
-        "hint row should occupy the bottom line: {hint_row_contents:?}",
+    let input_row = row_to_string(1);
+    assert!(
+        input_row.contains("? for shortcuts"),
+        "expected shortcut hint in the empty composer placeholder: {input_row:?}",
     );
+
+    let footer_rows = (3..area.height).map(row_to_string).collect::<Vec<_>>();
+    assert_eq!(
+        footer_rows
+            .iter()
+            .filter(|row| row.contains("? for shortcuts"))
+            .count(),
+        0,
+        "shortcut hint should not render below the textarea: {footer_rows:?}",
+    );
+}
+
+#[test]
+fn shortcut_overlay_still_renders_below_prompt_when_requested() {
+    use crossterm::event::KeyCode;
+    use crossterm::event::KeyEvent;
+    use crossterm::event::KeyModifiers;
+
+    let (tx, _rx) = unbounded_channel::<AppEvent>();
+    let sender = AppEventSender::new(tx);
+    let mut composer = ChatComposer::new(true, sender, false, "? for shortcuts".to_string(), false);
+    let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE));
+
+    let area = Rect::new(0, 0, 80, 10);
+    let mut buf = Buffer::empty(area);
+    composer.render(area, &mut buf);
+
+    let rendered = (0..area.height)
+        .map(|y| {
+            (0..area.width)
+                .map(|x| buf[(x, y)].symbol().chars().next().unwrap_or(' '))
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>();
 
     assert!(
-        hint_row_idx > 0,
-        "expected a spacing row above the footer hints",
-    );
-
-    let spacing_row = row_to_string(hint_row_idx - 1);
-    assert_eq!(
-        spacing_row.trim(),
-        "",
-        "expected blank spacing row above hints but saw: {spacing_row:?}",
+        rendered.iter().any(|row| row.contains("newline")),
+        "shortcut overlay should still render below the prompt: {rendered:?}",
     );
 }
 

--- a/nori-rs/tui/src/bottom_pane/chat_composer/tests/snapshots/nori_tui__bottom_pane__chat_composer__tests__composer_acp_mode_footer_default.snap
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/tests/snapshots/nori_tui__bottom_pane__chat_composer__tests__composer_acp_mode_footer_default.snap
@@ -10,4 +10,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  ? for shortcuts                                                                           [ Plan ]"
+"                                                                                            [ Plan ]"

--- a/nori-rs/tui/src/bottom_pane/chat_composer/tests/snapshots/nori_tui__bottom_pane__chat_composer__tests__composer_acp_mode_textarea_top_right.snap
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/tests/snapshots/nori_tui__bottom_pane__chat_composer__tests__composer_acp_mode_textarea_top_right.snap
@@ -10,4 +10,3 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  ? for shortcuts                                                                                   "

--- a/nori-rs/tui/src/bottom_pane/chat_composer/tests/snapshots/nori_tui__bottom_pane__chat_composer__tests__footer_mode_hidden_while_typing.snap
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/tests/snapshots/nori_tui__bottom_pane__chat_composer__tests__footer_mode_hidden_while_typing.snap
@@ -10,4 +10,3 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"                                                                                                    "

--- a/nori-rs/tui/src/bottom_pane/chat_composer/tests/snapshots/nori_tui__bottom_pane__chat_composer__tests__part2__empty.snap
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/tests/snapshots/nori_tui__bottom_pane__chat_composer__tests__part2__empty.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  ? for shortcuts                                                                                   "
+"                                                                                                    "

--- a/nori-rs/tui/src/bottom_pane/footer.rs
+++ b/nori-rs/tui/src/bottom_pane/footer.rs
@@ -186,10 +186,9 @@ fn render_footer_row(area: Rect, buf: &mut Buffer, row: FooterRow) {
 }
 
 fn footer_rows(props: &FooterProps) -> Vec<FooterRow> {
-    // Show the context indicator on the left, appended after the primary hint
-    // (e.g., "? for shortcuts"). Keep it visible even when typing (i.e., when
-    // the shortcut hint is hidden). Hide it only for the multi-line
-    // ShortcutOverlay.
+    // Keep footer metadata visible while typing. Hide it only for the
+    // multi-line ShortcutOverlay so the expanded shortcut table owns the
+    // footer area.
     match props.mode {
         FooterMode::CtrlCReminder => {
             vec![FooterRow::left(ctrl_c_reminder_line(CtrlCReminderState {
@@ -199,25 +198,14 @@ fn footer_rows(props: &FooterProps) -> Vec<FooterRow> {
         FooterMode::ShortcutSummary => {
             let footer_segments = footer_segment_groups(props);
             if props.vertical_footer {
-                let mut rows = footer_segments
+                footer_segments
                     .left
                     .into_iter()
                     .chain(footer_segments.right)
                     .map(FooterRow::left)
-                    .collect::<Vec<_>>();
-                rows.push(FooterRow::left(shortcuts_hint_line()));
-                rows
+                    .collect()
             } else {
-                let mut line = join_footer_segments(&footer_segments.left);
-                // Only add separator if there's already content
-                if !line.spans.is_empty() {
-                    line.push_span(" · ".dim());
-                }
-                line.extend(shortcuts_hint_line().spans);
-                vec![FooterRow {
-                    left: line,
-                    right: join_footer_segments(&footer_segments.right),
-                }]
+                footer_row_for_segment_groups(footer_segments)
             }
         }
         FooterMode::ShortcutOverlay => shortcut_overlay_lines(ShortcutsState {
@@ -237,17 +225,26 @@ fn footer_rows(props: &FooterProps) -> Vec<FooterRow> {
                     .chain(footer_segments.right)
                     .collect::<Vec<_>>();
                 if segments.is_empty() {
-                    vec![FooterRow::left(Line::from(""))]
+                    Vec::new()
                 } else {
                     segments.into_iter().map(FooterRow::left).collect()
                 }
             } else {
-                vec![FooterRow {
-                    left: join_footer_segments(&footer_segments.left),
-                    right: join_footer_segments(&footer_segments.right),
-                }]
+                footer_row_for_segment_groups(footer_segments)
             }
         }
+    }
+}
+
+fn footer_row_for_segment_groups(footer_segments: FooterSegmentGroups) -> Vec<FooterRow> {
+    let row = FooterRow {
+        left: join_footer_segments(&footer_segments.left),
+        right: join_footer_segments(&footer_segments.right),
+    };
+    if row.left.spans.is_empty() && row.right.spans.is_empty() {
+        Vec::new()
+    } else {
+        vec![row]
     }
 }
 
@@ -378,13 +375,6 @@ fn build_columns(entries: Vec<Line<'static>>) -> Vec<Line<'static>> {
             line.dim()
         })
         .collect()
-}
-
-fn shortcuts_hint_line() -> Line<'static> {
-    Line::from(vec![
-        key_hint::plain(KeyCode::Char('?')).into(),
-        " for shortcuts".dim(),
-    ])
 }
 
 #[derive(Clone, Debug, Default)]
@@ -1257,7 +1247,7 @@ mod tests {
             ..default_props()
         });
 
-        assert_eq!(rendered.trim(), "Context 16% (42.6K) · ? for shortcuts");
+        assert_eq!(rendered.trim(), "Context 16% (42.6K)");
     }
 
     #[test]

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_shortcuts_context_running.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_shortcuts_context_running.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  Context 72% · ? for shortcuts                                                 "
+"  Context 72%                                                                   "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_shortcuts_default.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_shortcuts_default.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ? for shortcuts                                                               "
+"                                                                                "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_shortcuts_vertical.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_shortcuts_vertical.snap
@@ -8,4 +8,3 @@ expression: terminal.backend()
 "  Approvals: Agent                                                              "
 "  Skillset: clifford                                                            "
 "  Skillsets v19.1.1                                                             "
-"  ? for shortcuts                                                               "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_vertical_with_segments_disabled.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_vertical_with_segments_disabled.snap
@@ -5,4 +5,3 @@ expression: terminal.backend()
 "  ⎇ feature/test                                                                "
 "  Context 27% (34.0K)                                                           "
 "  Approvals: Agent                                                              "
-"  ? for shortcuts                                                               "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_all_segments_disabled.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_all_segments_disabled.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ? for shortcuts                                                               "
+"                                                                                "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_approval_mode_full_access.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_approval_mode_full_access.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ⎇ main · Approvals: Full Access · ? for shortcuts                             "
+"  ⎇ main · Approvals: Full Access                                               "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_approval_mode_read_only.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_approval_mode_read_only.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ⎇ main · Approvals: Read Only · ? for shortcuts                               "
+"  ⎇ main · Approvals: Read Only                                                 "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_cached_tokens.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_cached_tokens.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  Context 27% (34.0K) · Tokens: 155K total (32.0K cached) · ? for shortcuts     "
+"  Context 27% (34.0K) · Tokens: 155K total (32.0K cached)                       "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_context_no_percent.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_context_no_percent.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  Context 34.0K · Tokens: 34.0K total · ? for shortcuts                         "
+"  Context 34.0K · Tokens: 34.0K total                                           "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_git_branch_disabled.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_git_branch_disabled.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  +10 -3 · ? for shortcuts                                                      "
+"  +10 -3                                                                        "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_large_token_usage.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_large_token_usage.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  Context 1.23M · Tokens: 1.23M total · ? for shortcuts                         "
+"  Context 1.23M · Tokens: 1.23M total                                           "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_multiple_active_skillsets.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_multiple_active_skillsets.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ⎇ auto/my-branch-20260220 · Skillsets: clifford, rust-dev · ? for shortcuts   "
+"  ⎇ auto/my-branch-20260220 · Skillsets: clifford, rust-dev                     "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_multiple_segments_disabled.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_multiple_segments_disabled.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  Context 27% (34.0K) · Approvals: Agent · ? for shortcuts                      "
+"  Context 27% (34.0K) · Approvals: Agent                                        "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_no_active_skillsets.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_no_active_skillsets.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ⎇ main · ? for shortcuts                                                      "
+"  ⎇ main                                                                        "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_no_nori.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_no_nori.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  Context 85% · ? for shortcuts                                                 "
+"  Context 85%                                                                   "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_only_git.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_only_git.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ⎇ main · +5 -2 · Context 100% · ? for shortcuts                               "
+"  ⎇ main · +5 -2 · Context 100%                                                 "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_prompt_summary.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_prompt_summary.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  Task: Fix auth bug · ⎇ main · ? for shortcuts                                 "
+"  Task: Fix auth bug · ⎇ main                                                   "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_single_active_skillset.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_single_active_skillset.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ⎇ main · Skillset: python-ml · ? for shortcuts                                "
+"  ⎇ main · Skillset: python-ml                                                  "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_untracked_alert.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_untracked_alert.snap
@@ -1,6 +1,5 @@
 ---
 source: tui/src/bottom_pane/footer.rs
-assertion_line: 680
 expression: terminal.backend()
 ---
-"  ⎇ main · ! · ? for shortcuts                                                  "
+"  ⎇ main · !                                                                    "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_vim_mode_insert.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_vim_mode_insert.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  INSERT · ⎇ main · ? for shortcuts                                             "
+"  INSERT · ⎇ main                                                               "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_vim_mode_normal.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_vim_mode_normal.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  NORMAL · ⎇ main · ? for shortcuts                                             "
+"  NORMAL · ⎇ main                                                               "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_worktree_name_disabled.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_worktree_name_disabled.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ⎇ auto/fix-auth-bug-20260205 · Skillset: clifford · ? for shortcuts           "
+"  ⎇ auto/fix-auth-bug-20260205 · Skillset: clifford                             "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_zero_token_usage.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__footer__tests__footer_with_zero_token_usage.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"  ? for shortcuts                                                               "
+"                                                                                "

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__tests__queued_messages_visible_when_status_hidden_snapshot.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__tests__queued_messages_visible_when_status_hidden_snapshot.snap
@@ -6,6 +6,4 @@ expression: "render_snapshot(&pane, area)"
     ⌥ + ↑ edit                                  
                                                 
                                                 
-› Ask Nori to do anything                       
-                                                
-  ? for shortcuts
+› Ask Nori to do anything

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__tests__status_and_composer_fill_height_without_bottom_padding.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__tests__status_and_composer_fill_height_without_bottom_padding.snap
@@ -5,6 +5,4 @@ expression: "render_snapshot(&pane, area)"
 • Thinking really hard (0s • e
                               
                               
-› Ask Nori to do anything     
-                              
-  ? for shortcuts
+› Ask Nori to do anything

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__tests__status_and_queued_messages_snapshot.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__tests__status_and_queued_messages_snapshot.snap
@@ -7,6 +7,4 @@ expression: "render_snapshot(&pane, area)"
     ⌥ + ↑ edit                                  
                                                 
                                                 
-› Ask Nori to do anything                       
-                                                
-  ? for shortcuts
+› Ask Nori to do anything

--- a/nori-rs/tui/src/chatwidget/constructors.rs
+++ b/nori-rs/tui/src/chatwidget/constructors.rs
@@ -19,7 +19,9 @@ impl ChatWidget {
             fork_context,
         } = common;
         let mut rng = rand::rng();
-        let placeholder = EXAMPLE_PROMPTS[rng.random_range(0..EXAMPLE_PROMPTS.len())].to_string();
+        let placeholder = PROMPT_MODE_PLACEHOLDERS
+            [rng.random_range(0..PROMPT_MODE_PLACEHOLDERS.len())]
+        .to_string();
         let spawn_result = if deferred_spawn {
             // Deferred spawn: create a dummy channel. The real agent will be
             // spawned later via `spawn_deferred_agent()`.
@@ -144,7 +146,9 @@ impl ChatWidget {
             fork_context: _,
         } = common;
         let mut rng = rand::rng();
-        let placeholder = EXAMPLE_PROMPTS[rng.random_range(0..EXAMPLE_PROMPTS.len())].to_string();
+        let placeholder = PROMPT_MODE_PLACEHOLDERS
+            [rng.random_range(0..PROMPT_MODE_PLACEHOLDERS.len())]
+        .to_string();
         let spawn_result = spawn_acp_agent_resume(
             config.clone(),
             acp_session_id,

--- a/nori-rs/tui/src/chatwidget/mod.rs
+++ b/nori-rs/tui/src/chatwidget/mod.rs
@@ -560,13 +560,12 @@ impl Notification {
 
 const AGENT_NOTIFICATION_PREVIEW_GRAPHEMES: usize = 200;
 
-const EXAMPLE_PROMPTS: [&str; 6] = [
-    "Explain this codebase",
-    "Summarize recent commits",
-    "Implement {feature}",
-    "Find and fix a bug in @filename",
-    "Write tests for @filename",
-    "Improve documentation in @filename",
+const PROMPT_MODE_PLACEHOLDERS: [&str; 5] = [
+    "? for shortcuts",
+    "/ for slash command menu",
+    "$ for skill listing",
+    "! for shell commands",
+    "@ for file mentions",
 ];
 
 // Extract the first bold (Markdown) element in the form **...** from `s`.

--- a/nori-rs/tui/src/chatwidget/tests/part1.rs
+++ b/nori-rs/tui/src/chatwidget/tests/part1.rs
@@ -2,6 +2,20 @@ use super::*;
 use pretty_assertions::assert_eq;
 
 #[test]
+fn composer_placeholder_pool_advertises_prompt_capabilities() {
+    assert_eq!(
+        PROMPT_MODE_PLACEHOLDERS,
+        [
+            "? for shortcuts",
+            "/ for slash command menu",
+            "$ for skill listing",
+            "! for shell commands",
+            "@ for file mentions",
+        ],
+    );
+}
+
+#[test]
 fn resumed_initial_messages_render_history() {
     let (mut chat, mut rx, _ops) = make_chatwidget_manual();
 

--- a/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part3__status_widget_active.snap
+++ b/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part3__status_widget_active.snap
@@ -8,4 +8,3 @@ expression: terminal.backend()
 "                                                                                "
 "› Ask Nori to do anything                                                       "
 "                                                                                "
-"  ? for shortcuts                                                               "

--- a/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part4__chatwidget_tall.snap
+++ b/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part4__chatwidget_tall.snap
@@ -20,8 +20,7 @@ expression: term.backend().vt100().screen().contents()
   ↳ Hello, world! 14
   ↳ Hello, world! 15
   ↳ Hello, world! 16
+  ↳ Hello, world! 17
 
 
 › Ask Nori to do anything
-
-  ? for shortcuts


### PR DESCRIPTION
## Summary
- Replace task-example composer placeholders with rotating capability hints for `?`, `/`, `$`, `!`, and `@`.
- Remove the always-visible `? for shortcuts` footer row while preserving the expanded shortcut overlay behavior.
- Update TUI/e2e snapshots and readiness checks for the compact footer layout.

## Test Plan
- [x] `cargo test -p nori-tui`
- [x] `cargo build --bin nori`
- [x] `cargo test -p tui-pty-e2e`
- [x] `cargo insta pending-snapshots`
- [x] `just fmt`
- [x] `just fix -p nori-tui`
- [x] `just fix -p tui-pty-e2e`
- [x] TUI tmux verification with ElizACP: prompt rendered, accepted `hello`, prompt returned

🤖 Generated with [Nori](https://noriagentic.com/)

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets
