### PR TITLE
fix(tui): avoid repeated final message dividers

### DIFF
--- a/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_tool_call_no_duplicates.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/acp_tool_calls__acp_tool_call_no_duplicates.snap
@@ -12,8 +12,6 @@ expression: normalize_for_input_snapshot(contents)
 
 • Processing command...
 
-────────────────────────────────────────────────────────────────────────────────
-
 • Interleaved test done.
 
 › [DEFAULT_PROMPT]

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -149,6 +149,7 @@ Tool cells always appear in scrollback history before the agent text that follow
 - `handle_streaming_delta()` always calls `flush_active_cell()` before streaming text, even when the active cell contains an incomplete (still-running) ExecCell. The incomplete cell is sent to history immediately rather than held in `active_cell` until completion.
 - `flush_active_cell()` marks pending call_ids of incomplete ExecCells as completed (via `completed_client_tool_calls`) so that later completion events for the same call_ids do not create duplicate cells. The `pending_exec_cells` tracker is bypassed for this path -- cells go directly to history.
 - `add_boxed_history()` also always flushes the active cell first, applying the same ordering guarantee when non-streaming history cells are inserted.
+- Assistant message cells do not re-arm the final-message separator; a single tool-to-answer boundary should not become repeated dividers when one assistant turn arrives as multiple message cells.
 
 The trade-off: incomplete cells may appear in scrollback showing "Running"/"Exploring" status rather than their final "Ran"/"Explored" state, because they are flushed before completion events arrive.
 

--- a/nori-rs/tui/src/chatwidget/tests/part5.rs
+++ b/nori-rs/tui/src/chatwidget/tests/part5.rs
@@ -1,4 +1,5 @@
 use super::*;
+use pretty_assertions::assert_eq;
 
 /// ACP agents may stream reasoning before producing their final answer.
 /// This test verifies reasoning + answer rendering from an ACP agent.
@@ -894,4 +895,44 @@ fn exec_end_not_deferred_during_streaming() {
         tool_pos.unwrap(),
         done_pos.unwrap(),
     );
+}
+
+#[test]
+fn repeated_agent_messages_after_tool_use_share_one_separator() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
+
+    chat.handle_codex_event(Event {
+        id: "turn-1".into(),
+        msg: EventMsg::TaskStarted(TaskStartedEvent {
+            model_context_window: None,
+        }),
+    });
+    drain_insert_history(&mut rx);
+
+    let begin_ev = begin_exec(&mut chat, "call-1", "cargo test");
+    end_exec(&mut chat, begin_ev, "ok\n", "", 0);
+
+    for message in ["The", "suite is", "now in the ACP backend"] {
+        chat.handle_codex_event(Event {
+            id: "turn-1".into(),
+            msg: EventMsg::AgentMessage(AgentMessageEvent {
+                message: message.to_string(),
+            }),
+        });
+    }
+
+    chat.handle_codex_event(Event {
+        id: "turn-1".into(),
+        msg: EventMsg::TaskComplete(TaskCompleteEvent {
+            last_agent_message: None,
+        }),
+    });
+
+    let rendered = drain_insert_history(&mut rx)
+        .into_iter()
+        .map(|lines| lines_to_single_string(&lines))
+        .collect::<Vec<_>>()
+        .join("");
+
+    assert_eq!(rendered.matches("Worked for").count(), 1, "{rendered}");
 }

--- a/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part5__acp_multi_turn_conversation.snap
+++ b/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part5__acp_multi_turn_conversation.snap
@@ -4,8 +4,6 @@ expression: combined
 ---
 • I can help you refactor that function. First, let me analyze the current
   implementation.
-─ Worked for 0s ────────────────────────────────────────────────────────────────
-
 • Here's the refactored version:
   
   fn process(data: &str) -> Result<String, Error> {

--- a/nori-rs/tui/src/chatwidget/user_input.rs
+++ b/nori-rs/tui/src/chatwidget/user_input.rs
@@ -39,7 +39,9 @@ impl ChatWidget {
             // Always flush active cell before inserting new history to preserve
             // chronological ordering.
             self.flush_active_cell();
-            self.needs_final_message_separator = true;
+            if !cell.as_any().is::<history_cell::AgentMessageCell>() {
+                self.needs_final_message_separator = true;
+            }
         }
         self.app_event_tx.send(AppEvent::InsertHistoryCell(cell));
     }


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- Stop finalized assistant message history cells from re-arming the final-message divider.
- Add regression coverage for repeated ACP assistant messages after a tool call.
- Update TUI/e2e snapshots and document the separator invariant.

## Test Plan
- [x] env -u RUSTC_WRAPPER cargo test -p nori-tui
- [x] just fmt
- [x] env -u RUSTC_WRAPPER cargo build --bin nori
- [x] env -u RUSTC_WRAPPER cargo build -p mock-acp-agent
- [x] env -u RUSTC_WRAPPER cargo test -p tui-pty-e2e
- [x] env -u RUSTC_WRAPPER just fix -p nori-tui
- [x] env -u RUSTC_WRAPPER cargo insta pending-snapshots
- [x] git diff --check

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets