### PR TITLE
feat(tui): Make agent option history user-facing

### DIFF
--- a/nori-rs/acp/src/backend/session_reducer/tests.rs
+++ b/nori-rs/acp/src/backend/session_reducer/tests.rs
@@ -804,8 +804,8 @@ fn config_option_update_is_accepted_while_idle_and_emits_info_event() {
     )));
     assert!(has_event(&out.events, |e| matches!(
         e,
-        ClientEvent::SessionUpdateInfo(info)
-            if info.kind == nori_protocol::SessionUpdateKind::ConfigOptions
+        ClientEvent::SessionConfigUpdate(update)
+            if update.config_options == vec![sample_config_option()]
     )));
 }
 

--- a/nori-rs/acp/src/backend/session_runtime_driver.rs
+++ b/nori-rs/acp/src/backend/session_runtime_driver.rs
@@ -39,6 +39,7 @@ pub(crate) struct ReducerActions {
 fn client_event_kind(event: &ClientEvent) -> &'static str {
     match event {
         ClientEvent::SessionUpdateInfo(_) => "session_update_info",
+        ClientEvent::SessionConfigUpdate(_) => "session_config_update",
         ClientEvent::SessionPhaseChanged(_) => "session_phase_changed",
         ClientEvent::QueueChanged(_) => "queue_changed",
         ClientEvent::MessageDelta(_) => "message_delta",

--- a/nori-rs/acp/src/backend/transcript.rs
+++ b/nori-rs/acp/src/backend/transcript.rs
@@ -210,6 +210,7 @@ fn replay_entry_from_client_event(
         | nori_protocol::ClientEvent::ReplayEntry(_)
         | nori_protocol::ClientEvent::AgentCommandsUpdate(_)
         | nori_protocol::ClientEvent::SessionUpdateInfo(_)
+        | nori_protocol::ClientEvent::SessionConfigUpdate(_)
         | nori_protocol::ClientEvent::Warning(_) => None,
     }
 }

--- a/nori-rs/nori-protocol/docs.md
+++ b/nori-rs/nori-protocol/docs.md
@@ -6,7 +6,7 @@ Path: @/nori-rs/nori-protocol
 
 - Defines the normalized `ClientEvent` protocol that sits between raw ACP session updates (from `agent-client-protocol-schema`) and the TUI rendering layer. All ACP tool calls, messages, plans, approvals, and replay entries are transformed into this crate's types before reaching the TUI.
 - The `ClientEventNormalizer` is the stateful entry point: it accepts `acp::SessionUpdate` and `acp::RequestPermissionRequest` values and emits `Vec<ClientEvent>`.
-- Session-scoped ACP metadata is normalized into `ClientEvent::SessionUpdateInfo`, giving the rest of the stack one minimal rendering/replay path for mode, config, and session-info updates while still letting usage updates carry structured footer state.
+- Session-scoped ACP metadata is normalized into compact client events: simple mode/session/usage notes use `ClientEvent::SessionUpdateInfo`, while ACP session config snapshots use `ClientEvent::SessionConfigUpdate` so the TUI can diff option values without parsing display text.
 - Single-file crate (`lib.rs`) with no submodules.
 
 ### How it fits into the larger codebase
@@ -29,7 +29,8 @@ agent_client_protocol_schema::SessionUpdate
 - **`SessionRuntime` support types** in `session_runtime.rs` define the reducer-owned ACP runtime model used by `nori-acp`: `SessionPhase`, `PersistedSessionState`, `ActiveRequestState`, `OpenMessage`, and `QueuedPrompt`. These types let the backend treat prompt turns, `session/load`, queued prompts, and ownership of tool/approval updates as one ordered state machine instead of reconstructing turn state from racing tasks. `ActiveRequestState` keeps the last flushed assistant text so `PromptCompleted { last_agent_message, .. }` remains correct even when a later reasoning chunk closes the assistant buffer before the turn ends.
 - **Session update normalization** keeps the first pass intentionally small:
   - `UserMessageChunk` becomes `MessageDelta { stream: User, .. }`, which lets replay paths reconstruct visible user history during `session/load`.
-  - `CurrentModeUpdate`, `ConfigOptionUpdate`, and `SessionInfoUpdate` become lightweight `SessionUpdateInfo` summaries.
+  - `CurrentModeUpdate` and `SessionInfoUpdate` become lightweight `SessionUpdateInfo` summaries.
+  - `ConfigOptionUpdate` becomes `SessionConfigUpdate`, preserving the full option snapshot so the TUI can show only changed user-facing option values.
   - `UsageUpdate` also becomes `SessionUpdateInfo`, but the usage variant additionally carries `SessionUsageState` so the TUI can update footer context without reparsing the display string.
 - **Persisted session metadata** now includes `session_info` and `session_usage` alongside available commands, current mode, and config options. `nori-acp` owns persistence, but these structs live here so the reducer and replay pipeline share one runtime model.
 - **`is_generic_tool_call()`** gates initial `ToolCall` emission: tool calls with no `raw_input`, no `locations`, empty `content`, and no `/` in the title are suppressed (return empty `Vec`). The normalizer still records them internally so that later attributed `ToolCallUpdate` messages can refine the existing call without forcing the TUI to render a placeholder cell first.

--- a/nori-rs/nori-protocol/src/lib.rs
+++ b/nori-rs/nori-protocol/src/lib.rs
@@ -24,6 +24,7 @@ pub enum ClientEvent {
     ReplayEntry(ReplayEntry),
     AgentCommandsUpdate(AgentCommandsUpdate),
     SessionUpdateInfo(SessionUpdateInfo),
+    SessionConfigUpdate(SessionConfigUpdate),
     Warning(WarningInfo),
 }
 
@@ -68,6 +69,12 @@ pub struct AgentCommandInfo {
     pub name: String,
     pub description: String,
     pub input_hint: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SessionConfigUpdate {
+    pub config_options: Vec<acp::SessionConfigOption>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -371,9 +378,9 @@ impl ClientEventNormalizer {
                 )]
             }
             acp::SessionUpdate::ConfigOptionUpdate(update) => {
-                vec![ClientEvent::SessionUpdateInfo(
-                    session_update_info_from_config_options(update),
-                )]
+                vec![ClientEvent::SessionConfigUpdate(SessionConfigUpdate {
+                    config_options: update.config_options.clone(),
+                })]
             }
             acp::SessionUpdate::SessionInfoUpdate(update) => {
                 vec![ClientEvent::SessionUpdateInfo(
@@ -960,26 +967,6 @@ fn session_update_info_from_current_mode(update: &acp::CurrentModeUpdate) -> Ses
     SessionUpdateInfo {
         kind: SessionUpdateKind::CurrentMode,
         message: format!("ACP mode changed to {}", update.current_mode_id),
-        hint: None,
-        usage: None,
-    }
-}
-
-fn session_update_info_from_config_options(update: &acp::ConfigOptionUpdate) -> SessionUpdateInfo {
-    let names = update
-        .config_options
-        .iter()
-        .map(|option| option.name.as_str())
-        .collect::<Vec<_>>();
-    let message = if names.is_empty() {
-        "ACP config options updated".to_string()
-    } else {
-        format!("ACP config options updated: {}", names.join(", "))
-    };
-
-    SessionUpdateInfo {
-        kind: SessionUpdateKind::ConfigOptions,
-        message,
         hint: None,
         usage: None,
     }
@@ -2131,13 +2118,11 @@ mod tests {
         let events = normalizer.push_session_update(&update);
         assert_eq!(events.len(), 1);
 
-        let ClientEvent::SessionUpdateInfo(info) = &events[0] else {
-            panic!("expected SessionUpdateInfo");
+        let ClientEvent::SessionConfigUpdate(update) = &events[0] else {
+            panic!("expected SessionConfigUpdate");
         };
 
-        assert_eq!(info.kind, SessionUpdateKind::ConfigOptions);
-        assert_eq!(info.message, "ACP config options updated: Verbosity");
-        assert_eq!(info.hint, None);
+        assert_eq!(update.config_options, vec![sample_config_option()]);
     }
 
     #[test]

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -203,6 +203,10 @@ The Nori-specific agent picker UI lives in `nori/agent_picker.rs`, allowing user
 
 When an ACP agent exposes a select-style session config option categorized as `Mode` (or using id `mode`), the TUI derives a compact mode snapshot from the same live `config_options` data used by `/config`. The current mode label flows into the normal footer segment pipeline as the `mode_indicator` segment, rendered as compact bracketed text such as `[ Plan ]`; labels longer than 20 characters are truncated with an ellipsis. By default, the segment appears in the right side of the footer line and is skipped entirely when the selected agent does not expose mode options. While the composer has focus and no popup is active, `Shift-Tab` fetches the current ACP session config snapshot from the agent handle, chooses the next mode value in the agent-provided option order (including grouped options), and applies it through `session/set_config_option`. Successful changes from either `Shift-Tab` or the ACP `/config` menu refresh the footer segment through `AppEvent::AcpModeConfigSnapshot`. This remains live-session only and does not persist mode selections to `config.toml`.
 
+**Agent Options History** (`nori/session_config_history.rs`, `chatwidget/event_handlers.rs`, `chatwidget/pickers.rs`):
+
+Live `ClientEvent::SessionConfigUpdate` events carry the full ACP session config snapshot into the TUI. `ChatWidget` stores the first supported select-option snapshot as a silent baseline, then compares later snapshots against it and writes a user-facing history line only for values that actually changed, such as `Claude Code option updated: Effort=High`. User-triggered `/config` changes skip the old intermediate "updating" history line and render a single final message, such as `Claude Code option set: Model=Opus 4.6`; the returned snapshot is synced immediately so a later backend echo does not duplicate the same update. Unsupported config kinds, newly added options, and removed options are ignored for history noise while still allowing the mode footer snapshot to refresh from supported values.
+
 **System Info Collection** (`system_info.rs`):
 
 The `SystemInfo` struct collects environment data in a background thread to avoid blocking TUI startup:
@@ -369,7 +373,7 @@ Claude-backed agents have an additional compatibility path in `skill_picker_item
 
 **Live ACP Session Config Picker** (`chatwidget/pickers.rs`, `nori/session_config_picker.rs`):
 
-`/config` opens a two-step picker for the current ACP session. `ChatWidget::open_session_config_popup()` asks the `AcpAgentHandle` for the live `AcpBackend::config_options()` snapshot, renders supported `select` options, then opens a value picker for the selected option. Selecting a value sends `session/set_config_option` through `AcpBackend::set_config_option()` and shows an info or error message when the RPC finishes.
+`/config` opens a two-step picker for the current ACP session. `ChatWidget::open_session_config_popup()` asks the `AcpAgentHandle` for the live `AcpBackend::config_options()` snapshot, renders supported `select` options, then opens a value picker for the selected option. Selecting a value sends `session/set_config_option` through `AcpBackend::set_config_option()` and shows a single final info or error message when the RPC finishes.
 
 The picker intentionally only edits the active session. It does not run during `/agent` switching and it does not persist selected values. Unsupported ACP config kinds and future non-exhaustive select layouts are treated as unavailable rather than guessed.
 

--- a/nori-rs/tui/src/app/event_handling.rs
+++ b/nori-rs/tui/src/app/event_handling.rs
@@ -756,6 +756,13 @@ impl App {
                     );
                 }
             }
+            AppEvent::AcpSessionConfigSnapshot {
+                generation,
+                config_options,
+            } => {
+                self.chat_widget
+                    .handle_acp_session_config_snapshot(generation, &config_options);
+            }
             AppEvent::AcpModeConfigSnapshot { generation, mode } => {
                 self.chat_widget
                     .apply_acp_mode_config_snapshot(generation, mode);

--- a/nori-rs/tui/src/app/event_handling.rs
+++ b/nori-rs/tui/src/app/event_handling.rs
@@ -738,11 +738,16 @@ impl App {
                 success,
                 option_name,
                 value_name,
+                config_options,
                 error,
             } => {
                 if success {
                     self.chat_widget
-                        .add_info_message(format!("{option_name} set to: {value_name}"), None);
+                        .add_acp_session_config_set_message(&option_name, &value_name);
+                    if let Some(config_options) = config_options {
+                        self.chat_widget
+                            .sync_acp_session_config_snapshot(&config_options);
+                    }
                 } else {
                     let error_msg = error.unwrap_or_else(|| "Unknown error".to_string());
                     self.chat_widget.add_info_message(

--- a/nori-rs/tui/src/app_event.rs
+++ b/nori-rs/tui/src/app_event.rs
@@ -264,6 +264,12 @@ pub(crate) enum AppEvent {
         error: Option<String>,
     },
 
+    /// Latest raw ACP session config for silently seeding local UI state.
+    AcpSessionConfigSnapshot {
+        generation: i64,
+        config_options: Vec<SessionConfigOption>,
+    },
+
     /// Latest derived ACP mode config for the active session.
     AcpModeConfigSnapshot {
         generation: i64,

--- a/nori-rs/tui/src/app_event.rs
+++ b/nori-rs/tui/src/app_event.rs
@@ -260,6 +260,7 @@ pub(crate) enum AppEvent {
         success: bool,
         option_name: String,
         value_name: String,
+        config_options: Option<Vec<SessionConfigOption>>,
         error: Option<String>,
     },
 

--- a/nori-rs/tui/src/bottom_pane/mod.rs
+++ b/nori-rs/tui/src/bottom_pane/mod.rs
@@ -430,6 +430,10 @@ impl BottomPane {
         self.refresh_agent_command_descriptions();
     }
 
+    pub(crate) fn agent_display_name(&self) -> &str {
+        &self.agent_display_name
+    }
+
     pub(crate) fn set_acp_wire_recording_enabled(&mut self, enabled: bool) {
         self.acp_wire_recording_enabled = enabled;
         self.refresh_agent_command_descriptions();

--- a/nori-rs/tui/src/chatwidget/constructors.rs
+++ b/nori-rs/tui/src/chatwidget/constructors.rs
@@ -99,6 +99,7 @@ impl ChatWidget {
             expected_agent,
             session_configured_received: false,
             acp_handle: spawn_result.acp_handle,
+            acp_config_option_snapshot: None,
             acp_mode_config: None,
             acp_mode_config_generation: super::session_config_mode::next_acp_mode_config_generation(
             ),
@@ -221,6 +222,7 @@ impl ChatWidget {
             expected_agent,
             session_configured_received: false,
             acp_handle: spawn_result.acp_handle,
+            acp_config_option_snapshot: None,
             acp_mode_config: None,
             acp_mode_config_generation: super::session_config_mode::next_acp_mode_config_generation(
             ),

--- a/nori-rs/tui/src/chatwidget/event_handlers.rs
+++ b/nori-rs/tui/src/chatwidget/event_handlers.rs
@@ -1153,9 +1153,14 @@ impl ChatWidget {
             nori_protocol::ClientEvent::AgentCommandsUpdate(update) => {
                 self.bottom_pane.set_agent_commands(update.commands);
             }
+            nori_protocol::ClientEvent::SessionConfigUpdate(update) => {
+                self.handle_acp_session_config_update(&update.config_options);
+            }
             nori_protocol::ClientEvent::SessionUpdateInfo(update) => {
                 if update.kind == nori_protocol::SessionUpdateKind::ConfigOptions {
                     self.refresh_acp_mode_config_snapshot();
+                    self.request_redraw();
+                    return;
                 }
                 if update.kind == nori_protocol::SessionUpdateKind::Usage
                     && let Some(usage) = update.usage

--- a/nori-rs/tui/src/chatwidget/helpers.rs
+++ b/nori-rs/tui/src/chatwidget/helpers.rs
@@ -98,6 +98,18 @@ impl ChatWidget {
         );
     }
 
+    pub(crate) fn handle_acp_session_config_snapshot(
+        &mut self,
+        generation: i64,
+        config_options: &[nori_acp::SessionConfigOption],
+    ) {
+        if generation != self.acp_mode_config_generation {
+            return;
+        }
+
+        self.sync_acp_session_config_snapshot(config_options);
+    }
+
     pub(crate) fn add_acp_session_config_set_message(
         &mut self,
         option_name: &str,

--- a/nori-rs/tui/src/chatwidget/helpers.rs
+++ b/nori-rs/tui/src/chatwidget/helpers.rs
@@ -55,6 +55,64 @@ impl ChatWidget {
         self.request_redraw();
     }
 
+    pub(crate) fn handle_acp_session_config_update(
+        &mut self,
+        config_options: &[nori_acp::SessionConfigOption],
+    ) {
+        let next_snapshot =
+            crate::nori::session_config_history::snapshot_from_options(config_options);
+
+        if let Some(previous_snapshot) = &self.acp_config_option_snapshot {
+            let changes = crate::nori::session_config_history::changed_values(
+                previous_snapshot,
+                config_options,
+            );
+            if !changes.is_empty() {
+                self.add_to_history(
+                    crate::nori::session_config_history::new_agent_options_history_cell(
+                        self.bottom_pane.agent_display_name(),
+                        &changes,
+                    ),
+                );
+            }
+        }
+
+        self.acp_config_option_snapshot = Some(next_snapshot);
+        self.apply_acp_mode_config_snapshot(
+            self.acp_mode_config_generation,
+            crate::nori::session_config_mode::acp_mode_config_from_options(config_options),
+        );
+        self.request_redraw();
+    }
+
+    pub(crate) fn sync_acp_session_config_snapshot(
+        &mut self,
+        config_options: &[nori_acp::SessionConfigOption],
+    ) {
+        self.acp_config_option_snapshot = Some(
+            crate::nori::session_config_history::snapshot_from_options(config_options),
+        );
+        self.apply_acp_mode_config_snapshot(
+            self.acp_mode_config_generation,
+            crate::nori::session_config_mode::acp_mode_config_from_options(config_options),
+        );
+    }
+
+    pub(crate) fn add_acp_session_config_set_message(
+        &mut self,
+        option_name: &str,
+        value_name: &str,
+    ) {
+        self.add_to_history(
+            crate::nori::session_config_history::new_agent_option_set_history_cell(
+                self.bottom_pane.agent_display_name(),
+                option_name,
+                value_name,
+            ),
+        );
+        self.request_redraw();
+    }
+
     pub(crate) fn add_plain_history_lines(&mut self, lines: Vec<Line<'static>>) {
         self.add_boxed_history(Box::new(PlainHistoryCell::new(lines)));
         self.request_redraw();

--- a/nori-rs/tui/src/chatwidget/mod.rs
+++ b/nori-rs/tui/src/chatwidget/mod.rs
@@ -405,6 +405,7 @@ pub(crate) struct ChatWidget {
     session_configured_received: bool,
     // ACP agent handle for session config and model switching (only present in ACP mode)
     acp_handle: Option<AcpAgentHandle>,
+    acp_config_option_snapshot: Option<crate::nori::session_config_history::SessionConfigSnapshot>,
     acp_mode_config: Option<crate::nori::session_config_mode::AcpModeConfig>,
     acp_mode_config_generation: i64,
     // Session statistics tracking

--- a/nori-rs/tui/src/chatwidget/pickers.rs
+++ b/nori-rs/tui/src/chatwidget/pickers.rs
@@ -750,8 +750,8 @@ impl ChatWidget {
         if let Some(handle) = self.acp_handle.clone() {
             let app_event_tx = self.app_event_tx.clone();
             let generation = self.acp_mode_config_generation;
-            let option_name_for_result = option_name.clone();
-            let value_name_for_result = value_name.clone();
+            let option_name_for_result = option_name;
+            let value_name_for_result = value_name;
             tokio::spawn(async move {
                 match handle.set_session_config_option(config_id, value).await {
                     Ok(config_options) => {
@@ -765,6 +765,7 @@ impl ChatWidget {
                             success: true,
                             option_name: option_name_for_result,
                             value_name: value_name_for_result,
+                            config_options: Some(config_options),
                             error: None,
                         });
                     }
@@ -773,12 +774,12 @@ impl ChatWidget {
                             success: false,
                             option_name: option_name_for_result,
                             value_name: value_name_for_result,
+                            config_options: None,
                             error: Some(err.to_string()),
                         });
                     }
                 }
             });
-            self.add_info_message(format!("Updating {option_name} to: {value_name}..."), None);
         } else {
             self.add_info_message(
                 "No ACP agent handle available for session config".to_string(),

--- a/nori-rs/tui/src/chatwidget/session_config_mode.rs
+++ b/nori-rs/tui/src/chatwidget/session_config_mode.rs
@@ -74,6 +74,7 @@ impl ChatWidget {
                             success: true,
                             option_name: "Mode".to_string(),
                             value_name,
+                            config_options: Some(config_options),
                             error: None,
                         });
                     }
@@ -82,6 +83,7 @@ impl ChatWidget {
                             success: false,
                             option_name: "Mode".to_string(),
                             value_name: value_name.clone(),
+                            config_options: None,
                             error: Some(err.to_string()),
                         });
                         if let Some(config_options) = handle.get_session_config().await {
@@ -129,6 +131,7 @@ impl ChatWidget {
                         success: true,
                         option_name: "Mode".to_string(),
                         value_name,
+                        config_options: Some(config_options),
                         error: None,
                     });
                 }
@@ -137,6 +140,7 @@ impl ChatWidget {
                         success: false,
                         option_name: "Mode".to_string(),
                         value_name: mode.next_label,
+                        config_options: None,
                         error: Some(err.to_string()),
                     });
                 }

--- a/nori-rs/tui/src/chatwidget/session_config_mode.rs
+++ b/nori-rs/tui/src/chatwidget/session_config_mode.rs
@@ -39,11 +39,9 @@ impl ChatWidget {
             let Some(config_options) = handle.get_session_config().await else {
                 return;
             };
-            app_event_tx.send(AppEvent::AcpModeConfigSnapshot {
+            app_event_tx.send(AppEvent::AcpSessionConfigSnapshot {
                 generation,
-                mode: crate::nori::session_config_mode::acp_mode_config_from_options(
-                    &config_options,
-                ),
+                config_options,
             });
         });
     }

--- a/nori-rs/tui/src/chatwidget/tests/mod.rs
+++ b/nori-rs/tui/src/chatwidget/tests/mod.rs
@@ -308,6 +308,7 @@ pub(crate) fn make_chatwidget_manual() -> (
         session_configured_received: false,
         #[cfg(feature = "unstable")]
         acp_handle: None,
+        acp_config_option_snapshot: None,
         acp_mode_config: None,
         acp_mode_config_generation: super::session_config_mode::next_acp_mode_config_generation(),
         session_stats: crate::session_stats::SessionStats::new(),

--- a/nori-rs/tui/src/chatwidget/tests/part3.rs
+++ b/nori-rs/tui/src/chatwidget/tests/part3.rs
@@ -414,6 +414,134 @@ fn session_update_info_events_only_render_non_usage_history() {
     assert_snapshot!("session_update_info_history", combined);
 }
 
+fn select_config_option(
+    id: &'static str,
+    name: &'static str,
+    current_value: &'static str,
+    values: &[(&'static str, &'static str)],
+) -> nori_acp::SessionConfigOption {
+    nori_acp::SessionConfigOption::select(
+        id,
+        name,
+        current_value,
+        values
+            .iter()
+            .map(|(value, label)| nori_acp::SessionConfigSelectOption::new(*value, *label))
+            .collect::<Vec<_>>(),
+    )
+}
+
+#[test]
+fn session_config_update_history_shows_only_changed_values_after_baseline() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
+    chat.set_agent("claude-code");
+
+    chat.handle_client_event(nori_protocol::ClientEvent::SessionConfigUpdate(
+        nori_protocol::SessionConfigUpdate {
+            config_options: vec![
+                select_config_option(
+                    "mode",
+                    "Mode",
+                    "default",
+                    &[("default", "Default"), ("plan", "Plan")],
+                ),
+                select_config_option(
+                    "model",
+                    "Model",
+                    "opus-4-6",
+                    &[("opus-4-6", "Opus 4.6"), ("sonnet-4-6", "Sonnet 4.6")],
+                ),
+                select_config_option(
+                    "effort",
+                    "Effort",
+                    "medium",
+                    &[("medium", "Medium"), ("high", "High")],
+                ),
+            ],
+        },
+    ));
+    assert!(
+        drain_insert_history(&mut rx).is_empty(),
+        "the first config snapshot should establish a baseline without history noise"
+    );
+
+    chat.handle_client_event(nori_protocol::ClientEvent::SessionConfigUpdate(
+        nori_protocol::SessionConfigUpdate {
+            config_options: vec![
+                select_config_option(
+                    "mode",
+                    "Mode",
+                    "default",
+                    &[("default", "Default"), ("plan", "Plan")],
+                ),
+                select_config_option(
+                    "model",
+                    "Model",
+                    "opus-4-6",
+                    &[("opus-4-6", "Opus 4.6"), ("sonnet-4-6", "Sonnet 4.6")],
+                ),
+                select_config_option(
+                    "effort",
+                    "Effort",
+                    "high",
+                    &[("medium", "Medium"), ("high", "High")],
+                ),
+            ],
+        },
+    ));
+
+    let cells = drain_insert_history(&mut rx);
+    let rendered = cells
+        .iter()
+        .map(|lines| lines_to_single_string(lines))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert_snapshot!("session_config_update_changed_values_history", rendered);
+}
+
+#[test]
+fn session_config_set_history_uses_final_agent_named_message() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
+    chat.set_agent("claude-code");
+
+    chat.add_acp_session_config_set_message("Model", "Opus 4.6");
+
+    let cells = drain_insert_history(&mut rx);
+    let rendered = cells
+        .iter()
+        .map(|lines| lines_to_single_string(lines))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert_snapshot!("session_config_set_history", rendered);
+}
+
+#[test]
+fn synced_session_config_snapshot_prevents_duplicate_update_history() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
+    chat.set_agent("claude-code");
+    let config_options = vec![select_config_option(
+        "model",
+        "Model",
+        "opus-4-6",
+        &[("opus-4-6", "Opus 4.6"), ("sonnet-4-6", "Sonnet 4.6")],
+    )];
+
+    chat.add_acp_session_config_set_message("Model", "Opus 4.6");
+    chat.sync_acp_session_config_snapshot(&config_options);
+    assert_eq!(drain_insert_history(&mut rx).len(), 1);
+
+    chat.handle_client_event(nori_protocol::ClientEvent::SessionConfigUpdate(
+        nori_protocol::SessionConfigUpdate { config_options },
+    ));
+
+    assert!(
+        drain_insert_history(&mut rx).is_empty(),
+        "a backend echo of a synced picker result should not duplicate history"
+    );
+}
+
 #[test]
 fn session_usage_updates_footer_and_disables_transcript_fallback() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();

--- a/nori-rs/tui/src/chatwidget/tests/part3.rs
+++ b/nori-rs/tui/src/chatwidget/tests/part3.rs
@@ -543,6 +543,44 @@ fn synced_session_config_snapshot_prevents_duplicate_update_history() {
 }
 
 #[test]
+fn session_config_snapshot_seeds_first_update_history_baseline() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
+    chat.set_agent("claude-code");
+    let baseline = vec![select_config_option(
+        "effort",
+        "Effort",
+        "medium",
+        &[("medium", "Medium"), ("high", "High")],
+    )];
+
+    chat.handle_acp_session_config_snapshot(chat.acp_mode_config_generation(), &baseline);
+    assert!(
+        drain_insert_history(&mut rx).is_empty(),
+        "initial session config fetched for the footer should not add history noise"
+    );
+
+    chat.handle_client_event(nori_protocol::ClientEvent::SessionConfigUpdate(
+        nori_protocol::SessionConfigUpdate {
+            config_options: vec![select_config_option(
+                "effort",
+                "Effort",
+                "high",
+                &[("medium", "Medium"), ("high", "High")],
+            )],
+        },
+    ));
+
+    let cells = drain_insert_history(&mut rx);
+    let rendered = cells
+        .iter()
+        .map(|lines| lines_to_single_string(lines))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert_eq!(rendered, "• Claude Code option updated: Effort=High\n");
+}
+
+#[test]
 fn session_usage_updates_footer_and_disables_transcript_fallback() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
 

--- a/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part3__session_config_set_history.snap
+++ b/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part3__session_config_set_history.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/chatwidget/tests/part3.rs
+expression: rendered
+---
+• Claude Code option set: Model=Opus 4.6

--- a/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part3__session_config_update_changed_values_history.snap
+++ b/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part3__session_config_update_changed_values_history.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/chatwidget/tests/part3.rs
+expression: rendered
+---
+• Claude Code option updated: Effort=High

--- a/nori-rs/tui/src/nori/mod.rs
+++ b/nori-rs/tui/src/nori/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod exit_message;
 pub(crate) mod fork_picker;
 pub(crate) mod onboarding;
 pub(crate) mod resume_session_picker;
+pub(crate) mod session_config_history;
 pub(crate) mod session_config_mode;
 pub(crate) mod session_config_picker;
 pub(crate) mod session_header;

--- a/nori-rs/tui/src/nori/session_config_history.rs
+++ b/nori-rs/tui/src/nori/session_config_history.rs
@@ -1,0 +1,111 @@
+//! User-facing history rendering for ACP session config snapshots.
+
+use std::collections::BTreeMap;
+
+use nori_acp as acp;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+
+use crate::history_cell::PlainHistoryCell;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SessionConfigDisplayValue {
+    pub(crate) name: String,
+    pub(crate) value: String,
+}
+
+pub(crate) type SessionConfigSnapshot = BTreeMap<String, SessionConfigDisplayValue>;
+
+pub(crate) fn snapshot_from_options(
+    config_options: &[acp::SessionConfigOption],
+) -> SessionConfigSnapshot {
+    config_options
+        .iter()
+        .filter_map(|option| display_value(option).map(|display| (option.id.to_string(), display)))
+        .collect()
+}
+
+pub(crate) fn changed_values(
+    previous: &SessionConfigSnapshot,
+    config_options: &[acp::SessionConfigOption],
+) -> Vec<SessionConfigDisplayValue> {
+    config_options
+        .iter()
+        .filter_map(|option| {
+            let current = display_value(option)?;
+            let previous = previous.get(&option.id.to_string())?;
+            (previous.value != current.value).then_some(current)
+        })
+        .collect()
+}
+
+pub(crate) fn new_agent_options_history_cell(
+    agent_display_name: &str,
+    changes: &[SessionConfigDisplayValue],
+) -> PlainHistoryCell {
+    let agent_display_name = if agent_display_name.is_empty() {
+        "Agent"
+    } else {
+        agent_display_name
+    };
+    let noun = if changes.len() == 1 {
+        "option"
+    } else {
+        "options"
+    };
+    let mut line = vec![
+        "• ".dim(),
+        format!("{agent_display_name} {noun} updated: ").into(),
+    ];
+
+    for (index, change) in changes.iter().enumerate() {
+        if index > 0 {
+            line.push(", ".into());
+        }
+        line.push(format!("{}={}", change.name, change.value).cyan().bold());
+    }
+
+    PlainHistoryCell::new(vec![Line::from(line)])
+}
+
+pub(crate) fn new_agent_option_set_history_cell(
+    agent_display_name: &str,
+    option_name: &str,
+    value_name: &str,
+) -> PlainHistoryCell {
+    let agent_display_name = if agent_display_name.is_empty() {
+        "Agent"
+    } else {
+        agent_display_name
+    };
+    PlainHistoryCell::new(vec![Line::from(vec![
+        "• ".dim(),
+        format!("{agent_display_name} option set: ").into(),
+        format!("{option_name}={value_name}").cyan().bold(),
+    ])])
+}
+
+fn display_value(option: &acp::SessionConfigOption) -> Option<SessionConfigDisplayValue> {
+    let acp::SessionConfigKind::Select(select) = &option.kind else {
+        return None;
+    };
+
+    let value = match &select.options {
+        acp::SessionConfigSelectOptions::Ungrouped(options) => options
+            .iter()
+            .find(|value| value.value == select.current_value)
+            .map(|value| value.name.clone()),
+        acp::SessionConfigSelectOptions::Grouped(groups) => groups
+            .iter()
+            .flat_map(|group| group.options.iter())
+            .find(|value| value.value == select.current_value)
+            .map(|value| value.name.clone()),
+        _ => None,
+    }
+    .unwrap_or_else(|| select.current_value.to_string());
+
+    Some(SessionConfigDisplayValue {
+        name: option.name.clone(),
+        value,
+    })
+}

--- a/nori-rs/tui/src/nori/session_config_picker.rs
+++ b/nori-rs/tui/src/nori/session_config_picker.rs
@@ -187,14 +187,18 @@ fn value_item(
     let value_name = option_value.name.clone();
     let group_name = group_name.map(str::to_string);
 
-    let actions: Vec<SelectionAction> = vec![Box::new(move |tx| {
-        tx.send(AppEvent::SetAcpSessionConfigOption {
-            config_id: config_id.clone(),
-            value: value.clone(),
-            option_name: option_name.clone(),
-            value_name: value_name.clone(),
-        });
-    })];
+    let actions: Vec<SelectionAction> = if is_current {
+        Vec::new()
+    } else {
+        vec![Box::new(move |tx| {
+            tx.send(AppEvent::SetAcpSessionConfigOption {
+                config_id: config_id.clone(),
+                value: value.clone(),
+                option_name: option_name.clone(),
+                value_name: value_name.clone(),
+            });
+        })]
+    };
 
     let description = match (&option_value.description, group_name) {
         (Some(description), Some(group_name)) => Some(format!("[{group_name}] {description}")),
@@ -291,6 +295,62 @@ mod tests {
         assert_eq!(names, vec!["[Safe]", "Ask", "[Active]", "Plan", "Build"]);
         assert!(params.items[3].is_current);
         assert_eq!(params.initial_selected_idx, Some(3));
+    }
+
+    #[test]
+    fn value_picker_current_value_has_no_set_action() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let app_event_tx = crate::app_event_sender::AppEventSender::new(tx);
+        let mut current_view = crate::bottom_pane::ListSelectionView::new(
+            super::acp_session_config_value_picker_params(&model_option()),
+            app_event_tx.clone(),
+        );
+
+        crate::bottom_pane::BottomPaneView::handle_key_event(
+            &mut current_view,
+            crossterm::event::KeyEvent::new(
+                crossterm::event::KeyCode::Enter,
+                crossterm::event::KeyModifiers::NONE,
+            ),
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "accepting the already-current value should not request a config change"
+        );
+
+        let mut alternate_view = crate::bottom_pane::ListSelectionView::new(
+            super::acp_session_config_value_picker_params(&model_option()),
+            app_event_tx,
+        );
+        crate::bottom_pane::BottomPaneView::handle_key_event(
+            &mut alternate_view,
+            crossterm::event::KeyEvent::new(
+                crossterm::event::KeyCode::Down,
+                crossterm::event::KeyModifiers::NONE,
+            ),
+        );
+        crate::bottom_pane::BottomPaneView::handle_key_event(
+            &mut alternate_view,
+            crossterm::event::KeyEvent::new(
+                crossterm::event::KeyCode::Enter,
+                crossterm::event::KeyModifiers::NONE,
+            ),
+        );
+
+        let event = rx.try_recv().expect("alternate value emits config change");
+        assert!(matches!(
+            event,
+            AppEvent::SetAcpSessionConfigOption {
+                config_id,
+                value,
+                option_name,
+                value_name,
+            } if config_id == "model"
+                && value == "mock-model-fast"
+                && option_name == "Model"
+                && value_name == "Mock Fast Model"
+        ));
+        assert!(rx.try_recv().is_err(), "expected a single config event");
     }
 
     #[test]

--- a/nori-rs/tui/src/viewonly_transcript.rs
+++ b/nori-rs/tui/src/viewonly_transcript.rs
@@ -177,6 +177,7 @@ fn format_client_event(event: &nori_protocol::ClientEvent) -> Option<String> {
         | nori_protocol::ClientEvent::ContextCompacted(_)
         | nori_protocol::ClientEvent::ReplayEntry(_)
         | nori_protocol::ClientEvent::AgentCommandsUpdate(_)
+        | nori_protocol::ClientEvent::SessionConfigUpdate(_)
         | nori_protocol::ClientEvent::Warning(_) => None,
     }
 }


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- Replace raw ACP config history messages with agent-named, changed-only option history.
- Remove noisy in-progress session config history lines and suppress redundant current-value selections.
- Seed initial config snapshots silently so the first real backend update is still shown.

## Test Plan
- [x] `env RUSTC_WRAPPER= cargo test -p nori-protocol`
- [x] `env RUSTC_WRAPPER= cargo test -p nori-acp`
- [x] `env RUSTC_WRAPPER= cargo test -p nori-tui`
- [x] `env RUSTC_WRAPPER= cargo build --bin nori`
- [x] `env RUSTC_WRAPPER= cargo test -p tui-pty-e2e`
- [x] TUI smoke test with ElizACP via tmux

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets