### PR TITLE
docs: specify ACP-canonical protocol unification

### DIFF
--- a/docs/plans/protocol-unification-implementation.md
+++ b/docs/plans/protocol-unification-implementation.md
@@ -1,0 +1,677 @@
+# ACP-Canonical Protocol Unification Implementation Plan
+
+**Goal:** Delete `codex-protocol`, make `nori-protocol` the single ACP schema entry point, and expose an ACP-faithful event boundary from the embeddable Nori harness.
+
+**Architecture:** `nori-protocol` re-exports the ACP schema and defines a source-nested `SessionEvent::{Acp, Nori}` boundary. Raw ACP notifications, requests, and responses cross that boundary unchanged; the small Nori branch covers only harness-owned lifecycle and product concerns, while commands and queries use typed harness methods.
+
+**Tech Stack:** Rust workspace, Tokio channels/tasks, `agent-client-protocol` SDK, `agent-client-protocol-schema`, Serde JSONL transcripts, Cargo nextest/tests, mock ACP agent, Ratatui TUI
+
+---
+
+**Testing Plan**
+
+Add a black-box harness integration test that starts the real mock ACP agent,
+submits a prompt, and observes raw ACP notifications followed by the correlated
+ACP prompt response through `SessionEvent`. It must validate observable order,
+request identity, stop reason, and content without inspecting reducer fields or
+mocking the harness.
+
+Add a black-box delegated-request integration test in which the mock agent asks
+for permission and performs representative filesystem/terminal requests. It
+must prove that delegated requests reach the consumer as raw `AgentRequest`
+values and that a schema-native response with the same `RequestId` reaches the
+agent. A separate configuration case must prove that requests configured for
+harness handling are completed without leaking a duplicate outward request.
+
+Add transcript behavior tests that load checked-in version-2 normalized event
+fixtures through the public transcript loader, replay a newly recorded session,
+and verify that equivalent user-visible content and Nori-owned state are
+restored. The test observes the loader/replay boundary, not private decoder
+types or serialized enum layout.
+
+Add harness behavior tests for queue changes, replay brackets, lifecycle phase,
+goals, undo, user shell, hook output, and transport failure. Each test should
+exercise a real harness operation and assert only the public `SessionEvent`
+sequence. Prompt/ACP failures must be observed as ACP responses; only failures
+without an ACP response may be observed as `NoriEvent::RequestFailed`.
+
+Add query-boundary tests that call history, prompt discovery, undo-list,
+session-list, config, and close methods and receive their results directly.
+They must also drain the event stream to prove the query result is not
+duplicated as a correlated Nori event.
+
+Keep the existing TUI PTY end-to-end suite as the frontend regression boundary
+and add one minimal headless example/test that consumes the same public harness
+API. Dependency and import checks supplement these behavioral tests but do not
+replace them.
+
+<!-- prettier-ignore -->
+NOTE: I will write *all* tests before I add any implementation behavior.
+
+For this phased plan, “all tests” means every test for the next behavioral
+slice. Each task that introduces behavior begins by adding and observing its
+own failing public-boundary tests before editing that behavior.
+
+## Preconditions and constraints
+
+- Do not begin until the active CLI configuration rework has landed on `main`.
+- Create a new implementation worktree from the then-current `main`; do not
+  reuse the docs worktree or edit the protected branch.
+- Read the repository `AGENTS.md` and required skills before implementation.
+- The user has approved removal of the `codex-protocol` dependency as a hard
+  cut. Do not add, upgrade, or remove any other dependency without asking.
+- Re-audit the repository after the configuration work. Current paths and
+  consumers below describe commit `500ee202`, not a substitute for that audit.
+- Before deleting anything, present the refreshed exact module/type/variant
+  list and remaining consumers for the promised sanity-check.
+- Do not add a compatibility facade, deprecated aliases, or a second normalized
+  ACP vocabulary.
+- Prefer one atomic implementation PR (with reviewable commits) so `main` never
+  has two endorsed protocol boundaries.
+
+The normative design and current deletion inventory are in
+`docs/specs/protocol-unification.md`.
+
+## Task 1: Refresh the post-configuration inventory and pass the deletion gate
+
+**Files to inspect:**
+
+- `nori-rs/Cargo.toml`
+- `Cargo.lock`
+- every `nori-rs/*/Cargo.toml`
+- `nori-rs/protocol/src/**/*.rs`
+- `nori-rs/nori-protocol/src/**/*.rs`
+- `nori-rs/acp-host/src/**/*.rs`
+- `nori-rs/harness/src/**/*.rs`
+- `nori-rs/tui/src/**/*.rs`
+- configuration files and crates changed by the prerequisite rework
+
+**Step 1: Rebase and establish a clean baseline**
+
+Rebase the implementation branch onto the configuration refactor's landed
+commit. Record `git status`, `git rev-parse HEAD`, and the baseline results of
+the repository's required checks before editing.
+
+**Step 2: Re-run dependency and import audits**
+
+Use Cargo metadata/tree plus source search to answer all of these questions:
+
+```bash
+cargo tree --manifest-path nori-rs/Cargo.toml -i codex-protocol
+rg -n 'codex-protocol' nori-rs -g Cargo.toml
+rg -n '\bcodex_protocol\b' nori-rs -g '*.rs'
+rg -n 'agent-client-protocol-schema' nori-rs -g Cargo.toml
+rg -n '\bagent_client_protocol_schema\b' nori-rs -g '*.rs'
+rg -n 'agent-client-protocol' nori-rs -g Cargo.toml
+rg -n '\bagent_client_protocol\b' nori-rs -g '*.rs'
+```
+
+List each direct dependency edge and each importing source file. Classify each
+use as ACP agent/client semantics, Nori-owned domain, configuration/runtime
+policy, presentation, persistence compatibility, or dead code.
+
+**Step 3: Re-run producer/consumer audits**
+
+For every `ClientEvent`, `Op`, and `EventMsg` variant in the normative spec,
+identify:
+
+- all production constructors/producers;
+- all production matches/consumers;
+- all persistence readers/writers;
+- all tests and fixtures; and
+- whether the configuration refactor added or removed any usage.
+
+Do not classify a variant as dead solely because one frontend ignores it.
+
+**Step 4: Resolve configuration ownership**
+
+Identify the post-refactor homes of login, model, MCP, approval, sandbox, and
+shell-environment types. In particular, decide the concrete owners of
+`AskForApproval` and `SandboxPolicy` from actual runtime/API use. They must not
+move into `nori-protocol` merely to avoid a cycle.
+
+**Step 5: Resolve the two live Nori extension gaps**
+
+Present the live prompt-summary and user-visible nonfatal-notice producers and
+consumers. Co-design and record the smallest truthful event additions, or an
+explicit decision to remove/relocate each behavior. Do not overload
+`RequestFailed`, `ContextCompacted`, or `HookOutput`.
+
+**Step 6: Stop at the deletion gate**
+
+Post the refreshed exact deletion/rehoming list, including remaining consumers,
+for user sanity-check. Do not proceed with file deletion until it is approved.
+
+## Task 2: Lock the new public boundary with failing behavioral tests
+
+**Files:**
+
+- Create: `nori-rs/harness/tests/session_event_boundary_test.rs`
+- Modify: `nori-rs/harness/src/backend/tests/mod.rs`
+- Modify: relevant split files under `nori-rs/harness/src/backend/tests/`
+- Modify: `nori-rs/acp-host/src/connection/acp_connection_tests.rs`
+- Modify: mock-agent scenarios in the post-refactor `mock-acp-agent` crate
+
+**Step 1: Write the bootstrap buffering test**
+
+Construct the harness through its public API, then begin reading the event
+stream. Assert initialization and session-creation responses are present once,
+in request order, even when the constructor awaited bootstrap before returning.
+Use a consumer that intentionally starts late to prove bootstrap neither drops
+early responses nor deadlocks on an unavailable receiver.
+
+**Step 2: Write the prompt-stream test**
+
+Start the real mock ACP subprocess through the public harness constructor. Send
+a prompt through the handle and collect outward events until its response. The
+assertion should have this shape:
+
+```rust
+assert!(matches!(
+    events.last(),
+    Some(SessionEvent::Acp(AcpEvent::Response {
+        request_id,
+        response: Ok(acp::v1::AgentResponse::PromptResponse(_)),
+    })) if request_id == &prompt_request_id
+));
+```
+
+Assert at least one preceding raw session notification carries the expected
+assistant content. Do not assert private channel calls or reducer state.
+
+**Step 3: Write delegated request round-trip tests**
+
+Make the mock agent issue each supported agent-to-client request family. Observe
+`AcpEvent::Request`, respond through the public handle using the same
+`RequestId`, and assert the agent proceeds. Cover permission plus representative
+filesystem and terminal requests; cover elicitation or extension requests when
+the currently selected ACP schema exposes them. Include both a
+`ClientResponse` success and a schema-native `Error` response.
+
+**Step 4: Write the load-stream test**
+
+Have the mock agent emit representative session notifications during
+`session/load` before returning its load response. Assert the public load method
+returns a distinct `RequestId`, the notifications remain in source order, and
+the final `AcpEvent::Response` carries that same ID and the ACP load response.
+
+**Step 5: Write harness-handled request tests**
+
+Configure filesystem/terminal handling inside the harness. Assert the agent
+receives a result and no corresponding outward `AcpEvent::Request` is emitted.
+This catches double dispatch and accidental leakage.
+
+**Step 6: Write error ownership tests**
+
+Cover:
+
+- ACP error response → `AcpEvent::Response(Err(...))`;
+- clean prompt completion/cancel → ACP prompt response;
+- subprocess loss or transport failure before response →
+  `NoriEvent::RequestFailed`; and
+- orderly close versus unexpected connection loss → distinct
+  `SessionEnded` reasons.
+
+**Step 7: Write Nori-event ownership tests**
+
+Exercise real harness operations that cause session start/phase/end, queue,
+replay, compaction, goal, capabilities, undo, user-shell, hook, prompt-summary,
+and nonfatal-notice transitions. Assert their public `NoriEvent` order and
+payload meaning, and assert that no Nori tool/message/plan/usage/mode/config/
+permission mirror is emitted.
+
+**Step 8: Write direct-query result tests**
+
+Call history lookup/search, custom prompt discovery, undo listing, session
+listing, config mutation, and close through the public handle. Assert each
+caller receives its typed result without reading the event stream. Drain the
+stream concurrently and assert no correlated Nori result event is emitted;
+ACP-backed operations may still expose their raw `AcpEvent::Response`.
+
+**Step 9: Write request-lifecycle race tests**
+
+Use deterministic mock-agent barriers—not sleeps—to cover:
+
+- two same-content requests retaining distinct `RequestId` values;
+- cancellation racing with the agent's final notification and response;
+- subprocess disconnect while delegated requests are pending;
+- a dropped public event receiver while the harness auto-handles a request; and
+- a typed query completing concurrently with prompt stream events.
+
+Assert terminal public outcomes: no response is delivered to the wrong request,
+pending responders close once, auto-handled work does not stall, and query
+results are neither lost nor duplicated as Nori events.
+
+**Step 10: Run the tests and confirm the intended failure**
+
+Run the narrowest package/test commands. Confirm failures occur because the
+new public API/behavior is absent—not because fixtures, subprocess setup, or
+test compilation are wrong.
+
+## Task 3: Establish `nori-protocol` as the ACP schema choke point
+
+**Files:**
+
+- Modify: `nori-rs/nori-protocol/Cargo.toml`
+- Rewrite: `nori-rs/nori-protocol/src/lib.rs`
+- Delete or move: `nori-rs/nori-protocol/src/session_runtime.rs`
+- Modify: `nori-rs/Cargo.toml`
+
+**Step 1: Re-export the schema**
+
+Add the public re-export:
+
+```rust
+pub use agent_client_protocol_schema as acp;
+```
+
+Define the approved boundary without a normalized ACP mirror:
+
+```rust
+pub enum SessionEvent {
+    Acp(AcpEvent),
+    Nori(NoriEvent),
+}
+
+pub enum AcpEvent {
+    Notification(acp::v1::AgentNotification),
+    Request {
+        request_id: acp::v1::RequestId,
+        request: acp::v1::AgentRequest,
+    },
+    Response {
+        request_id: acp::v1::RequestId,
+        response: Result<acp::v1::AgentResponse, acp::v1::Error>,
+    },
+}
+```
+
+Add only the traits required by channel use, logging, persistence adapters, and
+consumer tests. Do not derive a trait preemptively for symmetry.
+
+**Step 2: Add the Nori-only branch**
+
+Implement the approved first-pass outer variants exactly:
+
+```rust
+pub enum NoriEvent {
+    SessionStarted(SessionStarted),
+    SessionPhaseChanged(SessionPhase),
+    SessionEnded(SessionEnded),
+    QueueChanged(QueueSnapshot),
+    ReplayStarted(ReplayStarted),
+    ReplayFinished,
+    ContextCompacted(ContextCompacted),
+    GoalChanged(Option<ThreadGoal>),
+    CapabilitiesChanged(NoriCapabilities),
+    Undo(UndoEvent),
+    UserShell(UserShellEvent),
+    HookOutput(HookOutput),
+    RequestFailed(RequestFailure),
+}
+```
+
+Add only the separately user-approved resolution for the live prompt-summary
+and nonfatal-notice gaps from Task 1. Do not infer any further variant from old
+Codex vocabulary.
+
+Derive payload fields from audited public consumer needs. Keep the structs
+small; do not place ACP capability, content, tool, plan, mode, config-option, or
+usage fields in them.
+
+**Step 3: Move implementation state out**
+
+Move session phase machinery, active request state, open-message buffers,
+queued prompt state, and reducer-owned persisted state into private modules
+under `nori-rs/harness/src/backend/`. Delete `ClientEventNormalizer`; retain
+only genuinely needed private reduction/presentation transformations in their
+owner crates.
+
+**Step 4: Run protocol and boundary tests**
+
+Run `cargo test -p nori-protocol` and the failing harness boundary test. The
+protocol crate should compile with minimal dependencies; behavior tests may
+remain red until the relay is rewired in the next task.
+
+## Task 4: Relay raw ACP envelopes through `nori-acp-host` and `nori-harness`
+
+**Files:**
+
+- Modify: `nori-rs/acp-host/src/lib.rs`
+- Modify: `nori-rs/acp-host/src/connection/acp_connection.rs`
+- Modify: `nori-rs/acp-host/src/connection/mod.rs`
+- Delete or shrink: `nori-rs/acp-host/src/translator.rs`
+- Modify: `nori-rs/harness/src/backend/nori_client_context.rs`
+- Modify: `nori-rs/harness/src/backend/nori_client_mcp.rs`
+- Modify: `nori-rs/harness/src/backend/session.rs`
+- Modify: `nori-rs/harness/src/backend/session_reducer.rs`
+- Modify: `nori-rs/harness/src/backend/session_runtime_driver.rs`
+- Modify: `nori-rs/harness/src/backend/spawn_and_relay.rs`
+- Modify: `nori-rs/harness/src/backend/submit_and_ops.rs`
+- Modify: `nori-rs/harness/src/runtime.rs`
+
+**Step 1: Change connection output to raw schema envelopes**
+
+At the point where the SDK supplies an agent notification, agent request, or
+agent response, construct the matching `AcpEvent` while retaining its
+`RequestId`. Delete translation into `codex_protocol::EventMsg` and normalized
+`ClientEvent`.
+
+**Step 2: Preserve request routing policy**
+
+Keep the harness's configured choice to handle filesystem/terminal requests or
+delegate them. Delegated requests go to the public stream once. Public response
+methods route schema-native client success or error responses back to the
+pending ACP request. Cancellation and disconnect must close pending responders
+deterministically.
+
+**Step 3: Emit the small Nori branch**
+
+Emit lifecycle, queue, replay brackets, compaction, goals, capabilities, undo,
+user shell, hooks, the approved prompt-summary/nonfatal-notice resolution, and
+no-response failures at their actual owning transitions. Do not infer Nori
+duplicates from every ACP update.
+
+**Step 4: Replace the generic operation bus with typed methods**
+
+Replace `Op` submission sites with explicit handle methods. Return history,
+custom prompts, undo snapshots, session list, config mutation, and close results
+directly to their callers. Keep streamed progress on `SessionEvent` only where
+it is genuinely asynchronous session output; retain raw ACP responses for
+schema-complete observability without adding Nori result events.
+
+**Step 5: Make boundary tests pass**
+
+Run the tests from Task 2. Inspect complete output and fix the owning layer for
+ordering, request-correlation, or lifecycle failures; do not normalize away
+schema differences as a workaround.
+
+## Task 5: Version transcript persistence without preserving the old Rust API
+
+**Files:**
+
+- Modify: `nori-rs/harness/src/transcript/types.rs`
+- Modify: `nori-rs/harness/src/transcript/loader.rs`
+- Modify: `nori-rs/harness/src/transcript/recorder.rs`
+- Modify: `nori-rs/harness/src/transcript/project.rs`
+- Modify: `nori-rs/harness/src/transcript/tests.rs`
+- Add: compact private legacy-v2 decode module under
+  `nori-rs/harness/src/transcript/`
+- Add or update: versioned JSONL fixtures under
+  `nori-rs/harness/tests/fixtures/`
+
+**Step 1: Write legacy-load and new-round-trip tests**
+
+Load an existing version-2 record containing normalized `ClientEvent` values
+through the public loader. Before changing the loader, record an explicit
+fixture matrix for every checked-in v2 event: the ordered public message,
+plan/tool update, Nori state update, documented drop, warning, or load error it
+must produce. Lock the current public behavior for unknown fields, malformed
+JSONL records, and now-obsolete variants unless the deletion review explicitly
+approves a change.
+
+Record/reload a new session and assert the exact outward sequence:
+`ReplayStarted`, the expected raw ACP notifications and Nori-owned restoration
+events in source order, then `ReplayFinished`. Assert restored goal and session
+metadata through their public query/event boundaries rather than inspecting the
+decoder's state. Before changing persistence behavior, add and observe a failing
+test proving replay cannot repeat a recorded filesystem/terminal side effect or
+complete a live request from a historical response.
+
+**Step 2: Define a persistence-owned version**
+
+Increment the transcript schema. Store raw ACP envelopes and Nori events in a
+persistence envelope that can redact or omit secrets and ephemeral request
+channels. Do not require the public enums themselves to become a permanent
+storage ABI. Preserve request/response IDs for a typed offline transcript reader
+without making those historical envelopes replayable.
+
+**Step 3: Add a private version-2 decoder**
+
+Keep only the legacy shapes needed to decode user-owned records. Translate them
+directly into replayable ACP/Nori state. Do not export legacy types, implement a
+runtime compatibility facade, or write new version-2 records.
+
+**Step 4: Preserve replay ordering**
+
+Emit `ReplayStarted`, raw ACP notifications in original order, the minimum
+Nori-owned state restoration events, and `ReplayFinished`. Do not synthesize
+`ReplayEntry`, re-emit historical delegated requests, or deliver historical
+responses to live pending calls. Make the side-effect and live-completion tests
+from Step 1 pass.
+
+**Step 5: Run transcript and harness tests**
+
+Run the transcript test module, harness package tests, and the new black-box
+boundary test. Verify fixtures contain no credentials or machine-specific
+paths before committing them.
+
+## Task 6: Migrate the TUI and headless consumer without recreating protocol mirrors
+
+**Files:**
+
+- Modify: `nori-rs/tui/Cargo.toml`
+- Modify: current event dispatch files under `nori-rs/tui/src/nori/`
+- Modify: current event handlers under `nori-rs/tui/src/chatwidget/`
+- Modify: tool/message/plan presentation modules under `nori-rs/tui/src/`
+- Modify: `nori-rs/cli/Cargo.toml`
+- Modify: relevant `nori-rs/cli/src/*.rs` harness entry points
+- Add or update: a headless harness example/integration test in the harness or
+  CLI crate
+
+**Step 1: Write failing frontend and headless boundary tests**
+
+Add the smallest TUI regression cases that exercise representative raw ACP
+message, plan, tool, permission, and completion events plus Nori lifecycle and
+query behavior. Add the headless integration test that sends a prompt, consumes
+both source branches, answers one delegated request, and awaits one direct
+query. Run them against the old dispatch and confirm they fail for the expected
+missing-boundary reason.
+
+**Step 2: Change the top-level TUI dispatch**
+
+Match `SessionEvent::Acp` and `SessionEvent::Nori` first. Within `AcpEvent`,
+handle the ACP aggregate variants directly. Within `NoriEvent`, handle only
+Nori-owned lifecycle/product behavior.
+
+**Step 3: Keep projections private to presentation**
+
+Move tool titles, icons, invocation summaries, diff rendering, message chunk
+assembly for widgets, and mode/config labels into private TUI view models. They
+must not be exported by `nori-protocol` or fed back into the harness.
+
+**Step 4: Convert query call sites**
+
+Replace event-response waiting for history, prompts, undo lists, session lists,
+config mutation, and close with awaited typed method results. Keep UI request
+IDs local only when the UI itself needs stale-result suppression.
+
+**Step 5: Exercise both consumers**
+
+Run focused TUI unit/snapshot tests, then the PTY end-to-end suite. Run the
+headless integration/example against the same harness API to catch accidental
+terminal dependencies.
+
+## Task 7: Rehome residual Codex types and delete `codex-protocol`
+
+**Files:**
+
+- Delete: `nori-rs/protocol/`
+- Modify: `nori-rs/Cargo.toml` and `nori-rs/Cargo.lock`
+- Modify: Cargo manifests and imports in every refreshed reverse dependency
+- Modify or delete: residual type owners identified in Task 1
+
+The baseline reverse dependencies were `codex-app-server-protocol`,
+`codex-common`, `codex-core`, `codex-linux-sandbox`, `codex-otel`,
+`codex-rmcp-client`, `codex-sandbox`, `codex-windows-sandbox`, `nori-acp-host`,
+`nori-cli`, `nori-config`, `nori-harness`, and `nori-tui`. Use the refreshed
+list, not this baseline, when editing.
+
+**Step 1: Rehome only live non-protocol values**
+
+Move configuration/runtime policy to the post-refactor configuration owner,
+UI formatting to the frontend, private parser helpers to the harness/frontend,
+and persistence compatibility to the transcript loader. Prefer deletion over a
+new shared crate when a type has one consumer.
+
+**Step 2: Delete Codex/OpenAI model vocabulary**
+
+Delete Responses API items, legacy rollout events, old content/plan/tool/event
+mirrors, and no-op variants after the approved deletion audit. Localize any
+genuinely live app-server-only value to that crate rather than exporting it
+through Nori protocol.
+
+**Step 3: Remove every dependency edge and the crate**
+
+Remove `codex-protocol` from manifests and the lockfile, delete
+`nori-rs/protocol/`, and update imports. Do not leave an empty shell crate or a
+temporary alias.
+
+**Step 4: Enforce schema imports**
+
+Remove every direct `agent-client-protocol-schema` dependency except
+`nori-protocol`. Keep the higher-level `agent-client-protocol` SDK dependency
+only in `nori-acp-host` among client-side product crates. Agent implementations
+and conformance fixtures such as `mock-acp-agent` may depend on the SDK directly
+on the agent side. Import schema types through `nori_protocol::acp` even inside
+the host.
+
+**Step 5: Verify the hard cut**
+
+```bash
+cargo tree --manifest-path nori-rs/Cargo.toml -i codex-protocol
+rg -n 'codex-protocol' nori-rs -g Cargo.toml
+rg -n '\bcodex_protocol\b' nori-rs -g '*.rs'
+rg -n 'agent-client-protocol-schema' nori-rs -g Cargo.toml
+rg -n '\bagent_client_protocol_schema\b' nori-rs -g '*.rs'
+rg -n 'agent-client-protocol' nori-rs -g Cargo.toml
+rg -n '\bagent_client_protocol\b' nori-rs -g '*.rs'
+rg -n 'agent_client_protocol::schema' nori-rs -g '*.rs'
+```
+
+The Codex searches must find nothing. Schema manifest matches are allowed only
+for the workspace dependency declaration and `nori-protocol`; the sole schema
+source import is its public re-export. SDK manifest/source matches are allowed
+only for the workspace declaration, `nori-acp-host`, and explicitly agent-side
+or conformance-test crates. The final `::schema` search must find nothing,
+because even SDK consumers import schema values through `nori_protocol::acp`.
+
+## Task 8: Update architecture and protocol documentation
+
+**Files:**
+
+- Modify: `docs/specs/protocol-unification.md`
+- Modify: `docs/specs/crate-layering.md`
+- Modify: `docs/specs/acp-tui/*.md`
+- Modify: `nori-rs/docs.md`
+- Modify: `nori-rs/nori-protocol/docs.md`
+- Modify: `nori-rs/acp-host/docs.md`
+- Modify: `nori-rs/harness/docs.md`
+- Modify: component `docs.md` files in changed source directories
+- Modify: public README/headless embedding documentation where applicable
+
+**Step 1: Convert design claims to implemented facts**
+
+Update dependency diagrams, current-state descriptions, transcript version,
+public examples, and ownership rules. Remove claims that `Event`/`EventMsg`/`Op`
+are Nori's internal control plane or that two protocol vocabularies are
+deliberate.
+
+**Step 2: Document embedding and request delegation**
+
+Show a minimal Rust consumer matching the two source branches, sending a prompt,
+responding to a delegated ACP request, and awaiting a typed Nori query. Explain
+the filesystem/terminal auto-handle versus delegate configuration.
+
+**Step 3: Run documentation consistency searches**
+
+Search documentation for stale crate names, normalized `ClientEvent`, Codex
+event bus terminology, direct ACP schema imports, and transcript version claims.
+Update only statements invalidated by this implementation.
+
+## Task 9: Final verification and branch handoff
+
+**Step 1: Run formatting and static checks**
+
+Run the repository-prescribed Rust format, lint, and dependency checks. Inspect
+all output; do not ignore unrelated failures. Root-cause and fix every CI issue
+as required by `AGENTS.md`.
+
+**Step 2: Run package and workspace tests**
+
+At minimum, run:
+
+- `nori-protocol`, `nori-acp-host`, `nori-harness`, `nori-tui`, `nori-cli`, and
+  every rehomed support crate's tests;
+- the new black-box harness boundary and transcript compatibility tests;
+- the mock ACP agent/conformance tests; and
+- `cargo build --bin nori` plus `cargo test -p tui-pty-e2e`.
+
+Use the repository's canonical commands if the configuration refactor changes
+these package names or check entry points.
+
+**Step 3: Review the diff for simplification**
+
+Confirm the implementation is net-negative where expected, no compatibility
+facade remains, no public projection duplicates ACP, and no business logic sits
+in `nori-protocol`.
+
+**Step 4: Complete branch workflow**
+
+Follow the finishing-development and documentation skills, update the PR with
+the refreshed deletion inventory and exact verification results, and request
+review only after the full suite is green.
+
+## Backward compatibility notes
+
+- Rust imports and enum matches intentionally break. The hard cut is approved;
+  downstream embedders migrate to `SessionEvent`, raw ACP aggregates, and typed
+  handle methods.
+- There is no deprecation window for `codex_protocol`, `ClientEvent`, `Op`, or
+  `EventMsg`.
+- Existing user transcripts remain readable through a private version-2
+  decoder. New writes use the new schema only.
+- A headless JSON-RPC surface may version and correlate its own wire messages,
+  but those concerns do not alter the Rust event API.
+- ACP schema version changes are centralized at `nori-protocol`; this plan does
+  not itself authorize an ACP dependency upgrade.
+
+## Edge cases to cover
+
+- an agent sends a notification before the corresponding prompt/load response;
+- two requests have identical content but different ACP `RequestId` values;
+- cancellation races with a final notification or response;
+- the subprocess exits with delegated agent requests still awaiting responses;
+- a frontend drops the event receiver while the harness is auto-handling a
+  filesystem/terminal request;
+- replay is empty, interrupted, or contains a version-2 event that no longer
+  has a public equivalent;
+- a legacy transcript contains unknown future fields or malformed records;
+- an ACP extension aggregate is unknown to the current frontend but valid to
+  the schema;
+- queue and phase changes occur while replay is in progress;
+- goals are cleared (`None`) while a prompt is active;
+- a query completes concurrently with streamed events and produces no duplicate
+  event response;
+- config capabilities change after initialization; ACP and Nori capability
+  sources must remain separate; and
+- transport loss is not misreported as an ACP error response.
+
+**Testing Details** Add real mock-agent/harness boundary tests for raw ACP ordering and request correlation, public-operation tests for Nori events and typed queries, transcript loader/replay tests for version-2 compatibility and the new write format, and TUI/headless end-to-end regressions. Tests observe public behavior and real channels/subprocesses, not private state, enum serialization snapshots, or mocked call counts.
+
+**Implementation Details**
+
+- Wait for and rebase onto the configuration rework.
+- Refresh and approve the exact deletion inventory before deletion.
+- Re-export ACP schema only from `nori-protocol`.
+- Preserve raw ACP notification/request/response aggregates and request IDs.
+- Keep `NoriEvent` notification-only and outside ACP semantics.
+- Return query results through typed harness methods.
+- Move reducers and projections to their actual private owners.
+- Read old transcripts privately; write only the new version.
+- Remove every `codex-protocol` edge and delete the crate atomically.
+- Verify both TUI and headless embedders against the same harness API.
+
+**Question** After the configuration rework lands, the deletion gate must resolve the final owners of approval/sandbox policy, the name of Nori's persisted conversation identity, the minimal fields/derive traits of each Nori event payload, and the two explicit prompt-summary/nonfatal-notice extension gaps. No other design question currently reopens the approved ACP/Nori boundary.
+
+---

--- a/docs/specs/crate-layering.md
+++ b/docs/specs/crate-layering.md
@@ -67,32 +67,36 @@ Observed problems, in rough order of cost:
 ## 3. Target layout
 
 ```
-Layer 0 — leaves (independently useful, publishable to crates.io)
-├── nori-acp-host     ACP host-side library: agent registry, subprocess spawn,
-│                     JSON-RPC/stdio connection, session lifecycle, permission
-│                     plumbing. No TUI, no ~/.nori, no codex-* deps.
-├── nori-protocol     The internal types crate: session-runtime types plus the
-│                     adopted internal event vocabulary (today's codex-protocol
-│                     Event/EventMsg/Op), built on agent-client-protocol-schema.
-│                     Minimal deps, no business logic. Two vocabularies remain
-│                     deliberate: ACP wire types at the boundary, internal event
-│                     types as the harness's control plane (the same split
-│                     upstream keeps between codex-protocol and its app-server
-│                     protocol).
-└── mock-acp-agent    Conformance-test agent for ACP hosts and agent authors.
+Layer 0 — protocol substrate (independently useful, publishable to crates.io)
+└── nori-protocol     The public boundary types crate and sole ACP schema import
+                      choke point. It re-exports the ACP schema, carries raw ACP
+                      agent→client envelopes, and defines only the small set of
+                      Nori-owned events ACP does not cover. Minimal deps, no
+                      reducers, normalization, presentation, or other business
+                      logic. See docs/specs/protocol-unification.md.
 
-Layer 1 — headless runtime (the harness product)
-├── nori-harness      Session runtime over nori-acp-host: backend reducer,
-│                     transcript, undo, auto-worktree, hooks, message history.
-│                     Embeddable without a terminal.
+Layer 1 — configuration
 └── nori-config       ~/.nori loading, agent registry config, approval policy.
                       Runtime composition — no cargo features that move config.
 
-Layer 2 — frontends (thin)
+Layer 2 — ACP host
+└── nori-acp-host     ACP host-side library over nori-protocol and nori-config:
+                      agent registry, subprocess spawn, JSON-RPC/stdio
+                      connection, session lifecycle, permission plumbing.
+
+Layer 3 — headless runtime (the harness product)
+└── nori-harness      Session runtime over nori-acp-host: backend reducer,
+                      transcript, undo, auto-worktree, hooks, message history.
+                      Embeddable without a terminal UI.
+
+Layer 4 — frontends (thin)
 ├── nori-tui          Rendering and input only. Drives nori-harness through its
 │                     event interface; never imports nori-acp-host directly.
 └── nori-cli          The `nori` binary: dispatch, plus headless exec/RPC mode
                       over the same harness.
+
+Test support (outside the product dependency chain)
+└── mock-acp-agent    Conformance-test agent for ACP hosts and agent authors.
 ```
 
 Support crates keep their jobs where they are genuinely separate concerns
@@ -101,12 +105,13 @@ may depend upward.
 
 ### Dependency rules
 
-1. Arrows point down only. Layer 2 → Layer 1 → Layer 0. No sibling
-   cross-imports within a layer.
+1. Arrows point down only. Layer 4 → Layer 3 → Layer 2 → Layer 1 → Layer 0. No
+   sibling cross-imports within a layer.
 2. `nori-tui` never imports `nori-acp-host` directly — all agent interaction
    flows through `nori-harness` events (the way upstream codex-tui drives core
    via app-server-client).
-3. Nothing in Layers 0–1 may know a terminal exists (no ratatui, no ANSI).
+3. Nothing in Layers 0–3 may depend on ratatui or render terminal presentation
+   (including ANSI styling). ACP terminal operations remain a host concern.
 4. New functionality lands in a new module or crate before it grows an
    existing one ("resist adding code to core", inherited and kept).
 5. No cargo feature may change which crate owns a responsibility.
@@ -144,10 +149,13 @@ phases 3–5:
   conversation manager were already stripped (#196, #230, #438). What remains
   is a 22.5k-LOC utility/config grab-bag; roughly a third to half of it is
   unreferenced by the `nori` binary.
-- **codex-protocol is load-bearing and agent-agnostic.** It is the internal
-  event vocabulary (`Event`/`EventMsg`/`Op`) for *all* agents, and
-  `translator.rs` is the generic ACP-wire ↔ internal-event bridge on every
-  agent's hot path. Verdict: adopt and rename as Nori-owned, don't remove.
+- **The current codex-protocol path is load-bearing but not the target.** Its
+  `Event`/`EventMsg`/`Op` vocabulary and ACP translator currently sit on the hot
+  path, but they duplicate or distort the ACP boundary. The approved follow-up
+  is a hard cut: expose raw ACP aggregates through `nori-protocol`, retain only
+  Nori-owned concerns there, migrate query operations to typed harness methods,
+  and delete `codex-protocol`. See `docs/specs/protocol-unification.md` for the
+  normative ownership rule and deletion inventory.
 - **Upstream sync is dead.** No `upstream` remote exists and there have been
   zero merges from openai/codex since the squash-rename (#443). Deleting and
   renaming inherited crates carries no merge cost. Convention going forward:
@@ -167,7 +175,8 @@ plans go in `docs/plans/` as each is picked up.
 | D | Un-detour protocol imports | Rewire `codex_core::protocol::*` (178+ refs in tui, plus cli) to import `codex_protocol` directly; drop the re-exports from core's lib.rs | low | ~0 |
 | E | Sever nori-acp → codex-core | Extract the six leaf helpers (`user_notification`, `custom_prompts::discover_prompts_in`, `parse_command`, `util::create_patch_with_context`, `compact` constants) plus `config::types::McpServerConfig` into their target crates; acp's only remaining codex deps are protocol + rmcp OAuth store | medium | ~0 |
 | F | Extract config/auth | Pull codex-core's `config` subtree (6.2k, the biggest live consumer) and `auth` into `nori-config` / auth home; whatever codex-core still holds after B+E+F gets dissolved or renamed | medium | ~0 |
-| G | Split nori-acp | `nori-acp-host` (registry, connection, subprocess, wire) + `nori-harness` (backend reducer, transcript, undo, worktrees, hooks) + config move; adopt/rename `codex-protocol` into `nori-protocol` | medium | ~0 |
+| G | Split nori-acp | `nori-acp-host` (registry, connection, subprocess, wire) + `nori-harness` (backend reducer, transcript, undo, worktrees, hooks) + config move; completed crate split, with protocol unification now specified separately | medium | ~0 |
+| G2 | Unify protocol boundary | Re-export ACP schema from `nori-protocol`; emit raw ACP envelopes plus the small Nori event branch; replace the generic operation bus with typed harness methods; delete `codex-protocol` after the configuration rework and deletion review gate | high | −net |
 | H | Invert the TUI | Move orchestration out of `tui/src/nori/` and `chatwidget/` into the harness; TUI consumes harness events only (dependency rule 2 becomes enforceable) | high | −net |
 | I | Ecosystem surfaces | Publish `nori-acp-host` + `mock-acp-agent` to crates.io; document transcript/session format; add headless exec/RPC mode | low | +small |
 
@@ -188,7 +197,7 @@ dependency edge:
 | Edge | Verdict | Evidence |
 |------|---------|----------|
 | nori-acp → codex-core | **EXTRACT** | Six leaf helpers only: `user_notification` (`UserNotifier`, `AwaitingApproval`/`Idle`), `custom_prompts::discover_prompts_in`, `parse_command`, `util::create_patch_with_context`, two `compact` string constants, and `config::types::{McpServerConfig, McpServerTransportConfig}` (shared with tui — belongs in the config crate). No engine usage anywhere. |
-| nori-acp → codex-protocol | **KEEP / ADOPT** | The backend deliberately keeps `codex_protocol::{Event, EventMsg, Op}` as the internal control-plane representation for all agents (documented in `acp/src/backend/mod.rs`). `translator.rs` (1.6k LOC) bridges ACP wire ↔ these types on every agent's hot path — Claude, codex, cloud, and custom agents alike. Rename/merge into `nori-protocol`. |
+| nori-acp → codex-protocol | **CURRENTLY LIVE → DELETE** | The audit correctly found `codex_protocol::{Event, EventMsg, Op}` and the ACP translator on every agent's hot path. Subsequent protocol design rejected that second vocabulary: ACP owns agent↔client semantics, `nori-protocol` re-exports the schema and adds only Nori concerns, and the Codex crate is deleted by a hard cut. Implementation waits for the configuration rework and refreshed deletion gate. |
 | nori-acp → codex-rmcp-client | **KEEP** (or extract OAuth store) | Only the MCP OAuth token persistence (`load_oauth_tokens`/`save_oauth_tokens` etc.) in `connection/mcp.rs`; self-contained. |
 | nori-acp → mcp-types | **DELETE** | Zero usage; not even in acp's Cargo.toml. |
 | nori-tui → `codex_core::protocol::*` | **DELETE detour** | 178+ refs are re-exports of `codex_protocol`; rewire directly (slice D). |

--- a/docs/specs/protocol-unification.md
+++ b/docs/specs/protocol-unification.md
@@ -1,0 +1,739 @@
+# Protocol Unification at the Harness Boundary
+
+Status: **approved core design; implementation blocked on configuration and two Nori extension decisions**
+Created: 2026-07-18
+
+This specification replaces the earlier assumption that Nori should adopt the
+Codex `Event`/`EventMsg`/`Op` vocabulary. The target is one public protocol
+entry point, an ACP-faithful agent/client boundary, and a much smaller set of
+Nori-owned events for behavior that ACP does not define.
+
+No production code changes belong in this documentation PR. Implementation
+starts only after the active CLI configuration rework lands and the inventories
+in this document have been refreshed against its result.
+
+## Historical grounding
+
+This design is the unfinished protocol slice of the crate-boundary refactor,
+not a replacement for the boundaries that already landed:
+
+- #520 documented the target leaf/host/harness/frontend layering. Its import
+  audit correctly found Codex protocol on the live path, but its original
+  verdict was to adopt that vocabulary.
+- #524 removed the `codex-core` protocol re-export detour, making actual
+  protocol dependencies visible.
+- #526 severed the old ACP runtime's dependency on `codex-core`; #527 extracted
+  sandboxed execution; #528 extracted `nori-config`.
+- #529 extracted `nori-acp-host`; #530 made the TUI/CLI import configuration
+  from its owner; #531 moved session orchestration into the harness; and #532
+  named that product `nori-harness`.
+- #533 prepared the central crates for publishing and specified the transcript
+  format.
+
+Those changes established the physical crate boundaries, but left two protocol
+models on the harness hot path: the Codex `Event`/`EventMsg`/`Op` bus and
+`nori-protocol::ClientEvent`, which normalizes ACP schema values into a second
+Nori representation. At baseline commit `500ee202`, 13 crates still directly
+depend on `codex-protocol`, and schema imports are split across
+`nori-protocol`, `nori-harness`, and `nori-acp-host`.
+
+This spec supersedes only the old protocol verdict. The landed host/harness/TUI
+layering remains the foundation: the protocol cleanup makes that boundary
+truthful and usable by non-TUI embedders.
+
+## 1. Decision
+
+The refactor is a hard cut:
+
+- delete the `codex-protocol` crate rather than rename it, wrap it, or retain
+  deprecated aliases;
+- make `nori-protocol` the only import path for ACP schema types outside the ACP
+  host implementation;
+- preserve ACP's agent/client semantics without projecting them into parallel
+  Nori enums;
+- keep Nori-owned protocol types limited to harness lifecycle, persistence,
+  queueing, goals, undo, hooks, history, and UI/UX concerns that ACP does not
+  define;
+- keep normalization, reduction, and presentation logic out of
+  `nori-protocol`; and
+- replace the Codex submission/event bus with typed harness methods plus one
+  outward session event stream.
+
+The desired result is both conceptually smaller and a net deletion. Embedders
+of `nori-harness` should learn ACP plus a small Nori extension vocabulary, not
+ACP, a Codex compatibility protocol, and a second normalized ACP model.
+
+## 2. Ownership rule
+
+Use this test whenever a type is proposed for `nori-protocol`:
+
+1. If ACP defines the interaction between an agent and a client, ACP owns it.
+2. If Nori adds behavior around an ACP session and ACP does not define that
+   behavior, Nori may own the smallest type that expresses it.
+3. If a type exists only to reduce events, assemble state, translate content,
+   persist an implementation detail, or render a UI, it belongs in the harness,
+   persistence adapter, or frontend—not in the protocol crate.
+4. If a type describes Codex/OpenAI model internals rather than the Nori harness
+   boundary, delete it or localize it to its one remaining private consumer.
+
+Examples:
+
+| Concern                                                                                   | Owner                                                              |
+| ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Agent text, thoughts, plans, tool calls, usage, modes, config options, available commands | ACP schema                                                         |
+| Agent permission, filesystem, terminal, and elicitation requests                          | ACP schema                                                         |
+| Prompt/load/setup/list/close responses and ACP errors                                     | ACP schema                                                         |
+| Queue state, compaction, goals, undo, user shell, hooks                                   | Nori protocol                                                      |
+| Session reducer, open-message assembly, request tracking                                  | `nori-harness` private implementation                              |
+| Tool titles, icons, grouped output, friendly labels                                       | frontend presentation                                              |
+| Authentication, approval policy, sandbox policy, model defaults                           | configuration/runtime owner selected by the configuration refactor |
+
+## 3. Dependency choke point
+
+`nori-protocol` directly depends on and publicly re-exports the ACP schema
+crate:
+
+```rust
+// nori-protocol/src/lib.rs
+pub use agent_client_protocol_schema as acp;
+```
+
+All schema imports in Nori client-side product crates use that public path:
+
+```rust
+use nori_protocol::acp;
+use nori_protocol::acp::v1::SessionUpdate;
+```
+
+Direct imports of `agent_client_protocol_schema` outside `nori-protocol` are
+forbidden in the Nori client-side product graph. This gives Nori one place to
+change ACP library versions, vendor a schema implementation, or replace the
+current crate without rewriting every client consumer.
+
+`nori-acp-host` is the only client-side product exception at the SDK layer. It
+may directly depend on and import higher-level runtime traits and transport
+machinery from `agent-client-protocol`, while importing schema types through
+`nori_protocol::acp` like every other product crate. ACP agent implementations
+and conformance fixtures, including `mock-acp-agent`, may use the runtime SDK
+directly on the agent side; they are not client protocol consumers. No frontend
+may depend directly on either ACP crate or on `nori-acp-host`.
+
+The intended dependency shape is:
+
+```text
+nori-cli / nori-tui
+          |
+          v
+     nori-harness --------> nori-protocol::acp
+          |                         ^
+          v                         |
+     nori-acp-host -----------------+
+          |
+          +----> agent-client-protocol (runtime SDK only)
+
+nori-protocol ----> agent-client-protocol-schema
+```
+
+## 4. Public session event API
+
+The outward stream uses source-owned nesting:
+
+```rust
+pub enum SessionEvent {
+    Acp(AcpEvent),
+    Nori(NoriEvent),
+}
+```
+
+This preserves provenance at the type level. Consumers can exhaustively handle
+Nori additions without interleaving them with ACP variants, and ACP schema
+growth remains inside the ACP branch.
+
+### 4.1 Raw ACP envelopes
+
+The ACP branch contains the three directional envelopes an ACP agent can emit
+toward its client:
+
+```rust
+pub enum AcpEvent {
+    Notification(acp::v1::AgentNotification),
+    Request {
+        request_id: acp::v1::RequestId,
+        request: acp::v1::AgentRequest,
+    },
+    Response {
+        request_id: acp::v1::RequestId,
+        response: Result<acp::v1::AgentResponse, acp::v1::Error>,
+    },
+}
+```
+
+These variants are schema-complete for the outward agent-to-client event
+boundary:
+
+| Current interaction                                                               | New envelope                                                                     |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Session content, plans, tool calls, usage, commands, modes, config, session info  | `AcpEvent::Notification(AgentNotification::SessionNotification(...))`            |
+| Permission request                                                                | `AcpEvent::Request { request: AgentRequest::RequestPermissionRequest(...), .. }` |
+| Filesystem, terminal, elicitation, or extension request delegated to the embedder | `AcpEvent::Request { .. }`                                                       |
+| Prompt completion and stop reason                                                 | `AcpEvent::Response { response: Ok(AgentResponse::PromptResponse(...)), .. }`    |
+| Initialize, authenticate, setup, load, list, resume, config, and close completion | the corresponding `AgentResponse` variant                                        |
+| ACP-defined failure                                                               | `AcpEvent::Response { response: Err(...), .. }`                                  |
+
+The public event receiver must exist before the host issues its first ACP call.
+Initialization and session-creation responses are buffered in original order if
+construction awaits bootstrap, so a consumer that receives the harness only
+after bootstrap still observes them. The relay must not block bootstrap on an
+unavailable consumer or silently discard early responses.
+
+The harness may satisfy filesystem and terminal requests itself or delegate
+them according to harness configuration. A delegated request crosses the event
+boundary unchanged. Its eventual response returns through a typed harness
+method using the same `RequestId`; it is not converted into a Codex approval
+type.
+
+The stream is faithful, not necessarily wire-byte-identical. Transport framing
+and JSON-RPC bookkeeping stay in `nori-acp-host`; the schema envelope and
+request identity remain intact.
+
+### 4.2 Nori-only notifications
+
+The approved first-pass Nori branch is:
+
+```rust
+pub enum NoriEvent {
+    SessionStarted(SessionStarted),
+    SessionPhaseChanged(SessionPhase),
+    SessionEnded(SessionEnded),
+    QueueChanged(QueueSnapshot),
+    ReplayStarted(ReplayStarted),
+    ReplayFinished,
+    ContextCompacted(ContextCompacted),
+    GoalChanged(Option<ThreadGoal>),
+    CapabilitiesChanged(NoriCapabilities),
+    Undo(UndoEvent),
+    UserShell(UserShellEvent),
+    HookOutput(HookOutput),
+    RequestFailed(RequestFailure),
+}
+```
+
+The outer variants above are the approved first pass. The live-gap audit below
+must add or relocate two concerns before this becomes the final exhaustive Nori
+enum. Payload fields and their exact derive sets are intentionally not invented
+by this spec: they must be reduced to the fields required by real consumers
+during implementation. New public structs should derive only the traits their
+use requires.
+
+Variant semantics are fixed:
+
+- `SessionStarted` announces that the Nori harness session exists. ACP setup
+  responses still appear as raw ACP responses.
+- `SessionPhaseChanged` reports Nori's lifecycle projection of idle, loading,
+  prompting, and cancelling. It does not copy request content or completion
+  data.
+- `SessionEnded` reports orderly shutdown or connection loss with a Nori-owned
+  reason.
+- `QueueChanged` is the current Nori prompt/operation queue snapshot.
+- `ReplayStarted` and `ReplayFinished` bracket replayed raw ACP notifications.
+  There is no Nori `ReplayEntry` mirror.
+- `ContextCompacted` reports Nori's compaction lifecycle/result.
+- `GoalChanged(Some(...))` reports the current persistent Nori goal;
+  `GoalChanged(None)` reports that it was cleared.
+- `CapabilitiesChanged` contains only Nori harness capabilities. ACP agent and
+  session capabilities stay in ACP responses and notifications.
+- `Undo`, `UserShell`, and `HookOutput` report Nori-owned operations that ACP
+  does not standardize.
+- `RequestFailed` means the harness or transport failed before an ACP response
+  existed. ACP errors and successful prompt completion remain
+  `AcpEvent::Response`.
+
+`NoriEvent` is notification-oriented. It is not a second general-purpose
+request/response bus.
+
+#### Two live Nori concerns still need variant co-design
+
+The baseline producer/consumer audit found two outward Nori concerns that do
+not fit the approved first-pass variants without lying about their semantics:
+
+- prompt-summary generation is a separate background-agent result used by the
+  TUI footer and auto-worktree naming. It is neither context compaction nor hook
+  output; and
+- nonfatal user-visible notices include slow-cancellation advice, compaction
+  advice, reducer out-of-phase warnings, and hook failures. They are not
+  `RequestFailed`, because the owning request may continue or complete.
+
+Before implementation, co-design the smallest truthful additions—provisionally
+a prompt-summary update and a user-visible notice/diagnostic variant—or
+explicitly remove/relocate those behaviors. Do not overload `RequestFailed`,
+`ContextCompacted`, or `HookOutput`. This is a narrow completion of the Nori
+branch; it does not reopen the ACP envelopes or introduce ACP mirrors.
+
+### 4.3 Commands and queries
+
+Client-to-agent ACP operations are typed methods on the harness handle. Nori
+commands and queries are also typed methods. The exact trait split can follow
+the existing harness API, but it must preserve these categories:
+
+```rust
+// Illustrative method families; names and concrete return types are finalized
+// against the post-configuration-refactor harness API.
+impl HarnessHandle {
+    pub async fn prompt(&self, content: Vec<acp::v1::ContentBlock>) -> Result<acp::v1::RequestId>;
+    pub async fn load_session(&self, request: acp::v1::LoadSessionRequest) -> Result<acp::v1::RequestId>;
+    pub async fn cancel(&self) -> Result<()>;
+    pub async fn respond_to_agent(
+        &self,
+        request_id: acp::v1::RequestId,
+        response: std::result::Result<acp::v1::ClientResponse, acp::v1::Error>,
+    ) -> Result<()>;
+
+    pub async fn history_entry(&self, key: HistoryKey) -> Result<Option<HistoryEntry>>;
+    pub async fn search_history(&self, query: HistoryQuery) -> Result<Vec<HistoryEntry>>;
+    pub async fn custom_prompts(&self) -> Result<Vec<CustomPrompt>>;
+    pub async fn undo_snapshots(&self) -> Result<Vec<UndoSnapshot>>;
+    pub async fn list_sessions(&self) -> Result<acp::v1::ListSessionsResponse>;
+    pub async fn set_config_option(&self, change: acp::v1::SetSessionConfigOptionRequest) -> Result<acp::v1::SetSessionConfigOptionResponse>;
+    pub async fn close_session(&self) -> Result<acp::v1::CloseSessionResponse>;
+}
+```
+
+In particular, history lookup/search, custom prompt discovery, undo snapshot
+listing, session listing, config mutation, and session close do not return
+correlated `NoriEvent` variants. A CLI/headless JSON-RPC adapter may add its own
+correlation IDs at that external transport boundary without imposing them on
+Rust embedders or the ordered session stream.
+
+Prompt and load are streaming operations: submission returns the `RequestId`,
+zero or more raw ACP notifications may follow, and completion arrives as the
+correlated `AcpEvent::Response`. Query-style and other non-streaming ACP methods
+return their typed result directly; their raw `AcpEvent::Response` also remains
+visible so the boundary stays schema-complete. Those callers never have to
+consume or correlate the stream to finish the call. Nori does not add a
+duplicate response variant.
+
+## 5. `nori-protocol` is types only
+
+The crate contains public boundary types and no stateful reducer or
+presentation code.
+
+Current business logic moves out:
+
+- `ClientEventNormalizer` and its ACP-to-Nori projection helpers move into the
+  harness only where reduction is still needed; most projection code disappears
+  because raw ACP events cross the boundary.
+- `session_runtime::SessionRuntime`, `ActiveRequestState`, message assembly,
+  persisted reducer state, and queued-prompt internals move into private
+  `nori-harness` modules.
+- frontend projections such as tool kind inference, friendly invocation
+  descriptions, grouping, and command display move to or remain in `nori-tui`.
+- transcript serialization uses a persistence-owned envelope rather than
+  making the public event API serve as a storage schema by accident.
+
+A small public `SessionPhase` value may remain because phase changes are part
+of `NoriEvent`. It is a boundary value, not the session state machine.
+
+## 6. Compatibility and persistence
+
+The Rust API has no compatibility facade: `codex_protocol::{Event, EventMsg,
+Op}` and the current normalized `nori_protocol::ClientEvent` disappear in the
+hard cut.
+
+User-owned transcripts are different from Rust API compatibility. Current
+version-2 Nori transcript records contain serialized normalized `ClientEvent`
+values. The harness loader must continue to read those records, while the
+recorder writes a new version containing raw ACP envelopes plus Nori events.
+Legacy decode types live privately in the persistence adapter and are not
+re-exported from `nori-protocol`.
+
+Replay of a new transcript emits:
+
+1. `NoriEvent::ReplayStarted`;
+2. the recorded `SessionEvent::Acp` notifications in original order, plus only
+   the Nori events needed to restore Nori-owned state; and
+3. `NoriEvent::ReplayFinished`.
+
+Recorded ACP request/response envelopes retain `RequestId` so an offline
+transcript reader can correlate the historical exchange. Replay intentionally
+does **not** re-emit either envelope: a historical delegated request must never
+ask the embedder to perform an operation again, and a historical response must
+not complete a live request. A typed transcript-inspection API exposes stored
+records separately from replay.
+
+Secrets, transport-only metadata, and ephemeral approval channels must not be
+persisted merely because the public stream carries a schema object. The
+persistence adapter must redact or omit unsafe request/response content while
+preserving the minimum correlation and user-visible history required by the
+documented transcript format.
+
+## 7. Exact current deletion and rehoming inventory
+
+This records the current deletion and rehoming candidates at commit `500ee202`
+before the configuration rework. The top-level `ClientEvent`, `Op`, and
+`EventMsg` variant ledgers below are exhaustive at that baseline; secondary
+module types are grouped by ownership. The implementation must refresh all
+symbols, producers, and consumers after the configuration work lands, publish
+the resulting exact list for sanity-check, and receive approval before deleting
+them. That refreshed audit—not this frozen baseline—is the final deletion gate.
+
+### 7.1 Current `nori-protocol::ClientEvent`
+
+Delete ACP mirrors:
+
+- `ToolSnapshot`
+- `ApprovalRequest`
+- `MessageDelta`
+- `PlanSnapshot`
+- `AgentCommandsUpdate`
+- `SessionUpdateInfo`
+- `SessionConfigUpdate`
+- `SessionModeChanged`
+
+Replace rather than carry forward:
+
+- `SessionPhaseChanged` → `NoriEvent::SessionPhaseChanged`
+- `PromptCompleted` → `AcpEvent::Response`; transport/runtime failure only →
+  `NoriEvent::RequestFailed`
+- `LoadCompleted` → `AcpEvent::Response`
+- `QueueChanged` → `NoriEvent::QueueChanged`
+- `ContextCompacted` → `NoriEvent::ContextCompacted`
+- `ReplayEntry` → raw ACP notifications bracketed by `ReplayStarted` and
+  `ReplayFinished`
+- `SessionCapabilitiesChanged` → raw ACP capabilities plus
+  `NoriEvent::CapabilitiesChanged` for Nori-only capabilities
+- `ThreadGoalUpdated` and `ThreadGoalCleared` →
+  `NoriEvent::GoalChanged(Option<ThreadGoal>)`
+- `Warning` → an ACP error/notification when ACP owns the condition; otherwise
+  the pending Nori notice/diagnostic decision for user-visible nonfatal
+  conditions, or a private diagnostic only when no consumer needs it
+
+Delete the associated ACP projection vocabulary:
+
+- `AgentCommandInfo`, `AgentCommandsUpdate`
+- `AgentCapabilitiesView`, `SessionCapabilitiesView`,
+  `NoriClientCapabilitiesView`, and the ACP-derived portion of
+  `CommandAvailability`
+- `SessionConfigUpdate`, `SessionUpdateInfo`, `SessionUpdateKind`,
+  `SessionModeChanged`
+- `ReplayEntry`
+- `MessageDelta`, `MessageStream`
+- `PlanSnapshot`, `PlanEntry`, `PlanStatus`
+- `ToolSnapshot`, `ToolKind`, `ToolPhase`, `ToolLocation`
+- `ApprovalRequest`, `ApprovalSubject`, `ApprovalOption`, `ApprovalOptionKind`
+- `Invocation`, `Artifact`, `FileChange`, `FileOperation`
+- `ClientEventNormalizer`
+
+Move the following implementation types from `nori-protocol` into private
+`nori-harness` modules rather than exposing them as protocol:
+
+- `ActiveRequestKind`, `ActiveRequestState`
+- `OpenMessage`
+- `PersistedSessionState`, `SessionInfoState`, `SessionUsageState`
+- `TranscriptMessage`, `TranscriptRole`
+- `QueuedPromptKind`, `QueuedPrompt`
+- `SessionRuntime`
+
+### 7.2 Current `codex_protocol::Op`
+
+Delete or replace every variant:
+
+| `Op` variant             | Disposition                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------- |
+| `Interrupt`              | ACP cancel method                                                                      |
+| `UserInput`              | typed ACP prompt method with ACP content blocks                                        |
+| `ThreadGoalGet`          | typed Nori goal query                                                                  |
+| `ThreadGoalSet`          | typed Nori goal mutation                                                               |
+| `ThreadGoalClear`        | typed Nori goal mutation                                                               |
+| `UserTurn`               | delete Codex model-turn vocabulary                                                     |
+| `OverrideTurnContext`    | rehome post-refactor runtime/config mutation; do not put it in protocol                |
+| `ExecApproval`           | ACP client response to the original permission request                                 |
+| `PatchApproval`          | ACP client response to the original permission request                                 |
+| `ResolveElicitation`     | ACP client response when it is an ACP request; delete the current dead MCP legacy path |
+| `AddToHistory`           | typed Nori history command                                                             |
+| `GetHistoryEntryRequest` | typed Nori history query                                                               |
+| `SearchHistoryRequest`   | typed Nori history query                                                               |
+| `ListCustomPrompts`      | typed Nori query                                                                       |
+| `Compact`                | typed Nori operation plus Nori lifecycle event                                         |
+| `Undo`                   | typed Nori operation plus `NoriEvent::Undo`                                            |
+| `UndoList`               | typed Nori query                                                                       |
+| `UndoTo`                 | typed Nori operation plus `NoriEvent::Undo`                                            |
+| `Shutdown`               | harness shutdown/ACP close methods plus `SessionEnded`                                 |
+| `RunUserShellCommand`    | typed Nori operation plus `NoriEvent::UserShell`                                       |
+
+Delete `Submission` and `Event` with the queue protocol. The harness API owns
+command dispatch and the `SessionEvent` receiver owns outward events.
+
+### 7.3 Current `codex_protocol::EventMsg`
+
+Replace ACP-owned variants with raw ACP notifications, requests, or responses:
+
+- `TokenCount`
+- `AgentMessage`, `UserMessage`, `AgentMessageDelta`
+- `AgentReasoning`, `AgentReasoningDelta`, `AgentReasoningRawContent`,
+  `AgentReasoningRawContentDelta`, `AgentReasoningSectionBreak`
+- `SessionConfigured`
+- `McpToolCallBegin`, `McpToolCallEnd`
+- `WebSearchBegin`, `WebSearchEnd`
+- `ExecCommandBegin`, `ExecCommandOutputDelta`, `ExecCommandEnd`
+- `ViewImageToolCall`
+- `ExecApprovalRequest`, `ElicitationRequest`, `ApplyPatchApprovalRequest`
+- `PatchApplyBegin`, `PatchApplyEnd`, `TurnDiff`
+- `PlanUpdate`
+- `TurnAborted`
+- ACP-owned cases of `Error`, `Warning`, and `StreamError`
+
+Replace Nori-owned variants as follows:
+
+- `ContextCompacted` → `NoriEvent::ContextCompacted`
+- user-shell uses of `TaskStarted` and `TaskComplete` →
+  `NoriEvent::UserShell`; prompt lifecycle uses ACP responses and Nori phase
+- `UndoStarted`, `UndoCompleted`, `UndoListResult` → `NoriEvent::Undo` plus a
+  typed list query
+- `GetHistoryEntryResponse`, `SearchHistoryResponse`,
+  `ListCustomPromptsResponse` → typed method results
+- `ShutdownComplete` → `NoriEvent::SessionEnded`
+- `PromptSummary` → the pending Nori prompt-summary decision; it is not
+  compaction or hook output
+- `HookOutput` → `NoriEvent::HookOutput`
+- harness/transport failures represented by `Error` before any ACP response
+  exists → `NoriEvent::RequestFailed`
+- user-visible nonfatal `Warning` cases → the pending Nori notice decision
+- diagnostics with no public consumer → private logging/diagnostics
+- dead `StreamError` cases → deletion after the refreshed producer audit
+
+Delete the following no-op or legacy variants after the refreshed producer
+audit confirms the current result:
+
+- `RawResponseItem`
+- `ItemStarted`
+- `ItemCompleted`
+- `AgentMessageContentDelta`
+- `ReasoningContentDelta`
+- `ReasoningRawContentDelta`
+- `McpStartupUpdate`
+- `McpStartupComplete`
+- `DeprecationNotice`
+- `BackgroundEvent`
+
+At the current baseline, the first six are explicitly ignored by the TUI and
+have no producer. `AgentReasoningSectionBreak` has a consumer but no known
+producer. The final four appear consumer-only with no live ACP producer. These
+facts must be rechecked rather than assumed at deletion time.
+
+### 7.4 Other `codex-protocol` modules
+
+| Module                                    | Current symbols/variants                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Disposition                                                                                       |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `account`                                 | `PlanType`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | auth/app-server concern; rehome or delete, never absorb into Nori session protocol                |
+| `config_types`                            | `ReasoningEffort`, `ReasoningSummary`, `Verbosity`, `ForcedLoginMethod`, `TrustLevel`, `McpServerConfig`, `McpServerTransportConfig`, `SandboxMode`, shell environment types, and related config enums                                                                                                                                                                                                                                                                                                                                                                                                                 | configuration refactor decides ownership; do not automatically move them into `nori-protocol`     |
+| `models`                                  | `ResponseInputItem::{Message, FunctionCallOutput, McpToolCallOutput, CustomToolCallOutput}`; `ContentItem::{InputText, InputImage, OutputText}`; `ResponseItem::{Message, Reasoning, LocalShellCall, FunctionCall, FunctionCallOutput, CustomToolCall, CustomToolCallOutput, WebSearchCall, GhostSnapshot, CompactionSummary, Other}`; `LocalShellStatus::{Completed, InProgress, Incomplete}`; `LocalShellAction::Exec`; `WebSearchAction::{Search, OpenPage, FindInPage, Other}`; `ReasoningItemReasoningSummary::SummaryText`; `ReasoningItemContent::{ReasoningText, Text}`; shell/function-output payload structs | delete Codex/OpenAI Responses vocabulary or localize a genuinely live private app-server consumer |
+| `items`                                   | `TurnItem::{UserMessage, AgentMessage, Reasoning, WebSearch}`, `UserMessageItem`, `AgentMessageContent::Text`, `AgentMessageItem`, `ReasoningItem`, `WebSearchItem`, legacy conversions                                                                                                                                                                                                                                                                                                                                                                                                                                | delete; ACP session updates are canonical                                                         |
+| `user_input`                              | `UserInput::{Text, Image, LocalImage}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | ACP content blocks; local image preprocessing belongs in harness                                  |
+| `plan_tool`                               | `StepStatus`, `PlanItemArg`, `UpdatePlanArgs`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | delete in favor of ACP plan types                                                                 |
+| `parse_command`                           | `ParsedCommand::{Read, ListFiles, Search, Unknown}`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | private harness/frontend parsing and presentation                                                 |
+| `num_format`                              | numeric formatting helpers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | frontend/common presentation, not protocol                                                        |
+| `custom_prompts`                          | `CustomPrompt`, `CustomPromptKind`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | may remain Nori query-domain values; prefix/presentation constants stay in frontend               |
+| `message_history`                         | `HistoryEntry`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | may remain a Nori persistence/query-domain value                                                  |
+| `conversation_id`                         | `ConversationId`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | Nori transcript identity, not ACP `SessionId`; exact post-refactor name requires review           |
+| `approvals`                               | `SandboxRiskLevel::{Low, Medium, High}`, `SandboxCommandAssessment`, `ExecApprovalRequestEvent`, `ApplyPatchApprovalRequestEvent`, `ElicitationRequestEvent`, `ElicitationAction::{Accept, Decline, Cancel}`                                                                                                                                                                                                                                                                                                                                                                                                           | delete ACP mirrors; approval/sandbox policy ownership is revisited after configuration lands      |
+| `protocol/history` and legacy event files | `InitialHistory`, `ResumedHistory`, `RolloutItem`, `RolloutLine`, `SessionMeta`, `SessionMetaLine`, `CompactedItem`, `TurnContextItem`, `SessionSource`, `SubAgentSource`, legacy tags/constants, and `HasLegacyEvent`                                                                                                                                                                                                                                                                                                                                                                                                 | private legacy transcript decoder only where required; otherwise delete                           |
+| token/rate/final-output helpers           | `TokenUsage`, `TokenUsageInfo`, `RateLimitSnapshot`, `RateLimitWindow`, `CreditsSnapshot`, `FinalOutput` and formatting logic                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | ACP usage data is canonical; CLI formatting belongs in frontend                                   |
+
+`ReviewDecision` becomes ACP's permission outcome. Codex `FileChange` becomes ACP
+tool/diff content. `GitInfo`, MCP authentication status, goals, and hooks are
+reviewed as Nori runtime/query types, not carried over merely because they
+currently live in `codex-protocol`.
+
+### 7.5 Current dependency consumers
+
+At the baseline, 13 workspace crates directly depend on `codex-protocol`:
+
+- `codex-app-server-protocol`
+- `codex-common`
+- `codex-core`
+- `codex-linux-sandbox`
+- `codex-otel`
+- `codex-rmcp-client`
+- `codex-sandbox`
+- `codex-windows-sandbox`
+- `nori-acp-host`
+- `nori-cli`
+- `nori-config`
+- `nori-harness`
+- `nori-tui`
+
+Every edge must be deleted, rehomed, or replaced before the crate is removed.
+The app-server and sandbox support crates do not justify polluting the public
+harness protocol; their residual local types should move to their actual
+owner.
+
+## 8. Configuration prerequisite and open ownership checks
+
+Implementation waits for the active configuration rework. Immediately after it
+lands:
+
+1. rebase and rerun the dependency, import, producer, and consumer audits;
+2. identify the new owner of login, model, sandbox, approval, MCP, and shell
+   environment configuration;
+3. ensure no old config type was moved into `nori-protocol` merely to break a
+   dependency cycle;
+4. decide whether `AskForApproval` and `SandboxPolicy` remain public harness
+   configuration, become private runtime policy, or are replaced by the new
+   config vocabulary; and
+5. co-design the exact prompt-summary and nonfatal-notice additions identified
+   in §4.2; and
+6. present the refreshed exact deletion list for approval before any deletion.
+
+These checks may change where configuration types live. They do not reopen the
+approved ACP/Nori ownership rule or the hard-cut deletion of Codex protocol
+vocabulary.
+
+## 9. Acceptance criteria
+
+The implementation is complete only when:
+
+- `nori-rs/protocol` and the `codex-protocol` workspace package are deleted;
+- `cargo tree -i codex-protocol` reports no package;
+- only `nori-protocol` directly imports `agent-client-protocol-schema`;
+- among Nori client-side product crates, only `nori-acp-host` directly imports
+  the higher-level `agent-client-protocol` SDK; ACP agents and conformance
+  fixtures may import it on the agent side;
+- every other client-side product ACP schema import begins with
+  `nori_protocol::acp`;
+- `nori-protocol` contains boundary types but no reducer, normalizer, parser,
+  formatter, or state machine;
+- the harness emits the raw ACP envelopes and the approved Nori event variants,
+  including the explicitly approved resolution for prompt summaries and
+  nonfatal notices;
+- delegated ACP requests round-trip without conversion into Codex types;
+- query callers receive typed results without correlating the session stream,
+  and no duplicate Nori response variants exist;
+- old version-2 transcripts still load, while new transcripts persist the new
+  event schema;
+- the TUI and a headless harness integration both pass against the same public
+  API; and
+- the repository docs describe the implemented boundary without references to
+  Codex protocol as Nori's control plane.
+
+## 10. Approved decision record (verbatim and chronological)
+
+The excerpts below preserve the exact prompts and proposals that established
+this design. Typos and punctuation are intentionally unchanged.
+
+### 10.1 Initial boundary requirement
+
+User:
+
+> We focus on point number two there and clean up the unification of the protocol into one place. This should require that all protocol imports go through the nori protocol and we fully absorb whatever variants or domain objects are captured in the codex protocol into the nori protocol crate. This is a very important layer of the API to get correct because anyone who uses the nori Harness to embed ACP-like behavior or agents in some headless manner or into another interface will have to inherit whatever assumptions or mistakes or decisions we make with a nori protocol.
+
+### 10.2 Hard cut and deletion gate
+
+User:
+
+> definitely a hard cut
+
+User:
+
+> agreed I would also favor deletion, but you can give me a final list of exactly which variants those are. So I can sanity check the deletion first.
+
+Assistant proposal:
+
+> Deletion will be a review gate: I’ll provide the exact modules, types, and enum variants proposed for removal, with their remaining consumers, before deleting any of them.
+
+### 10.3 Narrow Nori protocol around ACP
+
+User:
+
+> Agreed, yes, but if we're getting into the point of changing anything with the actual protocol contents or variants, we absolutely need to narrow down the scope of the Nori protocol and lean more heavily on the ACP schema. The Nori protocol might be useful for things that are out of scope of ACP or for handling UI/UX concerns. that ACP can't address. However, overall, I'm very cognizant that our current protocol implementation is a bit too complicated and the whole point of using the ACP ecosystem is it much more carefully standardizes the exact boundary between interface on one side and agent on the other.
+
+Assistant proposals:
+
+> ACP owns all agent↔client semantics.
+
+> `nori-protocol` re-exports the ACP schema rather than copying it.
+
+> Nori-owned types exist only for harness lifecycle, persistence, queueing, goals, undo, hooks, history, and presentation concerns that ACP does not define.
+
+> Translation or UI enrichment belongs in the harness/TUI, not in protocol types.
+
+> Codex/OpenAI model vocabulary is deleted rather than adopted.
+
+### 10.4 Re-export boundary and source-owned nesting
+
+User:
+
+> That's definitely the best way to do this, because if we ever need to switch out our ACP library choice, use a different implementation, vendor some of the ACP code, whatever the situation is, we can do that easily if we export it from Nori protocol for every other crate to use. So definitely follow that. Your proposed rule about ACP owning agent to client semantics, and then protocol re-exports the ACP schema, and then the Nori specific types are just those other concerns not yet defined, like hardest lifecycle, persistence, etc, etc. That definitely sounds right to me. It definitely matters a lot how we do the exact details of that enum for the type of the Nori protocol. So let's co-design that.
+
+Assistant proposal:
+
+```rust
+pub enum SessionEvent {
+    Acp(AcpEvent),
+    Nori(NoriEvent),
+}
+```
+
+User:
+
+<!-- prettier-ignore -->
+> Agreed, that shape looks good.  Source-owned nested enums are definitely the way to go. Do those three variants of ACP event really encapsulate all of the ACP-like data that we currently hand back and forth across the event boundary between the Nori harness and any potential consumer like the current TUI or an eventual CLI-only headless exact version? like a third-party integration, for example, putting a Nori harness into a VS Code extension or other place.
+
+### 10.5 Raw ACP envelopes
+
+Assistant proposal:
+
+```rust
+pub enum AcpEvent {
+    Notification(acp::v1::AgentNotification),
+    Request {
+        request_id: acp::v1::RequestId,
+        request: acp::v1::AgentRequest,
+    },
+    Response {
+        request_id: acp::v1::RequestId,
+        response: Result<acp::v1::AgentResponse, acp::v1::Error>,
+    },
+}
+```
+
+User:
+
+> I think that looks right to me.
+
+### 10.6 Nori notifications and typed queries
+
+Assistant proposal:
+
+```rust
+pub enum NoriEvent {
+    SessionStarted(SessionStarted),
+    SessionPhaseChanged(SessionPhase),
+    SessionEnded(SessionEnded),
+    QueueChanged(QueueSnapshot),
+    ReplayStarted(ReplayStarted),
+    ReplayFinished,
+    ContextCompacted(ContextCompacted),
+    GoalChanged(Option<ThreadGoal>),
+    CapabilitiesChanged(NoriCapabilities),
+    Undo(UndoEvent),
+    UserShell(UserShellEvent),
+    HookOutput(HookOutput),
+    RequestFailed(RequestFailure),
+}
+```
+
+Assistant proposals:
+
+> I recommend keeping `NoriEvent` notification-oriented rather than turning it into another general request/response bus.
+
+> Those should be typed async methods on the harness handle. A headless JSON-RPC adapter can add correlation IDs at its own boundary without forcing every Rust embedder to coordinate unrelated query responses through the ordered session event stream.
+
+User:
+
+> That's perfect. Exactly right.
+
+### 10.7 Implementation prerequisite
+
+User:
+
+> There's a significant configuration rework going on in the CLI, so to avoid conflicts with our refactor work we need to wait for that to land.


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- records the approved hard-cut ACP/Nori ownership boundary, source-nested event API, typed method contract, and verbatim decision history
- inventories every current `ClientEvent`, `Op`, and `EventMsg` disposition at baseline `500ee202`, with a refreshed deletion-review gate after the configuration rework lands
- adds a behavior-first implementation plan and updates the crate-layering target without changing production code or dependencies

## Test Plan
- [x] `pnpm exec prettier --check docs/specs/protocol-unification.md docs/plans/protocol-unification-implementation.md`
- [x] `git diff --check`
- [x] `cargo +nightly fmt -- --check`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] build the real `mock-acp-agent` with the CI profile
- [x] run CI-profile tests for `codex-protocol`, `nori-acp-host`, `nori-harness`, `nori-config`, `nori-tui`, `nori-cli`, and `tui-pty-e2e`

## Notes

- Implementation remains blocked on the active configuration rework, the refreshed deletion sanity-check, and co-design of the prompt-summary and user-visible nonfatal-notice Nori extensions.
- The repository-wide `pnpm format` command rejects the baseline tracked `CLAUDE.md` and `GEMINI.md` symlinks; both new documents pass the targeted Prettier check.

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets