### PR TITLE
fix(tui): route /model through stable config_options

### DIFF
--- a/nori-rs/acp/docs.md
+++ b/nori-rs/acp/docs.md
@@ -301,7 +301,7 @@ ACP agents can expose runtime session configuration through `NewSessionResponse.
 This first implementation is deliberately live-session only:
 - `AcpBackend::config_options()` returns the current in-memory ACP config snapshot for TUI pickers.
 - `AcpBackend::set_config_option()` sends `session/set_config_option` for the current session and updates in-memory state from the response.
-- If the snapshot includes a select option categorized as `Mode` (or with id `mode`), the TUI derives the current mode label from the same live options, displays it through the normal `mode_indicator` footer segment, and uses `Shift-Tab` to cycle to the next value via `session/set_config_option`.
+- Config options use `SessionConfigOptionCategory` to tag their purpose. The `Mode` category drives the footer mode indicator and `Shift-Tab` cycling. The `Model` category is the stable mechanism for model selection -- the TUI's `/model` command checks for a Model-category config option first (see `@/nori-rs/tui/docs.md`) before falling back to the unstable `SessionModelState`. Real ACP agents like Claude Code provide model selection through this stable config_options path.
 - No config form is shown during `/agent` switching yet.
 - No ACP session config selections are persisted to `config.toml` yet.
 

--- a/nori-rs/tui-pty-e2e/src/lib.rs
+++ b/nori-rs/tui-pty-e2e/src/lib.rs
@@ -921,8 +921,9 @@ fn strip_git_stats_segment(line: &str) -> String {
 pub fn normalize_for_snapshot(contents: String) -> String {
     let mut normalized = contents;
 
-    // Replace temp directories: /tmp/claude/.tmpXXXXXX or /tmp/.tmpXXXXXX -> [TMP_DIR]
-    for pattern in &["/tmp/claude/.tmp", "/tmp/.tmp"] {
+    // Replace temp directories: /tmp/claude-*/.tmpXXXXXX, /tmp/claude/.tmpXXXXXX,
+    // or /tmp/.tmpXXXXXX -> [TMP_DIR]
+    for pattern in &["/tmp/claude-", "/tmp/claude/.tmp", "/tmp/.tmp"] {
         while let Some(start) = normalized.find(pattern) {
             let end = normalized[start..]
                 .find(|c: char| c.is_whitespace() || c == '│')
@@ -1006,6 +1007,13 @@ pub fn normalize_for_snapshot(contents: String) -> String {
                 if trimmed.len() < FIXED_BOX_WIDTH {
                     return format!("│ {:<width$} │", trimmed, width = FIXED_BOX_WIDTH);
                 }
+            }
+            // Normalize top border: "╭───────╮" -> fixed width
+            if line.starts_with('╭')
+                && line.ends_with('╮')
+                && line.chars().all(|c| c == '╭' || c == '─' || c == '╮')
+            {
+                return format!("╭{}╮", "─".repeat(FIXED_BOX_WIDTH + 2));
             }
             // Normalize bottom border: "╰───────╯" -> fixed width
             if line.starts_with('╰')

--- a/nori-rs/tui-pty-e2e/tests/snapshots/exit_statistics__exit_message_ctrl_d.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/exit_statistics__exit_message_ctrl_d.snap
@@ -6,7 +6,7 @@ expression: normalize_for_input_snapshot(session.screen_contents())
 
 • Sure, I'll help you with that!
 
-╭───────────────────────────────────────────────╮
+╭───────────────────────────────────────╮
 │  Goodbye! Thanks for using Nori.      │
 │                                       │
 │  Session: [SESSION_ID]                │

--- a/nori-rs/tui-pty-e2e/tests/snapshots/exit_statistics__exit_message_slash_exit.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/exit_statistics__exit_message_slash_exit.snap
@@ -6,7 +6,7 @@ expression: normalize_for_input_snapshot(session.screen_contents())
 
 • Sure, I'll help you with that!
 
-╭───────────────────────────────────────────────╮
+╭───────────────────────────────────────╮
 │  Goodbye! Thanks for using Nori.      │
 │                                       │
 │  Session: [SESSION_ID]                │

--- a/nori-rs/tui-pty-e2e/tests/snapshots/startup__startup_shows_nori_banner.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/startup__startup_shows_nori_banner.snap
@@ -2,7 +2,7 @@
 source: tui-pty-e2e/tests/startup.rs
 expression: "normalize_for_snapshot(header_lines.join(\"\\n\"))"
 ---
-╭────────────────────────────╮
+╭───────────────────────────────────────╮
 │  Nori CLI v0.0.0                      │
 │                                       │
 │  directory: [TMP_DIR]                 │

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -282,7 +282,7 @@ During background system info collection on unix, `check_worktree_cleanup()` run
 | Command | Description |
 |---------|-------------|
 | `/agent` | Switch between available ACP agents (dynamically shows current agent name) |
-| `/model` | Choose model (dynamically shows current agent/model name) |
+| `/model` | Choose model -- convenience shortcut that opens the Model-category config option value picker when available, falling back to the unstable model state (dynamically shows current agent/model name) |
 | `/config` | Configure live ACP session settings exposed by the current agent |
 | `/approvals` | Choose what Nori can do without approval (dynamically shows current approval mode) |
 | `/settings` | Configure Nori CLI settings (pinned plan drawer, custom working messages, vertical footer, terminal notifications, OS notifications, vim mode with enter behavior sub-picker, auto worktree, per session skillsets, notify after idle, hotkeys, script timeout, loop count, footer segments, file manager) |
@@ -379,6 +379,8 @@ Claude-backed agents have an additional compatibility path in `skill_picker_item
 `/config` opens a two-step picker for the current ACP session. `ChatWidget::open_session_config_popup()` asks the `AcpAgentHandle` for the live `AcpBackend::config_options()` snapshot, renders supported `select` options, then opens a value picker for the selected option. Selecting a value sends `session/set_config_option` through `AcpBackend::set_config_option()` and shows a single final info or error message when the RPC finishes.
 
 The picker intentionally only edits the active session. It does not run during `/agent` switching and it does not persist selected values. Unsupported ACP config kinds and future non-exhaustive select layouts are treated as unavailable rather than guessed.
+
+`/model` acts as a convenience shortcut into the same config_options mechanism. `ChatWidget::open_model_popup()` in `chatwidget/pickers.rs` first fetches config_options via `AcpAgentHandle::get_session_config()`, finds a config option with `SessionConfigOptionCategory::Model`, and if present sends `AppEvent::OpenAcpSessionConfigValuePicker` to open the value picker directly (bypassing the top-level config picker). When no Model-category config option exists, it falls back to the unstable `SessionModelState` (behind `#[cfg(feature = "unstable")]`), and finally to a "not supported" empty model picker. This means real ACP agents that provide model selection through config_options (the stable mechanism) work correctly with `/model`, while agents that only provide the unstable `session/set_model` path still function via the fallback.
 
 **Selection Popup Row Layout (`bottom_pane/selection_popup_common.rs`):**
 

--- a/nori-rs/tui/src/chatwidget/agent.rs
+++ b/nori-rs/tui/src/chatwidget/agent.rs
@@ -88,6 +88,11 @@ pub(crate) struct AcpAgentHandle {
 }
 
 impl AcpAgentHandle {
+    #[cfg(test)]
+    pub(crate) fn from_command_tx(command_tx: mpsc::UnboundedSender<AcpAgentCommand>) -> Self {
+        Self { command_tx }
+    }
+
     /// Get the current model state from the ACP agent.
     #[cfg(feature = "unstable")]
     pub async fn get_model_state(&self) -> Option<AcpModelState> {

--- a/nori-rs/tui/src/chatwidget/pickers.rs
+++ b/nori-rs/tui/src/chatwidget/pickers.rs
@@ -607,13 +607,29 @@ impl ChatWidget {
     }
 
     /// Open the ACP model picker popup.
+    ///
+    /// Prefers the stable `config_options` mechanism (Model-category config
+    /// option) over the unstable `SessionModelState`.  Falls back to the
+    /// unstable model state when no Model-category config option exists,
+    /// and to a static "not supported" message when neither is available.
     pub(crate) fn open_model_popup(&mut self) {
-        #[cfg(feature = "unstable")]
-        {
-            // ACP mode with unstable features - try to get model state from the agent
-            if let Some(handle) = self.acp_handle.clone() {
-                let app_event_tx = self.app_event_tx.clone();
-                tokio::spawn(async move {
+        if let Some(handle) = self.acp_handle.clone() {
+            let app_event_tx = self.app_event_tx.clone();
+            tokio::spawn(async move {
+                // First try the stable config_options path.
+                if let Some(config_options) = handle.get_session_config().await {
+                    let model_option = config_options.into_iter().find(|opt| {
+                        opt.category == Some(nori_acp::SessionConfigOptionCategory::Model)
+                    });
+                    if let Some(option) = model_option {
+                        app_event_tx.send(AppEvent::OpenAcpSessionConfigValuePicker { option });
+                        return;
+                    }
+                }
+
+                // Fall back to the unstable SessionModelState.
+                #[cfg(feature = "unstable")]
+                {
                     if let Some(model_state) = handle.get_model_state().await {
                         let models: Vec<crate::app_event::AcpModelInfo> = model_state
                             .available_models
@@ -637,19 +653,19 @@ impl ChatWidget {
                             models,
                             current_model_id,
                         });
-                    } else {
-                        // Failed to get model state - show empty picker with explanation
-                        tracing::warn!("Failed to get ACP model state");
-                        app_event_tx.send(AppEvent::OpenAcpModelPicker {
-                            models: vec![],
-                            current_model_id: None,
-                        });
+                        return;
                     }
+                }
+
+                // Neither mechanism provided models.
+                app_event_tx.send(AppEvent::OpenAcpModelPicker {
+                    models: vec![],
+                    current_model_id: None,
                 });
-                return;
-            }
+            });
+            return;
         }
-        // No ACP handle or unstable not enabled - show disabled model picker
+        // No ACP handle - show disabled model picker
         let params = crate::nori::agent_picker::acp_model_picker_params();
         self.bottom_pane.show_selection_view(params);
     }

--- a/nori-rs/tui/src/chatwidget/tests/mod.rs
+++ b/nori-rs/tui/src/chatwidget/tests/mod.rs
@@ -349,3 +349,4 @@ mod part5;
 mod part6;
 mod part7;
 mod part8;
+mod part9;

--- a/nori-rs/tui/src/chatwidget/tests/part9.rs
+++ b/nori-rs/tui/src/chatwidget/tests/part9.rs
@@ -1,0 +1,129 @@
+use super::*;
+use insta::assert_snapshot;
+use nori_acp::SessionConfigOption;
+use nori_acp::SessionConfigOptionCategory;
+use nori_acp::SessionConfigSelectOption;
+
+fn model_config_option() -> SessionConfigOption {
+    SessionConfigOption::select(
+        "model",
+        "Model",
+        "claude-opus-4-6",
+        vec![
+            SessionConfigSelectOption::new("claude-opus-4-6", "Opus 4.6")
+                .description("Most capable model"),
+            SessionConfigSelectOption::new("claude-sonnet-4-6", "Sonnet 4.6")
+                .description("Fast and capable"),
+        ],
+    )
+    .category(SessionConfigOptionCategory::Model)
+}
+
+/// When an ACP agent provides a Model-category config option, /model should
+/// open the session config value picker for that option (showing selectable
+/// model choices) instead of the "not supported" message.
+#[tokio::test]
+async fn model_popup_routes_to_config_option_when_model_category_present() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
+
+    // Set up a mock ACP handle that responds to GetSessionConfig with a
+    // Model-category config option.
+    let (command_tx, mut command_rx) =
+        tokio::sync::mpsc::unbounded_channel::<crate::chatwidget::agent::AcpAgentCommand>();
+    tokio::spawn(async move {
+        while let Some(command) = command_rx.recv().await {
+            if let crate::chatwidget::agent::AcpAgentCommand::GetSessionConfig { response_tx } =
+                command
+            {
+                let _ = response_tx.send(vec![model_config_option()]);
+            }
+        }
+    });
+    chat.acp_handle = Some(crate::chatwidget::agent::AcpAgentHandle::from_command_tx(
+        command_tx,
+    ));
+
+    chat.open_model_popup();
+
+    // The async task sends an event — wait for it.
+    let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("timed out waiting for event")
+        .expect("channel closed");
+
+    // Should route to the session config value picker, not the ACP model picker.
+    assert_matches!(
+        event,
+        AppEvent::OpenAcpSessionConfigValuePicker { option } => {
+            assert_eq!(option.category, Some(SessionConfigOptionCategory::Model));
+        }
+    );
+}
+
+/// When an ACP handle is present but config_options have NO Model-category
+/// option (and unstable model state is empty), /model should show the
+/// "not supported" fallback.
+#[tokio::test]
+async fn model_popup_falls_back_when_no_model_config_option() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
+
+    // Set up a mock ACP handle that responds to GetSessionConfig with a
+    // Mode-only config option (no Model category).
+    let (command_tx, mut command_rx) =
+        tokio::sync::mpsc::unbounded_channel::<crate::chatwidget::agent::AcpAgentCommand>();
+    tokio::spawn(async move {
+        while let Some(command) = command_rx.recv().await {
+            match command {
+                crate::chatwidget::agent::AcpAgentCommand::GetSessionConfig { response_tx } => {
+                    let mode_only = SessionConfigOption::select(
+                        "mode",
+                        "Mode",
+                        "plan",
+                        vec![
+                            SessionConfigSelectOption::new("plan", "Plan"),
+                            SessionConfigSelectOption::new("build", "Build"),
+                        ],
+                    )
+                    .category(SessionConfigOptionCategory::Mode);
+                    let _ = response_tx.send(vec![mode_only]);
+                }
+                #[cfg(feature = "unstable")]
+                crate::chatwidget::agent::AcpAgentCommand::GetModelState { response_tx } => {
+                    let _ = response_tx.send(nori_acp::AcpModelState::new());
+                }
+                _ => {}
+            }
+        }
+    });
+    chat.acp_handle = Some(crate::chatwidget::agent::AcpAgentHandle::from_command_tx(
+        command_tx,
+    ));
+
+    chat.open_model_popup();
+
+    // Wait for the event. With no Model-category config option and empty
+    // unstable model state, it should fall back to the empty model picker.
+    let event = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("timed out waiting for event")
+        .expect("channel closed");
+
+    assert_matches!(
+        event,
+        AppEvent::OpenAcpModelPicker { models, .. } => {
+            assert!(models.is_empty(), "expected empty models list for fallback");
+        }
+    );
+}
+
+/// Snapshot: the model value picker rendered via a Model-category config option
+/// should display selectable model names.
+#[test]
+fn model_popup_via_config_option_snapshot() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual();
+
+    chat.open_acp_session_config_value_picker(model_config_option());
+
+    let popup = render_bottom_popup(&chat, 80);
+    assert_snapshot!("model_popup_via_config_option", popup);
+}

--- a/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part9__model_popup_via_config_option.snap
+++ b/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part9__model_popup_via_config_option.snap
@@ -1,0 +1,11 @@
+---
+source: tui/src/chatwidget/tests/part9.rs
+expression: popup
+---
+  Model
+  Select a value for this ACP session setting
+
+› 1. Opus 4.6 (current)  Most capable model
+  2. Sonnet 4.6          Fast and capable
+
+  ↑/k ↓/j to navigate, enter to confirm, esc to go back


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- Fix `/model` command regression: now checks the stable `config_options` mechanism (`SessionConfigOptionCategory::Model`) before falling back to the deprecated unstable `SessionModelState`. Real ACP agents provide models through config_options, so `/model` was showing "Model switching not supported" when it shouldn't.
- Fix pre-existing flaky E2E snapshot tests: normalize `/tmp/claude-<uid>/` paths and box top borders to fixed width in `normalize_for_snapshot`.

## Test Plan
- [x] 3 new unit tests for model popup routing (config_options path, fallback path, snapshot)
- [x] All 1311 TUI lib tests pass
- [x] All 9 E2E tests pass
- [x] Clippy and fmt clean

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets