### PR TITLE
feat(tui): reflow transcript on terminal resize

### DIFF
--- a/nori-rs/nori-config/docs.md
+++ b/nori-rs/nori-config/docs.md
@@ -28,6 +28,11 @@ The crate owns:
 Resolution applies typed CLI overrides, raw dotted overrides, then the user
 file. Project trust resolves against the effective cwd and primary git root.
 
+`[tui] resize_reflow` controls whether the inline TUI rebuilds terminal
+scrollback after width changes. It defaults to `true`; the `/settings` toggle
+persists to this same key, so startup configuration and runtime changes share
+one source of truth.
+
 ### Things to Know
 
 - These policy types are configuration semantics, not ACP session events; they

--- a/nori-rs/nori-config/src/loader.rs
+++ b/nori-rs/nori-config/src/loader.rs
@@ -206,6 +206,7 @@ impl NoriConfig {
             notify: toml.notify,
             acp_proxy,
             animations: toml.tui.animations.unwrap_or(true),
+            resize_reflow: toml.tui.resize_reflow.unwrap_or(true),
             terminal_notifications: toml
                 .tui
                 .terminal_notifications
@@ -446,6 +447,33 @@ args = ["@example/not-allowed"]
 
         let config = NoriConfig::from_toml(toml, nori_home, overrides).unwrap();
         assert_eq!(config.cwd, custom_cwd);
+    }
+
+    #[test]
+    fn resize_reflow_defaults_to_enabled() {
+        let config = NoriConfig::from_toml(
+            NoriConfigToml::default(),
+            PathBuf::from("/tmp/nori"),
+            NoriConfigOverrides::default(),
+        )
+        .unwrap();
+
+        assert!(config.resize_reflow);
+    }
+
+    #[test]
+    fn resize_reflow_can_be_disabled_in_tui_config() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join(CONFIG_FILE);
+        std::fs::write(
+            &config_path,
+            "[tui]\nresize_reflow = false\n",
+        )
+        .unwrap();
+
+        let config = NoriConfig::load_from_path(&config_path).unwrap();
+
+        assert!(!config.resize_reflow);
     }
 
     #[test]

--- a/nori-rs/nori-config/src/loader.rs
+++ b/nori-rs/nori-config/src/loader.rs
@@ -465,11 +465,7 @@ args = ["@example/not-allowed"]
     fn resize_reflow_can_be_disabled_in_tui_config() {
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join(CONFIG_FILE);
-        std::fs::write(
-            &config_path,
-            "[tui]\nresize_reflow = false\n",
-        )
-        .unwrap();
+        std::fs::write(&config_path, "[tui]\nresize_reflow = false\n").unwrap();
 
         let config = NoriConfig::load_from_path(&config_path).unwrap();
 

--- a/nori-rs/nori-config/src/types/mod.rs
+++ b/nori-rs/nori-config/src/types/mod.rs
@@ -1821,6 +1821,9 @@ pub struct TuiConfigToml {
     /// Enable animations (shimmer effects, spinners)
     pub animations: Option<bool>,
 
+    /// Rebuild inline transcript scrollback when the terminal width changes.
+    pub resize_reflow: Option<bool>,
+
     /// Terminal notification preference (OSC 9 escape sequences)
     pub terminal_notifications: Option<TerminalNotifications>,
 
@@ -1883,6 +1886,9 @@ pub struct TuiConfig {
     /// Enable animations (shimmer effects, spinners)
     pub animations: bool,
 
+    /// Rebuild inline transcript scrollback when the terminal width changes.
+    pub resize_reflow: bool,
+
     /// Terminal notification preference (OSC 9 escape sequences)
     pub terminal_notifications: TerminalNotifications,
 
@@ -1897,6 +1903,7 @@ impl Default for TuiConfig {
     fn default() -> Self {
         Self {
             animations: true,
+            resize_reflow: true,
             terminal_notifications: TerminalNotifications::Enabled,
             os_notifications: OsNotifications::Enabled,
             vertical_footer: false,
@@ -2044,6 +2051,9 @@ pub struct NoriConfig {
     /// Enable TUI animations
     pub animations: bool,
 
+    /// Rebuild inline transcript scrollback when the terminal width changes.
+    pub resize_reflow: bool,
+
     /// Terminal notification preference (OSC 9 escape sequences)
     pub terminal_notifications: TerminalNotifications,
 
@@ -2187,6 +2197,7 @@ impl Default for NoriConfig {
                 log_dir: PathBuf::from(".nori/cli/acp-wire"),
             },
             animations: true,
+            resize_reflow: true,
             terminal_notifications: TerminalNotifications::Enabled,
             os_notifications: OsNotifications::Enabled,
             vertical_footer: false,

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -202,6 +202,29 @@ terminal before the UI starts. This matters to every child the TUI spawns with
 inherited stdin -- the external editor and the file browser -- which would
 otherwise be handed an EOF'd pipe and exit immediately.
 
+#### Inline transcript reflow
+
+In inline mode, terminal width changes rebuild the visible transcript at the
+new width. Completed assistant messages retain their raw Markdown source, so
+replay reruns Markdown layout instead of wrapping already-rendered lines.
+Streaming output remains transient and is consolidated into one source-backed
+assistant cell when the message finishes; user, tool, event, and assistant
+cells otherwise keep their semantic order.
+
+Reflow is width-only and trailing-debounced by 75 ms. It waits while a popup,
+transcript overlay, alternate screen, or assistant stream owns presentation,
+then runs once that boundary closes. The replay retains at most the newest
+1,000 semantic cells and 10,000 physical rows, truncating from the oldest edge
+and prefixing `… history truncated` plus a blank line when either limit applies.
+These bounds limit terminal output, not the in-memory transcript.
+
+Reflow deliberately clears the visible screen and the terminal's native
+scrollback, including output from before Nori started, before replaying the
+bounded history. It does not attempt to discover or preserve a scrollback
+origin. The behavior is enabled by default and can be toggled through
+`/settings` or `[tui] resize_reflow` in `config.toml`; disabling it cancels any
+pending replay.
+
 #### Lifecycle behavior
 
 An orderly ACP close completes the typed close call, leaves the raw close
@@ -323,7 +346,9 @@ stays resumable.
 
 Between `ReplayStarted` and `ReplayFinished`, replayed user and assistant
 messages are assembled in event order and rendered as static conversation
-history with turn boundaries. They are not handled as live output streams.
+history with turn boundaries. They are not handled as live output streams;
+replayed assistant messages use the same raw-Markdown-backed cells as completed
+live messages so later width changes use the same rendering path.
 View-only rendering recovers initialization identity and replay source from the
 stored lifecycle events, then runs raw session-information notifications
 through the same private normalizer and renderer as the live TUI.

--- a/nori-rs/tui/src/app/config_persistence.rs
+++ b/nori-rs/tui/src/app/config_persistence.rs
@@ -707,8 +707,8 @@ mod tests {
             .await
             .expect("persist resize reflow");
 
-        let config = std::fs::read_to_string(temp.path().join("config.toml"))
-            .expect("read config.toml");
+        let config =
+            std::fs::read_to_string(temp.path().join("config.toml")).expect("read config.toml");
         assert!(config.contains("[tui]"));
         assert!(config.contains("resize_reflow = false"));
     }

--- a/nori-rs/tui/src/app/config_persistence.rs
+++ b/nori-rs/tui/src/app/config_persistence.rs
@@ -10,6 +10,13 @@ async fn persist_acp_wire_recording_config(nori_home: &Path, enabled: bool) -> a
         .await
 }
 
+async fn persist_resize_reflow_config(nori_home: &Path, enabled: bool) -> anyhow::Result<()> {
+    ConfigEditsBuilder::new(nori_home)
+        .set_path(&["tui", "resize_reflow"], enabled)
+        .apply()
+        .await
+}
+
 /// Persist a session config option selection as the agent's default model.
 ///
 /// Returns `Ok(true)` only when `config_id` names the agent's Model-category
@@ -301,6 +308,37 @@ impl App {
             .add_info_message(format!("Pinned plan drawer {status}."), None);
         self.chat_widget
             .reopen_settings_focused(SettingsItem::PinnedPlanDrawer);
+    }
+
+    pub(super) async fn persist_resize_reflow_setting(
+        &mut self,
+        enabled: bool,
+        tui: &mut tui::Tui,
+    ) {
+        if let Err(err) = persist_resize_reflow_config(&self.config.nori_home, enabled).await {
+            tracing::error!(error = %err, "failed to persist resize_reflow setting");
+            self.chat_widget
+                .add_error_message(format!("Failed to save resize_reflow setting: {err}"));
+            return;
+        }
+
+        self.config.resize_reflow = enabled;
+        self.sync_runtime_config();
+        if enabled {
+            if let Ok(size) = tui.terminal.size() {
+                self.transcript_reflow
+                    .note_width(size.width, std::time::Instant::now());
+            }
+            self.transcript_reflow.schedule_immediate();
+            tui.frame_requester().schedule_frame();
+        } else {
+            self.transcript_reflow.cancel();
+        }
+        let status = if enabled { "enabled" } else { "disabled" };
+        self.chat_widget
+            .add_info_message(format!("Resize reflow {status}."), None);
+        self.chat_widget
+            .reopen_settings_focused(SettingsItem::ResizeReflow);
     }
 
     pub(super) async fn persist_acp_wire_recording_setting(&mut self, enabled: bool) {
@@ -659,6 +697,20 @@ mod tests {
             message,
             "failed to handle OAuth callback: OAuth token exchange failed: server returned 400"
         );
+    }
+
+    #[tokio::test]
+    async fn resize_reflow_persists_to_the_tui_section() {
+        let temp = TempDir::new().expect("temp home");
+
+        persist_resize_reflow_config(temp.path(), false)
+            .await
+            .expect("persist resize reflow");
+
+        let config = std::fs::read_to_string(temp.path().join("config.toml"))
+            .expect("read config.toml");
+        assert!(config.contains("[tui]"));
+        assert!(config.contains("resize_reflow = false"));
     }
 
     fn session_config_options_with_model() -> Vec<nori_protocol::acp::v1::SessionConfigOption> {

--- a/nori-rs/tui/src/app/event_handling.rs
+++ b/nori-rs/tui/src/app/event_handling.rs
@@ -42,6 +42,9 @@ impl App {
         tui: &mut tui::Tui,
         event: TuiEvent,
     ) -> Result<bool> {
+        if matches!(event, TuiEvent::Draw) {
+            self.handle_resize_reflow_draw(tui)?;
+        }
         if self.overlay.is_some() {
             let _ = self.handle_backtrack_overlay_event(tui, event).await?;
         } else {
@@ -293,6 +296,23 @@ impl App {
                     } else {
                         tui.insert_history_lines(display);
                     }
+                }
+            }
+            AppEvent::ConsolidateAgentMessage { source, cwd } => {
+                let consolidation = crate::transcript_reflow::consolidate_agent_message_cells(
+                    &mut self.transcript_cells,
+                    source,
+                    &cwd,
+                );
+                if let Some((range, replacement)) = consolidation
+                    && let Some(Overlay::Transcript(transcript)) = &mut self.overlay
+                {
+                    transcript.replace_cells(range, replacement);
+                    tui.frame_requester().schedule_frame();
+                }
+                if self.transcript_reflow.take_stream_finish_reflow_needed() {
+                    self.transcript_reflow.schedule_immediate();
+                    tui.frame_requester().schedule_frame();
                 }
             }
             AppEvent::StartCommitAnimation => {
@@ -885,6 +905,9 @@ impl App {
             }
             AppEvent::SetConfigPinnedPlanDrawer(enabled) => {
                 self.persist_pinned_plan_drawer_setting(enabled).await;
+            }
+            AppEvent::SetConfigResizeReflow(enabled) => {
+                self.persist_resize_reflow_setting(enabled, tui).await;
             }
             AppEvent::SetConfigAcpWireRecording(enabled) => {
                 self.persist_acp_wire_recording_setting(enabled).await;

--- a/nori-rs/tui/src/app/mod.rs
+++ b/nori-rs/tui/src/app/mod.rs
@@ -101,6 +101,7 @@ pub(crate) struct App {
     pub(crate) overlay: Option<Overlay>,
     pub(crate) deferred_history_lines: Vec<Line<'static>>,
     has_emitted_history_lines: bool,
+    pub(crate) transcript_reflow: crate::transcript_reflow::TranscriptReflowState,
 
     pub(crate) enhanced_keys_supported: bool,
     cloud_onboard: bool,
@@ -163,6 +164,7 @@ struct SystemInfoRefreshRequest {
 
 mod config_persistence;
 mod event_handling;
+mod resize_reflow;
 mod session_setup;
 
 impl App {
@@ -245,6 +247,7 @@ impl App {
             overlay: None,
             deferred_history_lines: Vec::new(),
             has_emitted_history_lines: false,
+            transcript_reflow: Default::default(),
             commit_anim_running: Arc::new(AtomicBool::new(false)),
             backtrack: BacktrackState::default(),
             pending_update_action: None,

--- a/nori-rs/tui/src/app/resize_reflow.rs
+++ b/nori-rs/tui/src/app/resize_reflow.rs
@@ -1,0 +1,75 @@
+use std::time::Instant;
+
+use color_eyre::eyre::Result;
+
+use super::App;
+use crate::transcript_reflow::REFLOW_DEBOUNCE;
+use crate::transcript_reflow::WidthChange;
+use crate::transcript_reflow::has_unconsolidated_agent_message;
+use crate::transcript_reflow::render_transcript_tail;
+use crate::tui;
+
+impl App {
+    pub(super) fn handle_resize_reflow_draw(&mut self, tui: &mut tui::Tui) -> Result<()> {
+        let width = tui.terminal.size()?.width;
+        if !self.config.resize_reflow {
+            self.transcript_reflow.cancel();
+            return Ok(());
+        }
+
+        if self.transcript_reflow.note_width(width, Instant::now()) == WidthChange::Scheduled {
+            if self.chat_widget.has_active_agent_stream()
+                || has_unconsolidated_agent_message(&self.transcript_cells)
+            {
+                self.transcript_reflow
+                    .mark_resize_requested_during_stream();
+            }
+            tui.frame_requester().schedule_frame_in(REFLOW_DEBOUNCE);
+        }
+        self.maybe_run_resize_reflow(tui, width)
+    }
+
+    fn maybe_run_resize_reflow(&mut self, tui: &mut tui::Tui, width: u16) -> Result<()> {
+        let now = Instant::now();
+        let Some(deadline) = self.transcript_reflow.pending_until() else {
+            return Ok(());
+        };
+        if !self.transcript_reflow.pending_is_due(now) {
+            tui.frame_requester().schedule_frame_in(deadline - now);
+            return Ok(());
+        }
+        if self.overlay.is_some()
+            || self.chat_widget.has_active_overlay_or_popup()
+            || tui.is_alt_screen_active()
+        {
+            return Ok(());
+        }
+        if self.chat_widget.has_active_agent_stream()
+            || has_unconsolidated_agent_message(&self.transcript_cells)
+        {
+            self.transcript_reflow
+                .mark_resize_requested_during_stream();
+            return Ok(());
+        }
+        if self.transcript_cells.is_empty() {
+            self.transcript_reflow.mark_reflowed(width);
+            return Ok(());
+        }
+
+        let lines = render_transcript_tail(&self.transcript_cells, width);
+        tui.clear_pending_history_lines();
+        tui.terminal
+            .clear_scrollback_and_visible_screen_for_reflow()?;
+        let mut area = tui.terminal.viewport_area;
+        area.y = 0;
+        area.width = width;
+        tui.terminal.set_viewport_area(area);
+        self.deferred_history_lines.clear();
+        self.has_emitted_history_lines = !lines.is_empty();
+        if !lines.is_empty() {
+            tui.insert_history_lines(lines);
+        }
+        self.transcript_reflow.mark_reflowed(width);
+        Ok(())
+    }
+}

--- a/nori-rs/tui/src/app/resize_reflow.rs
+++ b/nori-rs/tui/src/app/resize_reflow.rs
@@ -21,8 +21,7 @@ impl App {
             if self.chat_widget.has_active_agent_stream()
                 || has_unconsolidated_agent_message(&self.transcript_cells)
             {
-                self.transcript_reflow
-                    .mark_resize_requested_during_stream();
+                self.transcript_reflow.mark_resize_requested_during_stream();
             }
             tui.frame_requester().schedule_frame_in(REFLOW_DEBOUNCE);
         }
@@ -47,8 +46,7 @@ impl App {
         if self.chat_widget.has_active_agent_stream()
             || has_unconsolidated_agent_message(&self.transcript_cells)
         {
-            self.transcript_reflow
-                .mark_resize_requested_during_stream();
+            self.transcript_reflow.mark_resize_requested_during_stream();
             return Ok(());
         }
         if self.transcript_cells.is_empty() {

--- a/nori-rs/tui/src/app/session_setup.rs
+++ b/nori-rs/tui/src/app/session_setup.rs
@@ -68,6 +68,7 @@ impl App {
         &mut self,
         entries: Vec<crate::viewonly_transcript::ViewonlyEntry>,
     ) {
+        use crate::history_cell::AgentMarkdownCell;
         use crate::history_cell::AgentMessageCell;
         use crate::markdown::append_markdown;
         use crate::viewonly_transcript::ViewonlyEntry;
@@ -95,10 +96,7 @@ impl App {
                     ));
                 }
                 ViewonlyEntry::Assistant { content } => {
-                    // Add assistant response with markdown rendering
-                    let mut lines = Vec::new();
-                    append_markdown(&content, None, &mut lines);
-                    let cell = AgentMessageCell::new(lines, true);
+                    let cell = AgentMarkdownCell::new(content, &self.config.cwd);
                     self.chat_widget.add_boxed_history(Box::new(cell));
                 }
                 ViewonlyEntry::Thinking { content } => {

--- a/nori-rs/tui/src/app_backtrack.rs
+++ b/nori-rs/tui/src/app_backtrack.rs
@@ -125,7 +125,9 @@ impl App {
     pub(crate) fn close_transcript_overlay(&mut self, tui: &mut tui::Tui) {
         let _ = tui.leave_alt_screen();
         let was_backtrack = self.backtrack.overlay_preview_active;
-        if !self.deferred_history_lines.is_empty() {
+        if self.transcript_reflow.has_pending_reflow() {
+            self.deferred_history_lines.clear();
+        } else if !self.deferred_history_lines.is_empty() {
             let lines = std::mem::take(&mut self.deferred_history_lines);
             tui.insert_history_lines(lines);
         }
@@ -134,6 +136,9 @@ impl App {
         if was_backtrack {
             // Ensure backtrack state is fully reset when overlay closes (e.g. via 'q').
             self.reset_backtrack_state();
+        }
+        if self.transcript_reflow.has_pending_reflow() {
+            tui.frame_requester().schedule_frame();
         }
     }
 

--- a/nori-rs/tui/src/app_event.rs
+++ b/nori-rs/tui/src/app_event.rs
@@ -138,6 +138,12 @@ pub(crate) enum AppEvent {
 
     InsertHistoryCell(Box<dyn HistoryCell>),
 
+    /// Replace the just-finished assistant stream cells with one raw-Markdown cell.
+    ConsolidateAgentMessage {
+        source: String,
+        cwd: PathBuf,
+    },
+
     StartCommitAnimation,
     StopCommitAnimation,
     CommitTick,
@@ -376,6 +382,9 @@ pub(crate) enum AppEvent {
 
     /// Set the TUI pinned plan drawer config setting.
     SetConfigPinnedPlanDrawer(bool),
+
+    /// Set width-resize transcript reflow.
+    SetConfigResizeReflow(bool),
 
     /// Set ACP wire JSONL recording for future ACP child subprocesses.
     SetConfigAcpWireRecording(bool),

--- a/nori-rs/tui/src/chatwidget/event_handlers.rs
+++ b/nori-rs/tui/src/chatwidget/event_handlers.rs
@@ -336,10 +336,17 @@ impl ChatWidget {
     }
 
     pub(super) fn flush_answer_stream_with_separator(&mut self) {
-        if let Some(mut controller) = self.stream_controller.take()
-            && let Some(cell) = controller.finalize()
-        {
-            self.add_boxed_history(cell);
+        if let Some(mut controller) = self.stream_controller.take() {
+            let (cell, source) = controller.finalize();
+            if let Some(cell) = cell {
+                self.add_boxed_history(cell);
+            }
+            if let Some(source) = source {
+                self.app_event_tx.send(AppEvent::ConsolidateAgentMessage {
+                    source,
+                    cwd: self.config.cwd.clone(),
+                });
+            }
         }
     }
 
@@ -585,6 +592,10 @@ impl ChatWidget {
                 self.app_event_tx.send(AppEvent::StopCommitAnimation);
             }
         }
+    }
+
+    pub(crate) fn has_active_agent_stream(&self) -> bool {
+        self.stream_controller.is_some()
     }
 
     #[inline]

--- a/nori-rs/tui/src/chatwidget/helpers.rs
+++ b/nori-rs/tui/src/chatwidget/helpers.rs
@@ -278,6 +278,10 @@ impl ChatWidget {
         self.bottom_pane.has_active_view()
     }
 
+    pub(crate) fn has_active_overlay_or_popup(&self) -> bool {
+        self.bottom_pane.has_active_overlay_or_popup()
+    }
+
     pub(crate) fn composer_is_empty(&self) -> bool {
         self.bottom_pane.composer_is_empty()
     }

--- a/nori-rs/tui/src/custom_terminal.rs
+++ b/nori-rs/tui/src/custom_terminal.rs
@@ -769,5 +769,4 @@ mod tests {
         let history = output.find("history after clear").expect("history bytes");
         assert!(clear < history);
     }
-
 }

--- a/nori-rs/tui/src/custom_terminal.rs
+++ b/nori-rs/tui/src/custom_terminal.rs
@@ -381,6 +381,18 @@ where
         Ok(())
     }
 
+    /// Clear the visible screen and native scrollback before transcript replay.
+    pub fn clear_scrollback_and_visible_screen_for_reflow(&mut self) -> io::Result<()> {
+        if self.viewport_area.is_empty() {
+            return Ok(());
+        }
+        write!(self.backend, "\x1b[2J\x1b[H\x1b[3J")?;
+        Write::flush(&mut self.backend)?;
+        self.last_known_cursor_pos = Position { x: 0, y: 0 };
+        self.previous_buffer_mut().reset();
+        Ok(())
+    }
+
     /// Clears the inactive buffer and swaps it with the current buffer
     pub fn swap_buffers(&mut self) {
         self.previous_buffer_mut().reset();
@@ -594,8 +606,100 @@ impl ModifierDiff {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+    use ratatui::backend::WindowSize;
+    use ratatui::buffer::Cell;
     use ratatui::layout::Rect;
     use ratatui::style::Style;
+
+    struct RecordingBackend {
+        inner: crate::test_backend::VT100Backend,
+        bytes: Vec<u8>,
+    }
+
+    impl RecordingBackend {
+        fn new(width: u16, height: u16) -> Self {
+            Self {
+                inner: crate::test_backend::VT100Backend::new(width, height),
+                bytes: Vec::new(),
+            }
+        }
+    }
+
+    impl Write for RecordingBackend {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            self.bytes.extend_from_slice(buffer);
+            self.inner.write(buffer)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Write::flush(&mut self.inner)
+        }
+    }
+
+    impl Backend for RecordingBackend {
+        fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
+        where
+            I: Iterator<Item = (u16, u16, &'a Cell)>,
+        {
+            self.inner.draw(content)
+        }
+
+        fn hide_cursor(&mut self) -> io::Result<()> {
+            self.inner.hide_cursor()
+        }
+
+        fn show_cursor(&mut self) -> io::Result<()> {
+            self.inner.show_cursor()
+        }
+
+        fn get_cursor_position(&mut self) -> io::Result<Position> {
+            self.inner.get_cursor_position()
+        }
+
+        fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+            self.inner.set_cursor_position(position)
+        }
+
+        fn clear(&mut self) -> io::Result<()> {
+            self.inner.clear()
+        }
+
+        fn clear_region(&mut self, clear_type: ClearType) -> io::Result<()> {
+            self.inner.clear_region(clear_type)
+        }
+
+        fn append_lines(&mut self, line_count: u16) -> io::Result<()> {
+            self.inner.append_lines(line_count)
+        }
+
+        fn scroll_region_up(
+            &mut self,
+            region: std::ops::Range<u16>,
+            line_count: u16,
+        ) -> io::Result<()> {
+            self.inner.scroll_region_up(region, line_count)
+        }
+
+        fn scroll_region_down(
+            &mut self,
+            region: std::ops::Range<u16>,
+            line_count: u16,
+        ) -> io::Result<()> {
+            self.inner.scroll_region_down(region, line_count)
+        }
+
+        fn size(&self) -> io::Result<Size> {
+            self.inner.size()
+        }
+
+        fn window_size(&mut self) -> io::Result<WindowSize> {
+            self.inner.window_size()
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Backend::flush(&mut self.inner)
+        }
+    }
 
     #[test]
     fn diff_buffers_does_not_emit_clear_to_end_for_full_width_row() {
@@ -642,4 +746,28 @@ mod tests {
             "expected clear-to-end to start after the remaining wide char; commands: {commands:?}"
         );
     }
+
+    #[test]
+    fn resize_reflow_clears_screen_then_homes_then_purges_before_history() {
+        let backend = RecordingBackend::new(80, 24);
+        let mut terminal = Terminal::with_options(backend).expect("terminal");
+        terminal.set_viewport_area(Rect::new(0, 20, 80, 4));
+
+        terminal
+            .clear_scrollback_and_visible_screen_for_reflow()
+            .expect("clear terminal");
+        crate::insert_history::insert_history_lines(
+            &mut terminal,
+            vec![ratatui::text::Line::from("history after clear")],
+        )
+        .expect("insert history");
+
+        let output = String::from_utf8_lossy(&terminal.backend().bytes);
+        let clear = output
+            .find("\x1b[2J\x1b[H\x1b[3J")
+            .expect("ordered resize-reflow clear sequence");
+        let history = output.find("history after clear").expect("history bytes");
+        assert!(clear < history);
+    }
+
 }

--- a/nori-rs/tui/src/history_cell/mod.rs
+++ b/nori-rs/tui/src/history_cell/mod.rs
@@ -19,6 +19,8 @@ use ratatui::style::Stylize;
 use ratatui::widgets::Paragraph;
 use ratatui::widgets::Wrap;
 use std::any::Any;
+use std::path::Path;
+use std::path::PathBuf;
 use unicode_width::UnicodeWidthStr;
 
 /// Represents an event to display in the conversation history. Returns its
@@ -203,6 +205,35 @@ impl HistoryCell for AgentMessageCell {
 
     fn is_stream_continuation(&self) -> bool {
         !self.is_first_line
+    }
+}
+
+/// A completed assistant message that keeps raw Markdown for width-aware replay.
+#[derive(Debug)]
+pub(crate) struct AgentMarkdownCell {
+    markdown_source: String,
+    cwd: PathBuf,
+}
+
+impl AgentMarkdownCell {
+    pub(crate) fn new(markdown_source: String, cwd: &Path) -> Self {
+        Self {
+            markdown_source,
+            cwd: cwd.to_path_buf(),
+        }
+    }
+}
+
+impl HistoryCell for AgentMarkdownCell {
+    fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
+        let mut lines = Vec::new();
+        crate::markdown::append_markdown_with_cwd(
+            &self.markdown_source,
+            Some(usize::from(width.saturating_sub(2).max(1))),
+            Some(&self.cwd),
+            &mut lines,
+        );
+        prefix_lines(lines, "• ".dim(), "  ".into())
     }
 }
 
@@ -609,5 +640,41 @@ impl HistoryCell for FinalMessageSeparator {
         } else {
             vec![Line::from_iter(["─".repeat(width as usize).dim()])]
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use insta::assert_snapshot;
+    use pretty_assertions::assert_ne;
+
+    use super::*;
+
+    #[test]
+    fn finalized_agent_markdown_reparses_at_each_width() {
+        let cell = AgentMarkdownCell::new(
+            "A deliberately long paragraph with [a long clickable link](https://example.com/a/very/long/path) before a table.\n\n| Name | Description |\n| --- | --- |\n| resize | a deliberately long explanation |".to_string(),
+            Path::new("/tmp"),
+        );
+
+        let wide = cell.display_lines(80);
+        let narrow = cell.display_lines(36);
+
+        assert_ne!(wide, narrow);
+        assert_snapshot!(
+            wide.iter()
+                .map(Line::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        assert_snapshot!(
+            narrow
+                .iter()
+                .map(Line::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
     }
 }

--- a/nori-rs/tui/src/history_cell/snapshots/nori_tui__history_cell__tests__finalized_agent_markdown_reparses_at_each_width-2.snap
+++ b/nori-rs/tui/src/history_cell/snapshots/nori_tui__history_cell__tests__finalized_agent_markdown_reparses_at_each_width-2.snap
@@ -1,0 +1,12 @@
+---
+source: tui/src/history_cell/mod.rs
+expression: "narrow.iter().map(Line::to_string).collect::<Vec<_>>().join(\"\\n\")"
+---
+• A deliberately long paragraph
+  with a long clickable link
+  (https://example.com/a/very/long/path)
+  before a table.
+  Name    Description               
+  ━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━
+  resize  a deliberately long       
+          explanation

--- a/nori-rs/tui/src/history_cell/snapshots/nori_tui__history_cell__tests__finalized_agent_markdown_reparses_at_each_width.snap
+++ b/nori-rs/tui/src/history_cell/snapshots/nori_tui__history_cell__tests__finalized_agent_markdown_reparses_at_each_width.snap
@@ -1,0 +1,9 @@
+---
+source: tui/src/history_cell/mod.rs
+expression: "wide.iter().map(Line::to_string).collect::<Vec<_>>().join(\"\\n\")"
+---
+• A deliberately long paragraph with a long clickable link
+  (https://example.com/a/very/long/path) before a table.
+  Name    Description                    
+  ━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  resize  a deliberately long explanation

--- a/nori-rs/tui/src/insert_history.rs
+++ b/nori-rs/tui/src/insert_history.rs
@@ -49,6 +49,21 @@ fn wrap_history_line<'a>(line: &'a Line<'a>, width: usize) -> Vec<Line<'a>> {
     }
 }
 
+pub(crate) fn wrap_history_lines_for_width(
+    lines: &[Line<'_>],
+    width: u16,
+) -> Vec<Line<'static>> {
+    let mut wrapped = Vec::new();
+    let width = usize::from(width.max(1));
+    for line in lines {
+        crate::render::line_utils::push_owned_lines(
+            &wrap_history_line(line, width),
+            &mut wrapped,
+        );
+    }
+    wrapped
+}
+
 fn physical_row_count(line: &Line<'_>, width: usize) -> usize {
     line.width().max(1).div_ceil(width.max(1))
 }

--- a/nori-rs/tui/src/insert_history.rs
+++ b/nori-rs/tui/src/insert_history.rs
@@ -49,17 +49,11 @@ fn wrap_history_line<'a>(line: &'a Line<'a>, width: usize) -> Vec<Line<'a>> {
     }
 }
 
-pub(crate) fn wrap_history_lines_for_width(
-    lines: &[Line<'_>],
-    width: u16,
-) -> Vec<Line<'static>> {
+pub(crate) fn wrap_history_lines_for_width(lines: &[Line<'_>], width: u16) -> Vec<Line<'static>> {
     let mut wrapped = Vec::new();
     let width = usize::from(width.max(1));
     for line in lines {
-        crate::render::line_utils::push_owned_lines(
-            &wrap_history_line(line, width),
-            &mut wrapped,
-        );
+        crate::render::line_utils::push_owned_lines(&wrap_history_line(line, width), &mut wrapped);
     }
     wrapped
 }

--- a/nori-rs/tui/src/lib.rs
+++ b/nori-rs/tui/src/lib.rs
@@ -77,6 +77,7 @@ mod system_info;
 mod terminal_palette;
 mod terminal_title;
 mod text_formatting;
+mod transcript_reflow;
 mod tui;
 mod ui_consts;
 mod ui_types;

--- a/nori-rs/tui/src/markdown_stream.rs
+++ b/nori-rs/tui/src/markdown_stream.rs
@@ -87,7 +87,7 @@ impl MarkdownStreamCollector {
     /// If the buffer does not end with a newline, a temporary one is appended
     /// for rendering. Optionally unwraps ```markdown language fences in
     /// non-test builds.
-    pub fn finalize_and_drain(&mut self) -> Vec<Line<'static>> {
+    pub fn finalize_and_drain(&mut self) -> (Vec<Line<'static>>, String) {
         let raw_buffer = self.buffer.clone();
         let mut source: String = raw_buffer.clone();
         if !source.ends_with('\n') {
@@ -113,7 +113,7 @@ impl MarkdownStreamCollector {
 
         // Reset collector state for next stream.
         self.clear();
-        out
+        (out, raw_buffer)
     }
 }
 
@@ -131,7 +131,7 @@ pub(crate) fn simulate_stream_markdown_for_tests(
         }
     }
     if finalize {
-        out.extend(collector.finalize_and_drain());
+        out.extend(collector.finalize_and_drain().0);
     }
     out
 }
@@ -156,7 +156,7 @@ mod tests {
     async fn finalize_commits_partial_line() {
         let mut c = super::MarkdownStreamCollector::new(None);
         c.push_delta("Line without newline");
-        let out = c.finalize_and_drain();
+        let (out, _source) = c.finalize_and_drain();
         assert_eq!(out.len(), 1);
     }
 
@@ -704,7 +704,7 @@ mod tests {
                 out.extend(collector.commit_complete_lines());
             }
         }
-        out.extend(collector.finalize_and_drain());
+        out.extend(collector.finalize_and_drain().0);
         out
     }
 

--- a/nori-rs/tui/src/nori/config_picker.rs
+++ b/nori-rs/tui/src/nori/config_picker.rs
@@ -27,6 +27,7 @@ use crate::nori::skillset_picker;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SettingsItem {
     PinnedPlanDrawer,
+    ResizeReflow,
     CustomWorkingMessages,
     VerticalFooter,
     TerminalNotifications,
@@ -58,6 +59,7 @@ pub fn config_picker_params(
         config.terminal_notifications == TerminalNotifications::Enabled;
     let os_notifications_enabled = config.os_notifications == OsNotifications::Enabled;
     let pinned_plan_drawer_enabled = config.pinned_plan_drawer;
+    let resize_reflow_enabled = config.resize_reflow;
     let custom_working_messages_enabled = config.custom_working_messages;
     let custom_working_messages_description = if config.custom_working_message_list.is_empty() {
         "Rotate playful status messages while the agent is working".to_string()
@@ -80,6 +82,21 @@ pub fn config_picker_params(
                     let new_value = !pinned_plan_drawer_enabled;
                     move || {
                         tx.send(AppEvent::SetConfigPinnedPlanDrawer(new_value));
+                    }
+                },
+            ),
+        ),
+        (
+            SettingsItem::ResizeReflow,
+            build_toggle_item(
+                "Resize Reflow",
+                "Reflow transcript history when the terminal width changes",
+                resize_reflow_enabled,
+                {
+                    let tx = app_event_tx.clone();
+                    let new_value = !resize_reflow_enabled;
+                    move || {
+                        tx.send(AppEvent::SetConfigResizeReflow(new_value));
                     }
                 },
             ),
@@ -780,19 +797,6 @@ mod tests {
     }
 
     #[test]
-    fn config_picker_returns_expected_items() {
-        let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
-        let tx = AppEventSender::new(tx_raw);
-        let config = make_test_config(false);
-
-        let params = config_picker_params(&config, tx, None);
-
-        assert_eq!(params.items.len(), 14);
-        assert!(params.title.is_some());
-        assert!(params.title.unwrap().contains("Configuration"));
-    }
-
-    #[test]
     fn config_picker_shows_current_state_on() {
         let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
         let tx = AppEventSender::new(tx_raw);
@@ -800,8 +804,12 @@ mod tests {
 
         let params = config_picker_params(&config, tx, None);
 
-        // Vertical Footer follows Pinned Plan Drawer and Custom Working Messages.
-        assert!(params.items[2].name.contains("(on)"));
+        let item = params
+            .items
+            .iter()
+            .find(|item| item.name.contains("Vertical Footer"))
+            .expect("config picker should include Vertical Footer");
+        assert!(item.name.contains("(on)"));
     }
 
     #[test]
@@ -812,29 +820,12 @@ mod tests {
 
         let params = config_picker_params(&config, tx, None);
 
-        // Vertical Footer follows Pinned Plan Drawer and Custom Working Messages.
-        assert!(params.items[2].name.contains("(off)"));
-    }
-
-    #[test]
-    fn config_picker_returns_expected_item_count() {
-        let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
-        let tx = AppEventSender::new(tx_raw);
-        let config = make_test_config(false);
-
-        let params = config_picker_params(&config, tx, None);
-
-        assert_eq!(params.items.len(), 14);
-        // The 1st item should be Pinned Plan Drawer
-        assert!(params.items[0].name.contains("Pinned Plan Drawer"));
-        assert!(params.items[1].name.contains("Custom Working Messages"));
-        assert!(params.items[5].name.contains("Vim Mode"));
-        assert!(params.items[6].name.contains("Auto Worktree"));
-        assert!(params.items[7].name.contains("Per Session Skillsets"));
-        assert!(params.items[8].name.contains("Notify After Idle"));
-        assert!(params.items[9].name.contains("Hotkeys"));
-        assert!(params.items[10].name.contains("Script Timeout"));
-        assert!(params.items[11].name.contains("Loop Count"));
+        let item = params
+            .items
+            .iter()
+            .find(|item| item.name.contains("Vertical Footer"))
+            .expect("config picker should include Vertical Footer");
+        assert!(item.name.contains("(off)"));
     }
 
     #[test]
@@ -862,6 +853,49 @@ mod tests {
             }
             _ => panic!("expected SetConfigCustomWorkingMessages event, got: {event:?}"),
         }
+    }
+
+    #[test]
+    fn config_picker_resize_reflow_action_sends_correct_event() {
+        let (tx_raw, mut rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let config = make_test_config(false);
+
+        let params = config_picker_params(&config, tx.clone(), None);
+        let item = params
+            .items
+            .iter()
+            .find(|item| item.name.contains("Resize Reflow"))
+            .expect("config picker should include Resize Reflow");
+        assert!(item.name.contains("(on)"));
+        for action in &item.actions {
+            action(&tx);
+        }
+
+        match rx.try_recv().expect("should receive event") {
+            AppEvent::SetConfigResizeReflow(enabled) => assert!(!enabled),
+            event => panic!("expected SetConfigResizeReflow event, got: {event:?}"),
+        }
+    }
+
+    #[test]
+    fn config_picker_resize_reflow_snapshot() {
+        let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let config = make_test_config(false);
+
+        let params = config_picker_params(&config, tx, None);
+        let item = params
+            .items
+            .iter()
+            .find(|item| item.name.contains("Resize Reflow"))
+            .expect("config picker should include Resize Reflow");
+
+        insta::assert_snapshot!(format!(
+            "{}\n{}",
+            item.name,
+            item.description.as_deref().unwrap_or_default()
+        ));
     }
 
     #[test]
@@ -896,8 +930,11 @@ mod tests {
 
         let params = config_picker_params(&config, tx, None);
 
-        // Default config has FiveSeconds, so should show "5 seconds"
-        let idle_item = &params.items[8];
+        let idle_item = params
+            .items
+            .iter()
+            .find(|item| item.name.contains("Notify After Idle"))
+            .expect("config picker should include Notify After Idle");
         assert!(
             idle_item.name.contains("5 seconds"),
             "Expected '5 seconds' in name, got: {}",
@@ -913,7 +950,11 @@ mod tests {
 
         let params = config_picker_params(&config, tx.clone(), None);
 
-        let idle_item = &params.items[8];
+        let idle_item = params
+            .items
+            .iter()
+            .find(|item| item.name.contains("Notify After Idle"))
+            .expect("config picker should include Notify After Idle");
         for action in &idle_item.actions {
             action(&tx);
         }
@@ -933,8 +974,11 @@ mod tests {
 
         let params = config_picker_params(&config, tx.clone(), None);
 
-        let vertical_footer_item = &params.items[2];
-        assert!(vertical_footer_item.name.contains("Vertical Footer"));
+        let vertical_footer_item = params
+            .items
+            .iter()
+            .find(|item| item.name.contains("Vertical Footer"))
+            .expect("config picker should include Vertical Footer");
         for action in &vertical_footer_item.actions {
             action(&tx);
         }
@@ -958,8 +1002,11 @@ mod tests {
 
         let params = config_picker_params(&config, tx.clone(), None);
 
-        let hotkeys_item = &params.items[9];
-        assert!(hotkeys_item.name.contains("Hotkeys"));
+        let hotkeys_item = params
+            .items
+            .iter()
+            .find(|item| item.name.contains("Hotkeys"))
+            .expect("config picker should include Hotkeys");
         for action in &hotkeys_item.actions {
             action(&tx);
         }
@@ -1036,7 +1083,7 @@ mod tests {
 
         let params = config_picker_params(&config, tx, None);
 
-        assert_eq!(params.items.len(), 14);
+        assert_eq!(params.items.len(), 15);
         // Find the vim mode item
         let vim_mode_item = params
             .items
@@ -1202,8 +1249,11 @@ mod tests {
 
         let params = config_picker_params(&config, tx, None);
 
-        // Default config has 30s timeout
-        let timeout_item = &params.items[10];
+        let timeout_item = params
+            .items
+            .iter()
+            .find(|item| item.name.contains("Script Timeout"))
+            .expect("config picker should include Script Timeout");
         assert!(
             timeout_item.name.contains("30s"),
             "Expected '30s' in name, got: {}",
@@ -1219,8 +1269,11 @@ mod tests {
 
         let params = config_picker_params(&config, tx.clone(), None);
 
-        let timeout_item = &params.items[10];
-        assert!(timeout_item.name.contains("Script Timeout"));
+        let timeout_item = params
+            .items
+            .iter()
+            .find(|item| item.name.contains("Script Timeout"))
+            .expect("config picker should include Script Timeout");
         for action in &timeout_item.actions {
             action(&tx);
         }

--- a/nori-rs/tui/src/nori/snapshots/nori_tui__nori__config_picker__tests__config_picker_resize_reflow_snapshot.snap
+++ b/nori-rs/tui/src/nori/snapshots/nori_tui__nori__config_picker__tests__config_picker_resize_reflow_snapshot.snap
@@ -1,0 +1,6 @@
+---
+source: tui/src/nori/config_picker.rs
+expression: "format!(\"{}\\n{}\", item.name, item.description.as_deref().unwrap_or_default())"
+---
+Resize Reflow (on)
+Reflow transcript history when the terminal width changes

--- a/nori-rs/tui/src/pager_overlay.rs
+++ b/nori-rs/tui/src/pager_overlay.rs
@@ -793,19 +793,20 @@ mod tests {
                 false,
             )),
         ]);
-        let replacement: Arc<dyn HistoryCell> = Arc::new(
-            crate::history_cell::AgentMarkdownCell::new(
+        let replacement: Arc<dyn HistoryCell> =
+            Arc::new(crate::history_cell::AgentMarkdownCell::new(
                 "first\nsecond".to_string(),
                 std::path::Path::new("/tmp"),
-            ),
-        );
+            ));
 
         overlay.replace_cells(1..3, replacement);
 
         assert_eq!(overlay.cells.len(), 2);
-        assert!(overlay.cells[1]
-            .as_any()
-            .is::<crate::history_cell::AgentMarkdownCell>());
+        assert!(
+            overlay.cells[1]
+                .as_any()
+                .is::<crate::history_cell::AgentMarkdownCell>()
+        );
     }
 
     #[test]

--- a/nori-rs/tui/src/pager_overlay.rs
+++ b/nori-rs/tui/src/pager_overlay.rs
@@ -456,6 +456,19 @@ impl TranscriptOverlay {
         }
     }
 
+    pub(crate) fn replace_cells(
+        &mut self,
+        range: std::ops::Range<usize>,
+        replacement: Arc<dyn HistoryCell>,
+    ) {
+        let follow_bottom = self.view.is_scrolled_to_bottom();
+        self.cells.splice(range, std::iter::once(replacement));
+        self.view.renderables = Self::render_cells(&self.cells, self.highlight_cell);
+        if follow_bottom {
+            self.view.scroll_offset = usize::MAX;
+        }
+    }
+
     pub(crate) fn set_highlight_cell(&mut self, cell: Option<usize>) {
         self.highlight_cell = cell;
         self.view.renderables = Self::render_cells(&self.cells, self.highlight_cell);
@@ -763,6 +776,36 @@ mod tests {
         }));
 
         assert_eq!(overlay.view.scroll_offset, 0);
+    }
+
+    #[test]
+    fn transcript_overlay_can_replace_finalized_stream_cells() {
+        let mut overlay = TranscriptOverlay::new(vec![
+            Arc::new(TestCell {
+                lines: vec![Line::from("tool")],
+            }),
+            Arc::new(crate::history_cell::AgentMessageCell::new(
+                vec![Line::from("first")],
+                true,
+            )),
+            Arc::new(crate::history_cell::AgentMessageCell::new(
+                vec![Line::from("second")],
+                false,
+            )),
+        ]);
+        let replacement: Arc<dyn HistoryCell> = Arc::new(
+            crate::history_cell::AgentMarkdownCell::new(
+                "first\nsecond".to_string(),
+                std::path::Path::new("/tmp"),
+            ),
+        );
+
+        overlay.replace_cells(1..3, replacement);
+
+        assert_eq!(overlay.cells.len(), 2);
+        assert!(overlay.cells[1]
+            .as_any()
+            .is::<crate::history_cell::AgentMarkdownCell>());
     }
 
     #[test]

--- a/nori-rs/tui/src/session_log.rs
+++ b/nori-rs/tui/src/session_log.rs
@@ -175,11 +175,11 @@ fn app_event_variant(event: &AppEvent) -> std::borrow::Cow<'static, str> {
     let debug = format!("{event:?}");
     std::borrow::Cow::Owned(
         debug
-        .split(['(', '{'])
-        .next()
-        .unwrap_or("app_event")
-        .trim()
-        .to_string(),
+            .split(['(', '{'])
+            .next()
+            .unwrap_or("app_event")
+            .trim()
+            .to_string(),
     )
 }
 

--- a/nori-rs/tui/src/session_log.rs
+++ b/nori-rs/tui/src/session_log.rs
@@ -161,11 +161,26 @@ pub(crate) fn log_inbound_app_event(event: &AppEvent) {
                 "ts": now_ts(),
                 "dir": "to_tui",
                 "kind": "app_event",
-                "variant": format!("{other:?}").split('(').next().unwrap_or("app_event"),
+                "variant": app_event_variant(other),
             });
             LOGGER.write_json_line(value);
         }
     }
+}
+
+fn app_event_variant(event: &AppEvent) -> std::borrow::Cow<'static, str> {
+    if matches!(event, AppEvent::ConsolidateAgentMessage { .. }) {
+        return "ConsolidateAgentMessage".into();
+    }
+    let debug = format!("{event:?}");
+    std::borrow::Cow::Owned(
+        debug
+        .split(['(', '{'])
+        .next()
+        .unwrap_or("app_event")
+        .trim()
+        .to_string(),
+    )
 }
 
 pub(crate) fn log_session_end() {
@@ -178,4 +193,23 @@ pub(crate) fn log_session_end() {
         "kind": "session_end",
     });
     LOGGER.write_json_line(value);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn struct_app_event_variant_excludes_debug_fields() {
+        let event = AppEvent::ConsolidateAgentMessage {
+            source: "secret raw Markdown".to_string(),
+            cwd: std::path::PathBuf::from("/secret/cwd"),
+        };
+
+        let variant = app_event_variant(&event);
+
+        assert_eq!(variant, "ConsolidateAgentMessage");
+        assert!(matches!(variant, std::borrow::Cow::Borrowed(_)));
+        assert!(!variant.contains("secret"));
+    }
 }

--- a/nori-rs/tui/src/streaming/controller.rs
+++ b/nori-rs/tui/src/streaming/controller.rs
@@ -39,9 +39,9 @@ impl StreamController {
     }
 
     /// Finalize the active stream. Drain and emit now.
-    pub(crate) fn finalize(&mut self) -> Option<Box<dyn HistoryCell>> {
+    pub(crate) fn finalize(&mut self) -> (Option<Box<dyn HistoryCell>>, Option<String>) {
         // Finalize collector first.
-        let remaining = {
+        let (remaining, source) = {
             let state = &mut self.state;
             state.collector.finalize_and_drain()
         };
@@ -59,7 +59,9 @@ impl StreamController {
         // Cleanup
         self.state.clear();
         self.finishing_after_drain = false;
-        self.emit(out_lines)
+        let cell = self.emit(out_lines);
+        let source = (!source.is_empty()).then_some(source);
+        (cell, source)
     }
 
     /// Step animation: commit at most one queued line and handle end-of-drain cleanup.
@@ -184,7 +186,7 @@ mod tests {
             }
         }
         // Finalize and flush remaining lines now.
-        if let Some(cell) = ctrl.finalize() {
+        if let Some(cell) = ctrl.finalize().0 {
             lines.extend(cell.transcript_lines(u16::MAX));
         }
 
@@ -218,6 +220,21 @@ mod tests {
         assert_eq!(
             streamed, expected,
             "expected exact rendered lines for loose/tight section"
+        );
+    }
+
+    #[test]
+    fn finalize_returns_the_complete_raw_markdown_source() {
+        let mut controller = StreamController::new(Some(20));
+        controller.push("A **formatted** line\n");
+        let _ = controller.on_commit_tick();
+        controller.push("and a final fragment");
+
+        let (_cell, source) = controller.finalize();
+
+        assert_eq!(
+            source.as_deref(),
+            Some("A **formatted** line\nand a final fragment")
         );
     }
 }

--- a/nori-rs/tui/src/transcript_reflow.rs
+++ b/nori-rs/tui/src/transcript_reflow.rs
@@ -115,9 +115,7 @@ pub(crate) fn consolidate_agent_message_cells(
     Some((range, replacement))
 }
 
-pub(crate) fn has_unconsolidated_agent_message(
-    transcript_cells: &[Arc<dyn HistoryCell>],
-) -> bool {
+pub(crate) fn has_unconsolidated_agent_message(transcript_cells: &[Arc<dyn HistoryCell>]) -> bool {
     transcript_cells
         .last()
         .is_some_and(|cell| cell.as_any().is::<AgentMessageCell>())
@@ -127,12 +125,7 @@ pub(crate) fn render_transcript_tail(
     transcript_cells: &[Arc<dyn HistoryCell>],
     width: u16,
 ) -> Vec<Line<'static>> {
-    render_transcript_tail_with_limits(
-        transcript_cells,
-        width,
-        MAX_REFLOW_CELLS,
-        MAX_REFLOW_ROWS,
-    )
+    render_transcript_tail_with_limits(transcript_cells, width, MAX_REFLOW_CELLS, MAX_REFLOW_ROWS)
 }
 
 fn render_transcript_tail_with_limits(
@@ -282,13 +275,7 @@ mod tests {
 
         assert_eq!(
             line_text(&rendered),
-            vec![
-                "… history truncated",
-                "",
-                "four",
-                "five",
-                "six",
-            ]
+            vec!["… history truncated", "", "four", "five", "six",]
         );
     }
 
@@ -360,7 +347,10 @@ mod tests {
         let narrow = line_text(&render_transcript_tail(&cells, 28));
         assert_eq!(wide.iter().filter(|line| line.contains("tool")).count(), 1);
         assert_eq!(wide.iter().filter(|line| line.contains("first")).count(), 1);
-        assert_eq!(wide.iter().filter(|line| line.contains("second")).count(), 1);
+        assert_eq!(
+            wide.iter().filter(|line| line.contains("second")).count(),
+            1
+        );
         assert_eq!(wide.first().map(String::as_str), Some("tool"));
         assert!(narrow.len() > wide.len());
     }

--- a/nori-rs/tui/src/transcript_reflow.rs
+++ b/nori-rs/tui/src/transcript_reflow.rs
@@ -1,0 +1,367 @@
+use std::collections::VecDeque;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
+
+use ratatui::text::Line;
+
+use crate::history_cell::AgentMarkdownCell;
+use crate::history_cell::AgentMessageCell;
+use crate::history_cell::HistoryCell;
+
+pub(crate) const MAX_REFLOW_CELLS: usize = 1_000;
+pub(crate) const MAX_REFLOW_ROWS: usize = 10_000;
+pub(crate) const REFLOW_DEBOUNCE: Duration = Duration::from_millis(75);
+const HISTORY_TRUNCATED_NOTICE: &str = "… history truncated";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum WidthChange {
+    Unchanged,
+    Initialized,
+    Scheduled,
+    Cancelled,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct TranscriptReflowState {
+    last_observed_width: Option<u16>,
+    last_reflow_width: Option<u16>,
+    pending_until: Option<Instant>,
+    resize_requested_during_stream: bool,
+}
+
+impl TranscriptReflowState {
+    pub(crate) fn note_width(&mut self, width: u16, now: Instant) -> WidthChange {
+        let Some(previous_width) = self.last_observed_width.replace(width) else {
+            self.last_reflow_width = Some(width);
+            return WidthChange::Initialized;
+        };
+        if previous_width == width {
+            return WidthChange::Unchanged;
+        }
+        if self.last_reflow_width == Some(width) {
+            self.cancel();
+            return WidthChange::Cancelled;
+        }
+        self.pending_until = Some(now + REFLOW_DEBOUNCE);
+        WidthChange::Scheduled
+    }
+
+    pub(crate) fn schedule_immediate(&mut self) {
+        self.pending_until = Some(Instant::now());
+    }
+
+    pub(crate) fn cancel(&mut self) {
+        self.pending_until = None;
+        self.resize_requested_during_stream = false;
+    }
+
+    pub(crate) fn has_pending_reflow(&self) -> bool {
+        self.pending_until.is_some()
+    }
+
+    pub(crate) fn pending_until(&self) -> Option<Instant> {
+        self.pending_until
+    }
+
+    pub(crate) fn pending_is_due(&self, now: Instant) -> bool {
+        self.pending_until.is_some_and(|deadline| now >= deadline)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn last_reflow_width(&self) -> Option<u16> {
+        self.last_reflow_width
+    }
+
+    pub(crate) fn mark_reflowed(&mut self, width: u16) {
+        self.last_reflow_width = Some(width);
+        self.pending_until = None;
+    }
+
+    pub(crate) fn mark_resize_requested_during_stream(&mut self) {
+        self.resize_requested_during_stream = true;
+    }
+
+    pub(crate) fn take_stream_finish_reflow_needed(&mut self) -> bool {
+        std::mem::take(&mut self.resize_requested_during_stream)
+    }
+}
+
+pub(crate) fn consolidate_agent_message_cells(
+    transcript_cells: &mut Vec<Arc<dyn HistoryCell>>,
+    source: String,
+    cwd: &Path,
+) -> Option<(std::ops::Range<usize>, Arc<dyn HistoryCell>)> {
+    let end = transcript_cells.len();
+    let mut start = end;
+    while start > 0 {
+        let cell = &transcript_cells[start - 1];
+        if !cell.as_any().is::<AgentMessageCell>() {
+            break;
+        }
+        start -= 1;
+        if !cell.is_stream_continuation() {
+            break;
+        }
+    }
+    if start == end {
+        return None;
+    }
+
+    let range = start..end;
+    let replacement = Arc::new(AgentMarkdownCell::new(source, cwd)) as Arc<dyn HistoryCell>;
+    transcript_cells.splice(range.clone(), std::iter::once(replacement.clone()));
+    Some((range, replacement))
+}
+
+pub(crate) fn has_unconsolidated_agent_message(
+    transcript_cells: &[Arc<dyn HistoryCell>],
+) -> bool {
+    transcript_cells
+        .last()
+        .is_some_and(|cell| cell.as_any().is::<AgentMessageCell>())
+}
+
+pub(crate) fn render_transcript_tail(
+    transcript_cells: &[Arc<dyn HistoryCell>],
+    width: u16,
+) -> Vec<Line<'static>> {
+    render_transcript_tail_with_limits(
+        transcript_cells,
+        width,
+        MAX_REFLOW_CELLS,
+        MAX_REFLOW_ROWS,
+    )
+}
+
+fn render_transcript_tail_with_limits(
+    transcript_cells: &[Arc<dyn HistoryCell>],
+    width: u16,
+    max_cells: usize,
+    max_rows: usize,
+) -> Vec<Line<'static>> {
+    let start = transcript_cells.len().saturating_sub(max_cells);
+    let mut truncated = start > 0;
+    let mut rendered = Vec::new();
+    let mut has_emitted = false;
+
+    for cell in &transcript_cells[start..] {
+        let mut lines = cell.display_lines(width);
+        if lines.is_empty() {
+            continue;
+        }
+        if !cell.is_stream_continuation() {
+            if has_emitted {
+                rendered.push(Line::default());
+            } else {
+                has_emitted = true;
+            }
+        }
+        rendered.append(&mut lines);
+    }
+    let rendered = crate::insert_history::wrap_history_lines_for_width(&rendered, width);
+
+    if physical_rows(&rendered, width) > max_rows {
+        truncated = true;
+    }
+    if !truncated {
+        return rendered;
+    }
+
+    let notice = Line::from(HISTORY_TRUNCATED_NOTICE);
+    let notice_rows = physical_rows(std::slice::from_ref(&notice), width).saturating_add(1);
+    let history_budget = max_rows.saturating_sub(notice_rows);
+    let retained = retain_newest_rows(rendered, width, history_budget);
+    if max_rows < notice_rows {
+        return retained;
+    }
+
+    let mut result = Vec::with_capacity(retained.len() + 2);
+    result.push(notice);
+    result.push(Line::default());
+    result.extend(retained);
+    result
+}
+
+fn retain_newest_rows(
+    lines: Vec<Line<'static>>,
+    width: u16,
+    max_rows: usize,
+) -> Vec<Line<'static>> {
+    let mut retained = VecDeque::new();
+    let mut rows: usize = 0;
+    for line in lines.into_iter().rev() {
+        let line_rows = physical_rows(std::slice::from_ref(&line), width);
+        if rows.saturating_add(line_rows) > max_rows {
+            break;
+        }
+        rows += line_rows;
+        retained.push_front(line);
+    }
+    retained.into_iter().collect()
+}
+
+fn physical_rows(lines: &[Line<'_>], width: u16) -> usize {
+    let width = usize::from(width.max(1));
+    lines
+        .iter()
+        .map(|line| line.width().max(1).div_ceil(width))
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use std::time::Instant;
+
+    use pretty_assertions::assert_eq;
+    use ratatui::text::Line;
+
+    use super::*;
+    use crate::history_cell::AgentMessageCell;
+    use crate::history_cell::HistoryCell;
+    use crate::history_cell::PlainHistoryCell;
+
+    fn plain(lines: &[&str]) -> Arc<dyn HistoryCell> {
+        Arc::new(PlainHistoryCell::new(
+            lines
+                .iter()
+                .map(|line| Line::from((*line).to_string()))
+                .collect(),
+        ))
+    }
+
+    fn line_text(lines: &[Line<'_>]) -> Vec<String> {
+        lines.iter().map(Line::to_string).collect()
+    }
+
+    #[test]
+    fn first_width_observation_does_not_schedule_reflow() {
+        let now = Instant::now();
+        let mut state = TranscriptReflowState::default();
+
+        assert_eq!(state.note_width(80, now), WidthChange::Initialized);
+        assert!(!state.has_pending_reflow());
+        assert_eq!(state.last_reflow_width(), Some(80));
+    }
+
+    #[test]
+    fn width_changes_use_a_trailing_seventy_five_millisecond_debounce() {
+        let started = Instant::now();
+        let mut state = TranscriptReflowState::default();
+        state.note_width(80, started);
+
+        assert_eq!(state.note_width(100, started), WidthChange::Scheduled);
+        assert!(!state.pending_is_due(started + Duration::from_millis(74)));
+
+        let repeated = started + Duration::from_millis(50);
+        assert_eq!(state.note_width(120, repeated), WidthChange::Scheduled);
+        assert!(!state.pending_is_due(started + Duration::from_millis(124)));
+        assert!(state.pending_is_due(started + Duration::from_millis(125)));
+    }
+
+    #[test]
+    fn settling_at_the_last_reflowed_width_cancels_pending_work() {
+        let now = Instant::now();
+        let mut state = TranscriptReflowState::default();
+        state.note_width(80, now);
+        state.note_width(100, now);
+
+        assert_eq!(state.note_width(80, now), WidthChange::Cancelled);
+        assert!(!state.has_pending_reflow());
+    }
+
+    #[test]
+    fn row_cap_can_trim_inside_one_large_cell_and_counts_the_notice() {
+        let cells = vec![plain(&["one", "two", "three", "four", "five", "six"])];
+
+        let rendered = render_transcript_tail_with_limits(&cells, 80, 10, 5);
+
+        assert_eq!(
+            line_text(&rendered),
+            vec![
+                "… history truncated",
+                "",
+                "four",
+                "five",
+                "six",
+            ]
+        );
+    }
+
+    #[test]
+    fn row_cap_counts_the_same_word_wrapping_as_history_insertion() {
+        let cells = vec![plain(&["aaaaa bbbbb ccccc ddddd eeeee"])];
+
+        let rendered = render_transcript_tail_with_limits(&cells, 10, 10, 4);
+
+        assert_eq!(
+            line_text(&rendered),
+            vec!["… history truncated", "", "eeeee"]
+        );
+    }
+
+    #[test]
+    fn default_cell_cap_keeps_the_newest_thousand_without_mutating_transcript() {
+        let cells = (0..1_001)
+            .map(|index| plain(&[&format!("cell {index}")]))
+            .collect::<Vec<_>>();
+
+        let rendered = line_text(&render_transcript_tail(&cells, 80));
+
+        assert_eq!(cells.len(), 1_001);
+        assert_eq!(&rendered[..2], &["… history truncated", ""]);
+        assert!(rendered.iter().any(|line| line == "cell 1"));
+        assert!(!rendered.iter().any(|line| line == "cell 0"));
+        assert_eq!(rendered.last().map(String::as_str), Some("cell 1000"));
+    }
+
+    #[test]
+    fn default_row_cap_includes_the_notice_and_keeps_the_newest_rows() {
+        let source = (0..10_001)
+            .map(|index| format!("row {index}"))
+            .collect::<Vec<_>>();
+        let cell: Arc<dyn HistoryCell> = Arc::new(PlainHistoryCell::new(
+            source.iter().cloned().map(Line::from).collect(),
+        ));
+
+        let rendered = line_text(&render_transcript_tail(&[cell], 80));
+
+        assert_eq!(rendered.len(), 10_000);
+        assert_eq!(&rendered[..2], &["… history truncated", ""]);
+        assert_eq!(rendered[2], "row 3");
+        assert_eq!(rendered.last().map(String::as_str), Some("row 10000"));
+    }
+
+    #[test]
+    fn consolidation_preserves_neighbor_order_and_reflows_the_message_once() {
+        let mut cells: Vec<Arc<dyn HistoryCell>> = vec![
+            plain(&["tool"]),
+            Arc::new(AgentMessageCell::new(vec![Line::from("first")], true)),
+            Arc::new(AgentMessageCell::new(vec![Line::from("second")], false)),
+        ];
+
+        assert!(has_unconsolidated_agent_message(&cells));
+
+        let consolidation = consolidate_agent_message_cells(
+            &mut cells,
+            "first paragraph with enough words to wrap at a narrow width\n\nsecond paragraph"
+                .to_string(),
+            Path::new("/tmp"),
+        );
+
+        assert!(consolidation.is_some());
+        assert!(!has_unconsolidated_agent_message(&cells));
+        assert_eq!(cells.len(), 2);
+        let wide = line_text(&render_transcript_tail(&cells, 80));
+        let narrow = line_text(&render_transcript_tail(&cells, 28));
+        assert_eq!(wide.iter().filter(|line| line.contains("tool")).count(), 1);
+        assert_eq!(wide.iter().filter(|line| line.contains("first")).count(), 1);
+        assert_eq!(wide.iter().filter(|line| line.contains("second")).count(), 1);
+        assert_eq!(wide.first().map(String::as_str), Some("tool"));
+        assert!(narrow.len() > wide.len());
+    }
+}

--- a/nori-rs/tui/src/tui.rs
+++ b/nori-rs/tui/src/tui.rs
@@ -365,6 +365,14 @@ impl Tui {
         self.frame_requester().schedule_frame();
     }
 
+    pub(crate) fn clear_pending_history_lines(&mut self) {
+        self.pending_history_lines.clear();
+    }
+
+    pub(crate) fn is_alt_screen_active(&self) -> bool {
+        self.alt_screen_active.load(Ordering::Relaxed)
+    }
+
     pub fn draw(
         &mut self,
         height: u16,
@@ -468,7 +476,7 @@ impl Tui {
             if !self.pending_history_lines.is_empty() {
                 // Cap pending lines to avoid unbounded growth if insertion
                 // is blocked for an extended period (e.g., full-screen widget).
-                const MAX_PENDING_LINES: usize = 1000;
+                const MAX_PENDING_LINES: usize = crate::transcript_reflow::MAX_REFLOW_ROWS;
                 if self.pending_history_lines.len() > MAX_PENDING_LINES {
                     let excess = self.pending_history_lines.len() - MAX_PENDING_LINES;
                     self.pending_history_lines.drain(..excess);


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- Reflow inline transcript history after terminal width changes by reparsing finalized assistant Markdown at the new width.
- Bound destructive scrollback replay to the newest 1,000 semantic cells and 10,000 physical rows, with popup, alternate-screen, and streaming deferrals.
- Enable the behavior by default through `[tui] resize_reflow`, with a persisted `/settings` toggle and updated architecture documentation.

## Test Plan
- [x] `cargo test -p nori-config`
- [x] `cargo test -p nori-tui`
- [x] `cargo build --bin nori`
- [x] `cargo test -p tui-pty-e2e`
- [x] `just fix -p nori-tui`
- [x] `just fix -p nori-config`
- [x] `just fmt`
- [x] Isolated tmux + deterministic ElizACP: resize 120→60 columns with reflow enabled; toggle off through `/settings`; resize 60→120 with native history preserved

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets
