### PR TITLE
fix(tut): Detect actual goodbye subagent names

### DIFF
--- a/nori-rs/acp/src/transcript_discovery.rs
+++ b/nori-rs/acp/src/transcript_discovery.rs
@@ -384,13 +384,7 @@ fn collect_subagents_from_value(value: &serde_json::Value, subagents: &mut Vec<S
             }
         }
         serde_json::Value::Object(map) => {
-            for key in [
-                "subagent_type",
-                "agentType",
-                "agent_type",
-                "agentId",
-                "agent_id",
-            ] {
+            for key in ["subagent_type", "agentType", "agent_type"] {
                 if let Some(subagent) = map.get(key).and_then(serde_json::Value::as_str) {
                     let subagent = subagent.to_string();
                     if !subagents.contains(&subagent) {
@@ -724,6 +718,51 @@ mod tests {
         assert_eq!(
             parse_transcript_subagents(&transcript_file),
             vec!["nori-code-reviewer".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_parse_transcript_subagents_ignores_internal_agent_ids() {
+        let temp_dir = TempDir::new().unwrap();
+        let transcript_file = temp_dir.path().join("session.jsonl");
+
+        {
+            let mut f = fs::File::create(&transcript_file).unwrap();
+            writeln!(
+                f,
+                r#"{{"type":"response_item","item":{{"type":"agent_spawned","agentId":"019e3cb4-f515-7d62-af6a-e0016ef364f3","agent_type":"nori-code-researcher"}}}}"#
+            )
+            .unwrap();
+            writeln!(
+                f,
+                r#"{{"type":"response_item","item":{{"type":"agent_update","agent_id":"a74c49cc919c22c12","status":"completed"}}}}"#
+            )
+            .unwrap();
+        }
+
+        assert_eq!(
+            parse_transcript_subagents(&transcript_file),
+            vec!["nori-code-researcher".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_parse_transcript_subagents_keeps_camel_case_agent_type() {
+        let temp_dir = TempDir::new().unwrap();
+        let transcript_file = temp_dir.path().join("session.jsonl");
+
+        {
+            let mut f = fs::File::create(&transcript_file).unwrap();
+            writeln!(
+                f,
+                r#"{{"type":"response_item","item":{{"type":"agent_spawned","agentId":"019e3cb4-f515-7d62-af6a-e0016ef364f3","agentType":"nori-code-researcher"}}}}"#
+            )
+            .unwrap();
+        }
+
+        assert_eq!(
+            parse_transcript_subagents(&transcript_file),
+            vec!["nori-code-researcher".to_string()]
         );
     }
 

--- a/nori-rs/tui/src/session_stats.rs
+++ b/nori-rs/tui/src/session_stats.rs
@@ -270,13 +270,7 @@ fn extract_subagent_from_value(value: &serde_json::Value) -> Option<String> {
         | serde_json::Value::String(_) => None,
         serde_json::Value::Array(values) => values.iter().find_map(extract_subagent_from_value),
         serde_json::Value::Object(map) => {
-            for key in [
-                "subagent_type",
-                "agentType",
-                "agent_type",
-                "agentId",
-                "agent_id",
-            ] {
+            for key in ["subagent_type", "agentType", "agent_type"] {
                 if let Some(value) = map.get(key).and_then(serde_json::Value::as_str) {
                     return Some(value.to_string());
                 }
@@ -477,6 +471,37 @@ mod tests {
         let raw_input = json!({"description": "test", "prompt": "test"});
         let result = extract_subagent_from_raw_input(Some(&raw_input));
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn extract_subagent_ignores_internal_agent_id_fields() {
+        let raw_input = json!({
+            "agentId": "019e3cb4-f515-7d62-af6a-e0016ef364f3",
+            "agent_id": "a74c49cc919c22c12",
+            "message": "subagent lifecycle update"
+        });
+        let result = extract_subagent_from_raw_input(Some(&raw_input));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn extract_subagent_prefers_type_over_internal_agent_id() {
+        let raw_input = json!({
+            "agent_type": "nori-code-researcher",
+            "agentId": "019e3cb4-f515-7d62-af6a-e0016ef364f3"
+        });
+        let result = extract_subagent_from_raw_input(Some(&raw_input));
+        assert_eq!(result, Some("nori-code-researcher".to_string()));
+    }
+
+    #[test]
+    fn extract_subagent_prefers_camel_case_type_over_internal_agent_id() {
+        let raw_input = json!({
+            "agentType": "nori-code-researcher",
+            "agentId": "019e3cb4-f515-7d62-af6a-e0016ef364f3"
+        });
+        let result = extract_subagent_from_raw_input(Some(&raw_input));
+        assert_eq!(result, Some("nori-code-researcher".to_string()));
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- Ignore internal `agentId` / `agent_id` values when collecting goodbye-card subagent stats.
- Preserve real subagent names from `subagent_type`, `agent_type`, and `agentType` in live TUI stats and ACP transcript fallback parsing.
- Add regression coverage for Codex/Claude-style payloads where internal IDs appear alongside displayable subagent type fields.

## Test Plan
- [x] `cargo test -p nori-tui`
- [x] `cargo build -p mock-acp-agent`
- [x] `cargo test -p nori-acp`
- [x] `cargo build --bin nori`
- [x] `cargo test -p tui-pty-e2e`
- [x] Live tmux/bash verification with `nori --agent codex`
- [x] Live tmux/bash regression with `nori --agent claude`

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets