### PR TITLE
fix(tui): Render cloud reconnect status in the CLI

### DIFF
--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -58,6 +58,11 @@ The application event loop matches `SessionEvent::Acp` and
   distinction lives in
   [`event_handlers.rs`](src/chatwidget/event_handlers.rs) and
   [`presentation/mod.rs`](src/presentation/mod.rs).
+- Handroll's `_meta.nori.connection.status` extension is also presentation
+  only. Exact `reconnecting` and `connected` status-only frames render as
+  “Cloud connection lost. Reconnecting…” and “Cloud connection restored.”
+  info entries instead of generic redacted metadata. They do not change turn
+  ownership, replay ACP methods, or enter the session-info state reducer.
 - ACP requests drive the permission overlay and retain their raw `RequestId`.
 - Initialize responses and prompt responses matching the active request update
   UI lifecycle. For prompt errors, the correlated `NoriEvent::RequestFailed`
@@ -77,11 +82,12 @@ lossy and UI-specific; they are not fed back into the harness or exported from
 
 #### Structured session information
 
-ACP `SessionInfoUpdate` normalization retains `title`, `updatedAt`, and the
-complete `_meta` object as a private `SessionInfoPatch` alongside the legacy
-text projection. The chat widget captures the agent identity reported by ACP
-initialization and whether the current emission is live, agent replay, or
-transcript replay, then sends every patch to two presentation consumers:
+Ordinary ACP `SessionInfoUpdate` normalization retains `title`, `updatedAt`,
+and the complete `_meta` object as a private `SessionInfoPatch` alongside the
+legacy text projection. The chat widget captures the agent identity reported
+by ACP initialization and whether the current emission is live, agent replay,
+or transcript replay, then sends every retained patch to two presentation
+consumers:
 
 - The history renderer emits a visible entry for every update. Known Codex
   status, goal, error, archived, and closed fields receive friendly labels only

--- a/nori-rs/tui/src/chatwidget/tests/part10.rs
+++ b/nori-rs/tui/src/chatwidget/tests/part10.rs
@@ -340,6 +340,71 @@ fn session_info_updates_render_known_codex_fields() {
 }
 
 #[test]
+fn nori_connection_status_updates_render_clear_messages() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
+    let generation = chat.session_generation;
+
+    for status in ["reconnecting", "connected"] {
+        let meta = serde_json::json!({
+            "nori": {
+                "connection": {
+                    "status": status
+                }
+            }
+        })
+        .as_object()
+        .expect("metadata object")
+        .clone();
+        chat.handle_session_event(
+            generation,
+            session_info_update(nori_protocol::acp::v1::SessionInfoUpdate::new().meta(meta)),
+        );
+    }
+
+    let rendered = history_text(&mut rx);
+    insta::assert_snapshot!(rendered, @r"
+• Cloud connection lost. Reconnecting…
+
+• Cloud connection restored.
+");
+}
+
+#[test]
+fn nori_connection_status_with_other_metadata_uses_standard_rendering() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
+    let generation = chat.session_generation;
+    let meta = serde_json::json!({
+        "nori": {
+            "connection": {
+                "status": "reconnecting"
+            }
+        },
+        "vendor": {
+            "field": true
+        }
+    })
+    .as_object()
+    .expect("metadata object")
+    .clone();
+
+    chat.handle_session_event(
+        generation,
+        session_info_update(nori_protocol::acp::v1::SessionInfoUpdate::new().meta(meta)),
+    );
+
+    let rendered = history_text(&mut rx);
+    assert!(
+        rendered.contains("nori.connection.status=<string>"),
+        "{rendered}"
+    );
+    assert!(rendered.contains("vendor.field=<boolean>"), "{rendered}");
+    assert!(
+        !rendered.contains("Cloud connection lost. Reconnecting…"),
+        "{rendered}"
+    );
+}
+
+#[test]
 fn unknown_session_info_fields_render_types_without_values_in_stable_order() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
     let generation = chat.session_generation;

--- a/nori-rs/tui/src/presentation/mod.rs
+++ b/nori-rs/tui/src/presentation/mod.rs
@@ -472,8 +472,16 @@ impl ClientEventNormalizer {
                 })]
             }
             acp::SessionUpdate::SessionInfoUpdate(update) => {
+                if let Some(message) = nori_connection_message(update) {
+                    vec![ClientEvent::SessionUpdateInfo(SessionUpdateInfo {
+                        kind: SessionUpdateKind::SessionInfo,
+                        message: message.to_string(),
+                        hint: None,
+                        usage: None,
+                        session_info_patch: None,
+                    })]
                 // Hide only exact Nori lifecycle frames; preserve all displayable metadata.
-                if is_nori_turn_status_only(update) {
+                } else if is_nori_turn_status_only(update) {
                     Vec::new()
                 } else {
                     vec![ClientEvent::SessionUpdateInfo(
@@ -1084,6 +1092,25 @@ fn session_update_info_from_session_info(update: &acp::SessionInfoUpdate) -> Ses
             updated_at: update.updated_at.clone(),
             meta: update.meta.clone(),
         }),
+    }
+}
+
+fn nori_connection_message(update: &acp::SessionInfoUpdate) -> Option<&'static str> {
+    if !update.title.is_undefined() || !update.updated_at.is_undefined() {
+        return None;
+    }
+
+    let meta = update.meta.as_ref()?;
+    let nori = meta.get("nori")?.as_object()?;
+    let connection = nori.get("connection")?.as_object()?;
+    if meta.len() != 1 || nori.len() != 1 || connection.len() != 1 {
+        return None;
+    }
+
+    match connection.get("status")?.as_str()? {
+        "reconnecting" => Some("Cloud connection lost. Reconnecting…"),
+        "connected" => Some("Cloud connection restored."),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
## Summary

🤖 Generated with [Nori](https://noriagentic.com/)

- render Handroll reconnect lifecycle frames as clear cloud connection messages
- suppress generic redacted metadata rows only for exact status-only frames
- preserve mixed metadata through the standard session-info path
- document and snapshot the presentation contract

## Test Plan

- [x] cargo test -p nori-tui (1,223 passed, 1 ignored)
- [x] cargo build --bin nori
- [x] cargo test -p tui-pty-e2e
- [x] isolated tmux launch/input/response verification with ElizACP
- [x] just fix -p nori-tui
- [x] just fmt
- [x] independent code and test-hygiene review

Share Nori with your team: https://noriagentic.com/