### PR TITLE
fix(cli): add source context to first prompt

### DIFF
--- a/docs/followups/nori-client-mcp.md
+++ b/docs/followups/nori-client-mcp.md
@@ -20,16 +20,19 @@ capabilities that ACP does not yet provide directly.
 
 `nori-client` should be the single structured way an MCP-capable ACP agent
 learns about Nori-owned client context. The prompt stream should carry user
-work, goal context when goal automation is valid, and one-time fallback context
-only when MCP is unavailable. It should not carry repeated product explanation
-that an MCP-capable agent could discover through `nori-client`.
+work, goal context when goal automation is valid, and a one-time source envelope
+that identifies Nori CLI consistently across client surfaces. Only agents
+without HTTP MCP support should receive fallback operating guidance in that
+envelope. MCP-capable agents should not receive product explanation they can
+discover through `nori-client`.
 
 The boundary is:
 
 - MCP tools mutate or read Nori-owned live state.
 - MCP resources expose durable read-only facts.
 - MCP prompts package reusable workflows for the agent.
-- Prompt fallback is reserved for agents that cannot receive the MCP server.
+- Every agent receives first-prompt source attribution; prompt fallback is
+  reserved for agents that cannot receive the MCP server.
 
 ## MCP-Capable Agent Behavior
 
@@ -55,8 +58,18 @@ The server should expose:
 
 The agent should be able to discover this context through MCP list/read/get
 requests. Nori may include short MCP server instructions that point agents
-toward the resources and prompts, but ordinary user prompts should not be
-prefixed with the same static Nori operating text for MCP-capable agents.
+toward the resources and prompts. Its first ordinary user prompt still receives
+the shared source-only envelope:
+
+```text
+<context>
+Source: this message is from Nori CLI.
+</context>
+```
+
+This source attribution is distinct from the static Nori operating guidance
+that MCP-capable agents can discover through `nori-client`, and it is consumed
+once rather than repeated on later prompts.
 
 Resources and prompts should be curated guidance, not an arbitrary filesystem
 read API. Tools should remain reserved for Nori-owned state changes.
@@ -68,7 +81,8 @@ advertise `nori-client`.
 
 Non-MCP agents should receive a concise first-prompt-only `<context>` block that:
 
-- says the agent is operating inside Nori CLI over ACP,
+- identifies the source as Nori CLI, matching the MCP-capable envelope,
+- says the agent is operating over ACP,
 - includes `https://github.com/tilework-tech/nori-cli` as the stable source
   reference for implementation questions,
 - says MCP-backed Nori affordances are unavailable in this session, and
@@ -141,8 +155,10 @@ The behavior is correct when tests prove:
 - MCP clients can list and read the Nori context resources.
 - MCP clients can list and get the Nori workflow prompts.
 - non-MCP agents do not receive `nori-client`.
-- non-MCP first prompts receive the fallback `<context>` block exactly once.
-- MCP-capable first prompts do not receive the fallback block once the MCP
+- every agent's first prompt receives the Nori CLI source envelope exactly once.
+- non-MCP first prompts additionally receive fallback guidance inside that
+  envelope.
+- MCP-capable first prompts do not receive fallback guidance once the MCP
   context surface exists.
 - `/goal` is disabled in the TUI and inert in the backend when `nori-client` is
   unavailable.

--- a/nori-rs/harness/docs.md
+++ b/nori-rs/harness/docs.md
@@ -46,6 +46,11 @@ inventing a second public event vocabulary.
 
 A frontend constructs `SessionLaunchSpec` with one resolved `Arc<NoriConfig>`,
 CLI version, optional product/session context, and optional `SessionResume`.
+Product context has HTTP-MCP and non-HTTP-MCP variants. After ACP
+initialization reveals the connected agent's capabilities, the harness selects
+the matching variant and prepends it to the first locally submitted prompt
+only. This keeps source identity common across ACP agents while reserving MCP
+fallback guidance for agents that cannot use Nori's HTTP MCP affordances.
 `launch_session(spec)` returns `LaunchedSession`, containing a `HarnessHandle`
 and the session event receiver.
 

--- a/nori-rs/harness/src/backend/mod.rs
+++ b/nori-rs/harness/src/backend/mod.rs
@@ -202,11 +202,20 @@ pub struct AcpBackendConfig {
     /// Optional session context injected into the first prompt without
     /// `SUMMARY_PREFIX` framing. Used to provide product-level context
     /// (e.g. "you are running inside the nori CLI").
-    pub session_context: Option<String>,
+    pub session_context: Option<SessionContext>,
     /// MCP server configuration for listing via /mcp command
     pub mcp_servers: HashMap<String, McpServerConfig>,
     /// OAuth credentials store mode for MCP auth status computation
     pub mcp_oauth_credentials_store_mode: OAuthCredentialsStoreMode,
+}
+
+/// First-prompt product context selected from the agent's actual MCP support.
+#[derive(Debug, Clone)]
+pub struct SessionContext {
+    /// Context for agents that support Nori's HTTP MCP affordances.
+    pub with_http_mcp: String,
+    /// Context for agents that need the non-MCP fallback guidance.
+    pub without_http_mcp: String,
 }
 
 #[derive(Debug, Clone)]
@@ -337,14 +346,20 @@ impl AcpBackend {
     }
 }
 
-fn fallback_session_context_for_connection(
+fn session_context_for_connection(
     config: &AcpBackendConfig,
     connection: &AcpConnection,
 ) -> Option<String> {
     if connection.capabilities().mcp_capabilities.http {
-        None
+        config
+            .session_context
+            .as_ref()
+            .map(|context| context.with_http_mcp.clone())
     } else {
-        config.session_context.clone()
+        config
+            .session_context
+            .as_ref()
+            .map(|context| context.without_http_mcp.clone())
     }
 }
 

--- a/nori-rs/harness/src/backend/session.rs
+++ b/nori-rs/harness/src/backend/session.rs
@@ -617,7 +617,7 @@ impl AcpBackend {
             .as_ref()
             .and_then(|recorder| ConversationId::from_string(recorder.session_id()).ok())
             .unwrap_or_default();
-        let pending_hook_context = fallback_session_context_for_connection(config, &connection);
+        let pending_hook_context = session_context_for_connection(config, &connection);
         let backend = Self {
             connection,
             session_id: Arc::new(RwLock::new(session_id)),

--- a/nori-rs/harness/src/backend/spawn_and_relay.rs
+++ b/nori-rs/harness/src/backend/spawn_and_relay.rs
@@ -230,7 +230,7 @@ impl AcpBackend {
             .as_ref()
             .and_then(|recorder| ConversationId::from_string(recorder.session_id()).ok())
             .unwrap_or_default();
-        let pending_hook_context = fallback_session_context_for_connection(config, &connection);
+        let pending_hook_context = session_context_for_connection(config, &connection);
         let backend = Self {
             connection,
             session_id: Arc::new(RwLock::new(session_id)),

--- a/nori-rs/harness/src/lib.rs
+++ b/nori-rs/harness/src/lib.rs
@@ -47,6 +47,7 @@ pub use message_history::search_entries;
 pub use backend::AcpBackend;
 pub use backend::AcpBackendConfig;
 pub use backend::BackendEvent;
+pub use backend::SessionContext;
 pub use backend::probe::AgentSessionsProbe;
 pub use backend::probe::ProbeError;
 pub use backend::probe::probe_agent_sessions;

--- a/nori-rs/harness/src/runtime.rs
+++ b/nori-rs/harness/src/runtime.rs
@@ -24,6 +24,7 @@ use tokio::sync::oneshot;
 use crate::backend::AcpBackend;
 use crate::backend::AcpBackendConfig;
 use crate::backend::BackendEvent;
+use crate::backend::SessionContext;
 use crate::transcript::Transcript;
 use nori_protocol::AcpEvent;
 use nori_protocol::NoriEvent;
@@ -449,7 +450,7 @@ pub struct SessionLaunchSpec {
     /// Frontend version recorded in transcript metadata.
     pub cli_version: String,
     /// Product-level context injected into the first prompt.
-    pub session_context: Option<String>,
+    pub session_context: Option<SessionContext>,
     /// Conversation history injected into the first prompt (used by fork).
     pub initial_context: Option<String>,
     /// When set, resume the given session instead of starting fresh.

--- a/nori-rs/harness/tests/session_event_boundary.rs
+++ b/nori-rs/harness/tests/session_event_boundary.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use nori_config::NoriConfig;
+use nori_harness::SessionContext;
 use nori_harness::runtime::SessionLaunchSpec;
 use nori_harness::runtime::SessionResume;
 use nori_harness::runtime::launch_session;
@@ -631,6 +632,140 @@ async fn ordered_prompt_content_reaches_the_acp_agent_unchanged() {
     assert_eq!(
         recorded_prompt["message"]["params"]["prompt"],
         serde_json::to_value(prompt).expect("serialize expected prompt")
+    );
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "this helper turns missing ACP wire records into focused test failures"
+)]
+async fn record_cli_context_prompts(http_mcp: bool) -> Vec<String> {
+    let _mcp_guard = http_mcp.then(|| {
+        // SAFETY: callers are serialized with every other environment-mutating test.
+        unsafe { std::env::set_var("MOCK_AGENT_MCP_HTTP", "1") };
+        EnvGuard("MOCK_AGENT_MCP_HTTP")
+    });
+    let temp = tempfile::tempdir().expect("create session directory");
+    let wire_log_dir = temp.path().join("acp-wire");
+    let config = NoriConfig {
+        active_agent: "mock-model".to_string(),
+        cwd: temp.path().to_path_buf(),
+        nori_home: temp.path().to_path_buf(),
+        acp_proxy: nori_config::AcpProxyConfig {
+            enabled: true,
+            log_dir: wire_log_dir.clone(),
+        },
+        ..Default::default()
+    };
+    let mut session = launch_session(SessionLaunchSpec {
+        config: Arc::new(config),
+        cli_version: "boundary-test".to_string(),
+        session_context: Some(SessionContext {
+            with_http_mcp: include_str!("../../tui/session_context_http_mcp.md").to_string(),
+            without_http_mcp: include_str!("../../tui/session_context.md").to_string(),
+        }),
+        initial_context: None,
+        resume: None,
+    });
+
+    tokio::time::timeout(Duration::from_secs(10), session.handle.get_session_config())
+        .await
+        .expect("session bootstrap should complete")
+        .expect("session config should be available");
+
+    let first_request_id = session
+        .handle
+        .prompt(vec![acp::v1::ContentBlock::Text(
+            acp::v1::TextContent::new("first prompt"),
+        )])
+        .await
+        .expect("submit first prompt");
+    let second_request_id = session
+        .handle
+        .prompt(vec![acp::v1::ContentBlock::Text(
+            acp::v1::TextContent::new("second prompt"),
+        )])
+        .await
+        .expect("submit second prompt");
+
+    let mut completed = std::collections::HashSet::new();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while completed.len() < 2 {
+            if let Some(SessionEvent::Acp(AcpEvent::Response {
+                request_id,
+                response: Ok(acp::v1::AgentResponse::PromptResponse(_)),
+            })) = session.events.recv().await
+                && (request_id == first_request_id || request_id == second_request_id)
+            {
+                completed.insert(request_id);
+            }
+        }
+    })
+    .await
+    .expect("both prompts should complete");
+
+    session.handle.shutdown().await.expect("shutdown session");
+    collect_until_session_ended(&mut session).await;
+
+    let wire_log = std::fs::read_dir(&wire_log_dir)
+        .expect("wire log directory")
+        .map(|entry| entry.expect("wire log entry").path())
+        .find(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "jsonl")
+        })
+        .expect("ACP wire log");
+    std::fs::read_to_string(wire_log)
+        .expect("read ACP wire log")
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("valid wire log line"))
+        .filter(|record| {
+            record["direction"] == "client_to_agent"
+                && record["message"]["method"] == "session/prompt"
+        })
+        .map(|record| {
+            record["message"]["params"]["prompt"]
+                .as_array()
+                .expect("prompt content blocks")
+                .iter()
+                .filter_map(|block| block["text"].as_str())
+                .collect::<String>()
+        })
+        .collect()
+}
+
+#[tokio::test]
+#[serial]
+async fn http_mcp_agent_receives_cli_source_context_once_without_fallback_guidance() {
+    assert_eq!(
+        record_cli_context_prompts(true).await,
+        vec![
+            "<context>\nSource: this message is from Nori CLI.\n</context>\n\nfirst prompt",
+            "second prompt",
+        ]
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn non_mcp_agent_receives_full_cli_fallback_context_once() {
+    assert_eq!(
+        record_cli_context_prompts(false).await,
+        vec![
+            [
+                "<context>",
+                "Source: this message is from Nori CLI.",
+                "",
+                "You are operating over ACP.",
+                "For Nori CLI implementation questions, use https://github.com/tilework-tech/nori-cli as the stable source reference.",
+                "MCP-backed Nori affordances, including /goal completion tools such as update_goal, are unavailable in this session.",
+                "</context>",
+                "",
+                "first prompt",
+            ]
+            .join("\n"),
+            "second prompt".to_string(),
+        ]
     );
 }
 

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -25,6 +25,14 @@ The TUI depends on `nori-harness`, `nori-config`, and `nori-protocol`; it does
 not import the ACP host or ACP schema crate directly. Its ACP types arrive
 through `nori_protocol::acp`.
 
+At launch, the TUI supplies the harness with two Nori CLI context-envelope
+variants. Both identify the first prompt as coming from Nori CLI; the
+non-HTTP-MCP variant also explains the ACP fallback and unavailable MCP-backed
+affordances. The harness chooses between them from the connected agent's
+reported HTTP MCP capability and injects the selected envelope once. The CLI
+does not add a user identity because authenticated Nori Sessions identity is
+owned outside this layer.
+
 ### Core Implementation
 
 #### Source-first event dispatch

--- a/nori-rs/tui/session_context.md
+++ b/nori-rs/tui/session_context.md
@@ -1,5 +1,7 @@
 <context>
-You are operating inside Nori CLI over ACP.
-For implementation questions about Nori, use https://github.com/tilework-tech/nori-cli as the stable source reference.
-MCP-backed Nori affordances are unavailable in this session, including /goal completion tools such as update_goal.
+Source: this message is from Nori CLI.
+
+You are operating over ACP.
+For Nori CLI implementation questions, use https://github.com/tilework-tech/nori-cli as the stable source reference.
+MCP-backed Nori affordances, including /goal completion tools such as update_goal, are unavailable in this session.
 </context>

--- a/nori-rs/tui/session_context_http_mcp.md
+++ b/nori-rs/tui/session_context_http_mcp.md
@@ -1,0 +1,3 @@
+<context>
+Source: this message is from Nori CLI.
+</context>

--- a/nori-rs/tui/src/chatwidget/agent.rs
+++ b/nori-rs/tui/src/chatwidget/agent.rs
@@ -6,6 +6,7 @@
 //! resolved Nori config and maps session events onto [`AppEvent`]s.
 
 use nori_config::NoriConfig as Config;
+use nori_harness::SessionContext;
 use nori_harness::get_agent_display_name;
 use nori_harness::list_available_agents;
 pub(crate) use nori_harness::runtime::HarnessHandle;
@@ -112,7 +113,10 @@ fn launch_acp_agent(
     let spec = SessionLaunchSpec {
         config: Arc::new(config),
         cli_version: env!("CARGO_PKG_VERSION").to_string(),
-        session_context: Some(include_str!("../../session_context.md").to_string()),
+        session_context: Some(SessionContext {
+            with_http_mcp: include_str!("../../session_context_http_mcp.md").to_string(),
+            without_http_mcp: include_str!("../../session_context.md").to_string(),
+        }),
         initial_context: fork_context,
         resume,
     };


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- identify Nori CLI as the source in every agent's first prompt
- keep ACP/repository/MCP-unavailable guidance only for agents without HTTP MCP support
- omit `User:` because authenticated Sessions identity is owned by the handroll child, not the CLI
- preserve raw user prompt display/transcript text and leave later prompts unchanged

## Test Plan
- [x] `cargo test -p nori-harness`
- [x] `cargo test -p nori-tui`
- [x] `cargo build --bin nori`
- [x] `cargo test -p tui-pty-e2e`
- [x] `just fix -p nori-harness`
- [x] `just fix -p nori-tui`
- [x] `just fmt` and `cargo +nightly fmt -- --check`
- [x] Live isolated TUI prompt/response smoke test with ElizACP

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets