### PR TITLE
feat(harness): drive goals through the _session/goal extension when advertised

### DIFF
--- a/docs/followups/nori-client-mcp.md
+++ b/docs/followups/nori-client-mcp.md
@@ -107,12 +107,37 @@ prompts.
 `/goal` requires a close-the-loop path: the agent must be able to call the
 backend-owned goal tools to mark work complete or blocked. When `nori-client` is
 not available, goal automation should be unavailable as behavior, not merely
-dimmed as UI.
+dimmed as UI — unless the agent advertises the `_session/goal` extension
+described below.
 
 When the requested work is verified complete, the agent must call
 `update_goal` from the `nori-client` MCP server with the exact status `complete`
 and verify the returned status. A genuine impasse uses the
 exact status `blocked` through the same server.
+
+## Goal Extension Bridge (`_session/goal`)
+
+Agents may advertise a goal capability in the top-level `_meta` of the
+initialize response (`goal: {version: 1, controlMethod: "_session/goal",
+actions: [...]}`; `set` and `clear` are the required floor). When advertised,
+the harness prefers driving the goal through that extension: `/goal` sends
+`_session/goal` requests, the agent's native goal loop owns continuation, and
+the harness mirrors the goal snapshots the agent publishes on
+`session_info_update` `_meta.goal` into its own goal store and `GoalChanged`
+events. While the extension drives a goal:
+
+- the harness goal-continuation loop is suppressed,
+- the `<goal_context>`/`<goal_control>` prompt injection is skipped (the agent
+  runtime owns goal context), and
+- `/goal pause`/`resume` are honored only when the capability advertises those
+  actions; otherwise they fail with an explicit error rather than silently
+  diverging from the native loop.
+
+If an extension request fails and `nori-client` is available, the harness falls
+back to the MCP goal loop for that goal. Agents advertising the extension but
+not HTTP MCP get `/goal` through the extension alone. The end-to-end contract
+is exercised in `nori-rs/harness/tests/goal_ext_bridge.rs` against the mock
+agent (`MOCK_AGENT_GOAL_EXT`, `MOCK_AGENT_GOAL_EXT_AUTOCOMPLETE`).
 
 Required behavior:
 

--- a/docs/specs/goal-command-architecture-diagrams.md
+++ b/docs/specs/goal-command-architecture-diagrams.md
@@ -288,6 +288,19 @@ ThreadGoalState status changes; continuation loop stops
 | Context window            | Same Codex thread/session history, compacted as needed | External ACP agent's session context, steered by Nori prompts |
 | Subagents                 | Separate Codex threads only when explicitly spawned    | Determined by the external ACP agent, not by Nori goal state  |
 
+## Goal Extension Bridge
+
+A third path exists when the ACP agent advertises the `_session/goal`
+extension in the top-level `_meta` of its initialize response: the harness
+drives the agent's native goal loop over that extension instead of running its
+own continuation loop, and mirrors the goal snapshots the agent publishes
+(`session_info_update` `_meta.goal`) into `ThreadGoalState` and `GoalChanged`
+events. `ThreadGoalState` remains the source of truth for the TUI either way;
+only the continuation owner changes. The nori-client MCP loop diagrammed above
+stays the fallback for agents without the extension or when an extension call
+fails. Contract details: `docs/followups/nori-client-mcp.md`, "Goal Extension
+Bridge".
+
 ## Mental Model
 
 Both implementations are intentionally simple at the decision point: the model

--- a/nori-rs/acp-host/src/connection/acp_connection.rs
+++ b/nori-rs/acp-host/src/connection/acp_connection.rs
@@ -75,6 +75,10 @@ pub struct AcpConnection {
     /// Agent capabilities from the initialization handshake.
     agent_capabilities: acp::AgentCapabilities,
 
+    /// Top-level `_meta` of the initialize response, where agents advertise
+    /// ACP extensions (e.g. the `_session/goal` goal extension).
+    initialize_meta: Option<acp::Meta>,
+
     /// Ordered inbox of raw ACP events from the transport layer.
     event_rx: mpsc::Receiver<ConnectionEvent>,
 
@@ -117,8 +121,13 @@ async fn establish_connection(
     let write_cwd = cwd.to_path_buf();
     let read_cwd = cwd.to_path_buf();
 
-    let (init_tx, init_rx) =
-        oneshot::channel::<Result<(ConnectionTo<Agent>, acp::AgentCapabilities)>>();
+    let (init_tx, init_rx) = oneshot::channel::<
+        Result<(
+            ConnectionTo<Agent>,
+            acp::AgentCapabilities,
+            Option<acp::Meta>,
+        )>,
+    >();
 
     let connection_task = tokio::spawn(async move {
         let result = Client
@@ -355,7 +364,11 @@ async fn establish_connection(
                             );
                         }
                         debug!("ACP connection established, agent: {:?}", resp.agent_info);
-                        let _ = init_tx.send(Ok((connection.clone(), resp.agent_capabilities)));
+                        let _ = init_tx.send(Ok((
+                            connection.clone(),
+                            resp.agent_capabilities,
+                            resp.meta,
+                        )));
 
                         futures::future::pending::<Result<(), acp::Error>>().await
                     }
@@ -373,13 +386,14 @@ async fn establish_connection(
         }
     });
 
-    let (cx, capabilities) = init_rx
+    let (cx, capabilities, initialize_meta) = init_rx
         .await
         .context("ACP connection task died during initialization")??;
 
     Ok(AcpConnection {
         cx,
         agent_capabilities: capabilities,
+        initialize_meta,
         event_rx,
         event_tx: connection_event_tx,
         session_config_state,
@@ -899,6 +913,28 @@ impl AcpConnection {
     /// Get the agent's capabilities.
     pub fn capabilities(&self) -> &acp::AgentCapabilities {
         &self.agent_capabilities
+    }
+
+    /// Get the top-level `_meta` of the initialize response, where agents
+    /// advertise ACP extensions.
+    pub fn initialize_meta(&self) -> Option<&acp::Meta> {
+        self.initialize_meta.as_ref()
+    }
+
+    /// Send an extension (`_`-prefixed) method request to the agent and
+    /// return its raw JSON response.
+    pub async fn send_ext_request(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let request = agent_client_protocol::UntypedMessage::new(method, params)
+            .with_context(|| format!("failed to encode {method} request"))?;
+        self.cx
+            .send_request(request)
+            .block_task()
+            .await
+            .with_context(|| format!("{method} request failed"))
     }
 
     /// Take ownership of the ordered ACP event receiver.

--- a/nori-rs/harness/src/backend/goal_ext.rs
+++ b/nori-rs/harness/src/backend/goal_ext.rs
@@ -1,0 +1,415 @@
+//! Bridge types for the ACP `_session/goal` extension.
+//!
+//! The maintained Claude and Codex adapters advertise a goal capability in the
+//! top-level `_meta` of the initialize response and publish goal snapshots in
+//! the `_meta.goal` of `session_info_update` notifications. When the extension
+//! is usable, the agent's native goal loop owns continuation and the harness
+//! mirrors its state into `ThreadGoalState`; the nori-client MCP loop remains
+//! the fallback for agents without the extension (or when an extension call
+//! fails).
+
+use nori_protocol::acp;
+use serde::Deserialize;
+
+use super::thread_goal::GoalStatus;
+use super::thread_goal::ThreadGoalSnapshot;
+use super::thread_goal::ThreadGoalState;
+
+/// Wire value of the only extension version this bridge understands.
+const SUPPORTED_GOAL_EXTENSION_VERSION: u64 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GoalExtAction {
+    Set,
+    Pause,
+    Resume,
+    Clear,
+}
+
+impl GoalExtAction {
+    pub(super) fn wire_name(self) -> &'static str {
+        match self {
+            GoalExtAction::Set => "set",
+            GoalExtAction::Pause => "pause",
+            GoalExtAction::Resume => "resume",
+            GoalExtAction::Clear => "clear",
+        }
+    }
+
+    fn from_wire(name: &str) -> Option<Self> {
+        match name {
+            "set" => Some(GoalExtAction::Set),
+            "pause" => Some(GoalExtAction::Pause),
+            "resume" => Some(GoalExtAction::Resume),
+            "clear" => Some(GoalExtAction::Clear),
+            _ => None,
+        }
+    }
+}
+
+/// Goal capability advertised by the agent at initialize.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct GoalExtCapability {
+    pub(super) control_method: String,
+    pub(super) actions: Vec<GoalExtAction>,
+}
+
+impl GoalExtCapability {
+    /// Parses `_meta.goal` from the initialize response. Returns `None` when
+    /// the capability is absent, malformed, or of an unsupported version —
+    /// callers then fall back to the nori-client MCP goal loop.
+    pub(super) fn from_initialize_meta(meta: Option<&acp::v1::Meta>) -> Option<Self> {
+        #[derive(Deserialize)]
+        struct WireCapability {
+            version: u64,
+            #[serde(rename = "controlMethod")]
+            control_method: String,
+            actions: Vec<String>,
+        }
+
+        let goal = meta?.get("goal")?;
+        let wire: WireCapability = serde_json::from_value(goal.clone()).ok()?;
+        if wire.version != SUPPORTED_GOAL_EXTENSION_VERSION {
+            return None;
+        }
+        if !wire.control_method.starts_with('_') {
+            return None;
+        }
+        // Unknown actions are ignored rather than rejected so newer adapters
+        // stay compatible; `set` is the floor for driving a goal at all.
+        let actions: Vec<GoalExtAction> = wire
+            .actions
+            .iter()
+            .filter_map(|a| GoalExtAction::from_wire(a))
+            .collect();
+        if !actions.contains(&GoalExtAction::Set) || !actions.contains(&GoalExtAction::Clear) {
+            return None;
+        }
+        Some(GoalExtCapability {
+            control_method: wire.control_method,
+            actions,
+        })
+    }
+
+    pub(super) fn supports(&self, action: GoalExtAction) -> bool {
+        self.actions.contains(&action)
+    }
+}
+
+/// One `_meta.goal` value observed on a `session_info_update` notification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum GoalExtUpdate {
+    /// `"goal": null` — the agent-side goal was cleared.
+    Cleared,
+    Snapshot(GoalExtSnapshot),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct GoalExtSnapshot {
+    pub(super) objective: String,
+    pub(super) status: GoalStatus,
+}
+
+/// Extracts a goal update from a `session_info_update` `_meta`, if present.
+/// Returns `None` when there is no `goal` key or the value is malformed
+/// (malformed values are skipped so a buggy adapter cannot wedge goal state).
+pub(super) fn goal_update_from_session_info_meta(
+    meta: Option<&acp::v1::Meta>,
+) -> Option<GoalExtUpdate> {
+    #[derive(Deserialize)]
+    struct WireSnapshot {
+        objective: String,
+        status: String,
+    }
+
+    let goal = meta?.get("goal")?;
+    if goal.is_null() {
+        return Some(GoalExtUpdate::Cleared);
+    }
+    let wire: WireSnapshot = serde_json::from_value(goal.clone()).ok()?;
+    let status = match wire.status.as_str() {
+        "active" => GoalStatus::Active,
+        "paused" => GoalStatus::Paused,
+        "blocked" => GoalStatus::Blocked,
+        // The extension's single "limited" status folds nori's two budget
+        // statuses together; usage-limited is the conservative reading.
+        "limited" => GoalStatus::UsageLimited,
+        "complete" => GoalStatus::Complete,
+        _ => return None,
+    };
+    Some(GoalExtUpdate::Snapshot(GoalExtSnapshot {
+        objective: wire.objective,
+        status,
+    }))
+}
+
+/// Result of mirroring one agent goal update into `ThreadGoalState`.
+#[derive(Debug)]
+pub(super) enum GoalMirrorOutcome {
+    Unchanged,
+    Updated(ThreadGoalSnapshot),
+    Cleared,
+}
+
+/// Mirrors an agent-published goal update into the harness goal store.
+/// A status change on the same objective updates the stored goal in place
+/// (preserving time/token accounting); a new objective replaces it.
+pub(super) fn mirror_update(
+    state: &mut ThreadGoalState,
+    update: &GoalExtUpdate,
+    now: i64,
+) -> GoalMirrorOutcome {
+    match update {
+        GoalExtUpdate::Cleared => {
+            if state.clear() {
+                GoalMirrorOutcome::Cleared
+            } else {
+                GoalMirrorOutcome::Unchanged
+            }
+        }
+        GoalExtUpdate::Snapshot(snapshot) => {
+            let existing = state.snapshot(now);
+            let result = match existing {
+                Some(existing) if existing.objective == snapshot.objective => {
+                    if existing.status == snapshot.status {
+                        return GoalMirrorOutcome::Unchanged;
+                    }
+                    state.set_status(snapshot.status, now)
+                }
+                Some(_) | None => {
+                    state.set_objective(snapshot.objective.clone(), Some(snapshot.status), now)
+                }
+            };
+            match result {
+                Ok(updated) => GoalMirrorOutcome::Updated(updated),
+                Err(error) => {
+                    tracing::warn!("ignoring unusable agent goal snapshot: {error}");
+                    GoalMirrorOutcome::Unchanged
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn meta(value: serde_json::Value) -> acp::v1::Meta {
+        match value {
+            serde_json::Value::Object(map) => map,
+            other => panic!("expected object, got {other}"),
+        }
+    }
+
+    #[test]
+    fn capability_parses_full_codex_advertisement() {
+        let meta = meta(json!({
+            "steering": { "supported": true },
+            "goal": {
+                "version": 1,
+                "controlMethod": "_session/goal",
+                "actions": ["set", "pause", "resume", "clear"],
+            },
+        }));
+        let cap = GoalExtCapability::from_initialize_meta(Some(&meta))
+            .expect("codex-style capability should parse");
+        assert_eq!(cap.control_method, "_session/goal");
+        assert!(cap.supports(GoalExtAction::Set));
+        assert!(cap.supports(GoalExtAction::Pause));
+        assert!(cap.supports(GoalExtAction::Resume));
+        assert!(cap.supports(GoalExtAction::Clear));
+    }
+
+    #[test]
+    fn capability_parses_minimal_claude_advertisement() {
+        let meta = meta(json!({
+            "goal": {
+                "version": 1,
+                "controlMethod": "_session/goal",
+                "actions": ["set", "clear"],
+            },
+        }));
+        let cap = GoalExtCapability::from_initialize_meta(Some(&meta))
+            .expect("claude-style capability should parse");
+        assert!(cap.supports(GoalExtAction::Set));
+        assert!(cap.supports(GoalExtAction::Clear));
+        assert!(!cap.supports(GoalExtAction::Pause));
+        assert!(!cap.supports(GoalExtAction::Resume));
+    }
+
+    #[test]
+    fn capability_rejects_unsupported_version() {
+        let meta = meta(json!({
+            "goal": { "version": 2, "controlMethod": "_session/goal", "actions": ["set", "clear"] },
+        }));
+        assert_eq!(GoalExtCapability::from_initialize_meta(Some(&meta)), None);
+    }
+
+    #[test]
+    fn capability_requires_set_and_clear() {
+        for actions in [json!(["set"]), json!(["clear"])] {
+            let meta = meta(json!({
+                "goal": { "version": 1, "controlMethod": "_session/goal", "actions": actions },
+            }));
+            assert_eq!(GoalExtCapability::from_initialize_meta(Some(&meta)), None);
+        }
+    }
+
+    #[test]
+    fn capability_requires_extension_method_prefix() {
+        let meta = meta(json!({
+            "goal": { "version": 1, "controlMethod": "session/goal", "actions": ["set", "clear"] },
+        }));
+        assert_eq!(GoalExtCapability::from_initialize_meta(Some(&meta)), None);
+    }
+
+    #[test]
+    fn capability_ignores_unknown_actions() {
+        let meta = meta(json!({
+            "goal": {
+                "version": 1,
+                "controlMethod": "_session/goal",
+                "actions": ["set", "clear", "hibernate"],
+            },
+        }));
+        let cap = GoalExtCapability::from_initialize_meta(Some(&meta)).expect("should parse");
+        assert_eq!(cap.actions.len(), 2);
+    }
+
+    #[test]
+    fn capability_absent_meta_is_none() {
+        assert_eq!(GoalExtCapability::from_initialize_meta(None), None);
+        let no_goal = meta(json!({ "steering": { "supported": true } }));
+        assert_eq!(
+            GoalExtCapability::from_initialize_meta(Some(&no_goal)),
+            None
+        );
+    }
+
+    #[test]
+    fn snapshot_parses_each_status() {
+        for (wire, expected) in [
+            ("active", GoalStatus::Active),
+            ("paused", GoalStatus::Paused),
+            ("blocked", GoalStatus::Blocked),
+            ("limited", GoalStatus::UsageLimited),
+            ("complete", GoalStatus::Complete),
+        ] {
+            let meta = meta(json!({
+                "goal": { "objective": "ship it", "status": wire, "iterations": 3 },
+            }));
+            let update = goal_update_from_session_info_meta(Some(&meta))
+                .unwrap_or_else(|| panic!("status {wire} should parse"));
+            assert_eq!(
+                update,
+                GoalExtUpdate::Snapshot(GoalExtSnapshot {
+                    objective: "ship it".to_string(),
+                    status: expected,
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn snapshot_null_goal_is_cleared() {
+        let meta = meta(json!({ "goal": null }));
+        assert_eq!(
+            goal_update_from_session_info_meta(Some(&meta)),
+            Some(GoalExtUpdate::Cleared)
+        );
+    }
+
+    #[test]
+    fn snapshot_missing_goal_key_is_none() {
+        let meta = meta(json!({ "other": 1 }));
+        assert_eq!(goal_update_from_session_info_meta(Some(&meta)), None);
+        assert_eq!(goal_update_from_session_info_meta(None), None);
+    }
+
+    #[test]
+    fn snapshot_unknown_status_is_skipped() {
+        let meta = meta(json!({
+            "goal": { "objective": "ship it", "status": "meditating" },
+        }));
+        assert_eq!(goal_update_from_session_info_meta(Some(&meta)), None);
+    }
+
+    fn snapshot(objective: &str, status: GoalStatus) -> GoalExtUpdate {
+        GoalExtUpdate::Snapshot(GoalExtSnapshot {
+            objective: objective.to_string(),
+            status,
+        })
+    }
+
+    #[test]
+    fn mirror_new_snapshot_creates_goal() {
+        let mut state = ThreadGoalState::default();
+        let outcome = mirror_update(&mut state, &snapshot("ship it", GoalStatus::Active), 100);
+        let GoalMirrorOutcome::Updated(updated) = outcome else {
+            panic!("expected Updated, got {outcome:?}");
+        };
+        assert_eq!(updated.objective, "ship it");
+        assert_eq!(updated.status, GoalStatus::Active);
+        assert!(state.snapshot(100).is_some());
+    }
+
+    #[test]
+    fn mirror_identical_snapshot_is_unchanged() {
+        let mut state = ThreadGoalState::default();
+        mirror_update(&mut state, &snapshot("ship it", GoalStatus::Active), 100);
+        let outcome = mirror_update(&mut state, &snapshot("ship it", GoalStatus::Active), 160);
+        assert!(matches!(outcome, GoalMirrorOutcome::Unchanged));
+    }
+
+    #[test]
+    fn mirror_status_change_keeps_goal_identity() {
+        let mut state = ThreadGoalState::default();
+        mirror_update(&mut state, &snapshot("ship it", GoalStatus::Active), 100);
+        let outcome = mirror_update(&mut state, &snapshot("ship it", GoalStatus::Complete), 160);
+        let GoalMirrorOutcome::Updated(updated) = outcome else {
+            panic!("expected Updated, got {outcome:?}");
+        };
+        assert_eq!(updated.status, GoalStatus::Complete);
+        // Time accrued while active is preserved: the goal was updated in
+        // place, not replaced (a replacement would reset elapsed time to 0).
+        assert_eq!(updated.time_used_seconds, 60);
+    }
+
+    #[test]
+    fn mirror_new_objective_replaces_goal() {
+        let mut state = ThreadGoalState::default();
+        mirror_update(&mut state, &snapshot("ship it", GoalStatus::Active), 100);
+        let outcome = mirror_update(&mut state, &snapshot("test it", GoalStatus::Active), 160);
+        let GoalMirrorOutcome::Updated(updated) = outcome else {
+            panic!("expected Updated, got {outcome:?}");
+        };
+        assert_eq!(updated.objective, "test it");
+        assert_eq!(updated.time_used_seconds, 0);
+    }
+
+    #[test]
+    fn mirror_cleared_drops_goal() {
+        let mut state = ThreadGoalState::default();
+        mirror_update(&mut state, &snapshot("ship it", GoalStatus::Active), 100);
+        assert!(matches!(
+            mirror_update(&mut state, &GoalExtUpdate::Cleared, 160),
+            GoalMirrorOutcome::Cleared
+        ));
+        assert!(state.snapshot(160).is_none());
+        // Clearing an already-empty state reports no change.
+        assert!(matches!(
+            mirror_update(&mut state, &GoalExtUpdate::Cleared, 170),
+            GoalMirrorOutcome::Unchanged
+        ));
+    }
+
+    #[test]
+    fn mirror_empty_objective_is_skipped() {
+        let mut state = ThreadGoalState::default();
+        let outcome = mirror_update(&mut state, &snapshot("   ", GoalStatus::Active), 100);
+        assert!(matches!(outcome, GoalMirrorOutcome::Unchanged));
+        assert!(state.snapshot(100).is_none());
+    }
+}

--- a/nori-rs/harness/src/backend/mod.rs
+++ b/nori-rs/harness/src/backend/mod.rs
@@ -266,6 +266,11 @@ pub struct AcpBackend {
     goal_mcp_connected: Arc<AtomicBool>,
     /// Loopback HTTP server exposing the backend-owned `nori-client` MCP tools.
     goal_mcp_http_server: Arc<Mutex<Option<nori_client_mcp::NoriClientServer>>>,
+    /// True while the agent's native goal loop, driven via the `_session/goal`
+    /// ACP extension, owns continuation for the current goal. While set, the
+    /// harness mirrors agent goal snapshots instead of running its own
+    /// continuation loop.
+    goal_ext_driving: Arc<AtomicBool>,
     /// Transcript recorder cell used by local MCP tools created before the
     /// recorder's session ID is known.
     /// Accumulated context from hook `::context::` lines, prepended to next prompt
@@ -367,6 +372,7 @@ fn session_context_for_connection(
 pub mod browser_profile;
 #[cfg(unix)]
 pub mod browser_session;
+mod goal_ext;
 mod nori_client_context;
 mod nori_client_mcp;
 pub mod probe;
@@ -391,7 +397,10 @@ fn public_nori_capabilities(
     view: crate::normalized::SessionCapabilitiesView,
 ) -> nori_protocol::NoriCapabilities {
     nori_protocol::NoriCapabilities {
-        goal_management: view.nori_client.advertised,
+        goal_management: view
+            .builtin_commands
+            .get("goal")
+            .is_some_and(|command| command.enabled),
         builtin_commands: view.builtin_commands,
     }
 }

--- a/nori-rs/harness/src/backend/nori_client_mcp.rs
+++ b/nori-rs/harness/src/backend/nori_client_mcp.rs
@@ -114,6 +114,7 @@ pub(crate) struct NoriClientShared {
     connected: Arc<AtomicBool>,
     agent_capabilities: crate::normalized::AgentCapabilitiesView,
     nori_client_advertised: bool,
+    goal_ext_advertised: bool,
 }
 
 impl NoriClientShared {
@@ -123,6 +124,7 @@ impl NoriClientShared {
         connected: Arc<AtomicBool>,
         agent_capabilities: crate::normalized::AgentCapabilitiesView,
         nori_client_advertised: bool,
+        goal_ext_advertised: bool,
     ) -> Self {
         Self {
             thread_goal_state,
@@ -130,6 +132,7 @@ impl NoriClientShared {
             connected,
             agent_capabilities,
             nori_client_advertised,
+            goal_ext_advertised,
         }
     }
 }
@@ -288,6 +291,7 @@ impl ServerHandler for NoriClientService {
                 self.shared.agent_capabilities.clone(),
                 self.shared.nori_client_advertised,
                 true,
+                self.shared.goal_ext_advertised,
             );
             let _ = self
                 .shared
@@ -460,10 +464,13 @@ pub(super) fn capabilities_update_for_nori_client(
     nori_client_advertised: bool,
     nori_client_initialized: bool,
 ) -> crate::normalized::SessionCapabilitiesView {
+    let goal_ext_advertised =
+        goal_ext::GoalExtCapability::from_initialize_meta(connection.initialize_meta()).is_some();
     capabilities_update(
         agent_capabilities_view(connection),
         nori_client_advertised,
         nori_client_initialized,
+        goal_ext_advertised,
     )
 }
 
@@ -486,7 +493,9 @@ fn capabilities_update(
     agent: crate::normalized::AgentCapabilitiesView,
     nori_client_advertised: bool,
     nori_client_initialized: bool,
+    goal_ext_advertised: bool,
 ) -> crate::normalized::SessionCapabilitiesView {
+    let goal_available = nori_client_advertised || goal_ext_advertised;
     crate::normalized::SessionCapabilitiesView {
         agent,
         nori_client: crate::normalized::NoriClientCapabilitiesView {
@@ -496,9 +505,9 @@ fn capabilities_update(
         builtin_commands: HashMap::from([(
             "goal".to_string(),
             nori_protocol::CommandAvailability {
-                enabled: nori_client_advertised,
-                reason: (!nori_client_advertised).then(|| {
-                    "The active agent does not advertise HTTP MCP support, so /goal is unavailable."
+                enabled: goal_available,
+                reason: (!goal_available).then(|| {
+                    "The active agent advertises neither HTTP MCP support nor the goal extension, so /goal is unavailable."
                         .to_string()
                 }),
             },
@@ -523,6 +532,7 @@ pub(super) async fn register_for_session(
         Arc::clone(&connected),
         agent_capabilities_view(connection),
         true,
+        goal_ext::GoalExtCapability::from_initialize_meta(connection.initialize_meta()).is_some(),
     ))
     .await?;
     let advertised_server = next_server.as_mcp_server();
@@ -555,6 +565,24 @@ mod tests {
         }
     }
 
+    #[test]
+    fn goal_command_enabled_by_goal_extension_without_nori_client() {
+        let view = capabilities_update(test_agent_capabilities(), false, false, true);
+        let goal = view.builtin_commands.get("goal").expect("goal command");
+        assert!(goal.enabled);
+        assert_eq!(goal.reason, None);
+    }
+
+    #[test]
+    fn goal_command_disabled_without_nori_client_or_goal_extension() {
+        let view = capabilities_update(test_agent_capabilities(), false, false, false);
+        let goal = view.builtin_commands.get("goal").expect("goal command");
+        assert!(!goal.enabled);
+        assert!(goal.reason.as_deref().is_some_and(|reason| {
+            reason.contains("neither HTTP MCP support nor the goal extension")
+        }));
+    }
+
     fn service() -> NoriClientService {
         let (backend_event_tx, _backend_event_rx) = mpsc::channel(8);
         NoriClientService::new(NoriClientShared::new(
@@ -563,6 +591,7 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
             test_agent_capabilities(),
             true,
+            false,
         ))
     }
 
@@ -644,6 +673,7 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
             test_agent_capabilities(),
             true,
+            false,
         ));
 
         let create_result = create(&service, "Ship the ACP goal bridge").await;
@@ -728,6 +758,7 @@ mod tests {
             Arc::clone(&connected),
             test_agent_capabilities(),
             true,
+            false,
         ))
         .await
         .expect("nori-client server should spawn");
@@ -813,6 +844,7 @@ mod tests {
             Arc::clone(&connected),
             test_agent_capabilities(),
             true,
+            false,
         ))
         .await
         .expect("nori-client server should spawn");
@@ -920,6 +952,7 @@ mod tests {
             Arc::clone(&connected),
             test_agent_capabilities(),
             true,
+            false,
         ))
         .await
         .expect("nori-client server should spawn");

--- a/nori-rs/harness/src/backend/session.rs
+++ b/nori-rs/harness/src/backend/session.rs
@@ -636,6 +636,7 @@ impl AcpBackend {
             thread_goal_state,
             goal_mcp_connected,
             goal_mcp_http_server,
+            goal_ext_driving: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             pending_hook_context: Arc::new(Mutex::new(pending_hook_context)),
             transcript_recorder: Arc::new(RwLock::new(transcript_recorder)),
             session_event_tx: session_event_tx.clone(),
@@ -742,7 +743,8 @@ impl AcpBackend {
                 .ok();
         }
 
-        let goal_automation_available = backend.goal_mcp_http_server.lock().await.is_some();
+        let goal_automation_available = backend.goal_mcp_http_server.lock().await.is_some()
+            || backend.goal_ext_capability().is_some();
         let resume_goal_notice = {
             let goals = backend.thread_goal_state.lock().await;
             let now = thread_goal::now_seconds();

--- a/nori-rs/harness/src/backend/session_runtime_driver.rs
+++ b/nori-rs/harness/src/backend/session_runtime_driver.rs
@@ -556,6 +556,15 @@ impl AcpBackend {
             return;
         }
 
+        // The agent's native goal loop owns continuation while the
+        // `_session/goal` extension drives this goal.
+        if self
+            .goal_ext_driving
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return;
+        }
+
         // Safety invariant: a hidden continuation may only chain after another
         // hidden continuation once we have observed the agent actually connect to
         // the `nori-client` MCP endpoint (`goal.connected`). Until then the agent
@@ -578,6 +587,12 @@ impl AcpBackend {
     }
 
     pub(super) async fn submit_goal_continuation_if_idle(&self) {
+        if self
+            .goal_ext_driving
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return;
+        }
         if self.goal_mcp_http_server.lock().await.is_none() {
             return;
         }

--- a/nori-rs/harness/src/backend/spawn_and_relay.rs
+++ b/nori-rs/harness/src/backend/spawn_and_relay.rs
@@ -249,6 +249,7 @@ impl AcpBackend {
             thread_goal_state,
             goal_mcp_connected,
             goal_mcp_http_server,
+            goal_ext_driving: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             pending_hook_context: Arc::new(Mutex::new(pending_hook_context)),
             transcript_recorder: Arc::new(RwLock::new(transcript_recorder)),
             session_event_tx: session_event_tx.clone(),
@@ -369,6 +370,7 @@ impl AcpBackend {
                     match maybe_event {
                         Some(crate::connection::ConnectionEvent::SessionUpdate(update)) => {
                             backend.wait_for_prompt_phase().await;
+                            backend.observe_session_update_for_goal_ext(&update).await;
                             relay_seq += 1;
                             debug!(
                                 target: "acp_event_flow",
@@ -523,6 +525,7 @@ impl AcpBackend {
                                             .await;
                                     }
                                     crate::connection::ConnectionEvent::SessionUpdate(update) => {
+                                        backend.observe_session_update_for_goal_ext(&update).await;
                                         relay_seq += 1;
                                         debug!(
                                             target: "acp_event_flow",

--- a/nori-rs/harness/src/backend/thread_goal.rs
+++ b/nori-rs/harness/src/backend/thread_goal.rs
@@ -406,17 +406,55 @@ impl AcpBackend {
         objective: String,
         status: Option<nori_protocol::ThreadGoalStatus>,
     ) -> Result<nori_protocol::ThreadGoal> {
-        if !self.goal_automation_available().await {
+        let status = status.map(status_from_client);
+        // A non-active initial status cannot be expressed over the goal
+        // extension, so such goals always use the nori-client loop.
+        let ext = match status {
+            None | Some(GoalStatus::Active) => self.goal_ext_capability(),
+            Some(_) => None,
+        };
+        let mcp_available = self.goal_automation_available().await;
+        if ext.is_none() && !mcp_available {
             anyhow::bail!("goal management is unavailable for this session");
         }
-        let status = status.map(status_from_client);
-        let goal = self
-            .thread_goal_state
-            .lock()
-            .await
-            .set_objective(objective, status, now_seconds())
-            .map_err(anyhow::Error::msg)?;
-        let should_start = goal.status == GoalStatus::Active;
+        let mut ext_driving = false;
+        if let Some(capability) = &ext {
+            match self
+                .drive_goal_ext(capability, goal_ext::GoalExtAction::Set, Some(&objective))
+                .await
+            {
+                Ok(()) => ext_driving = true,
+                Err(error) if mcp_available => {
+                    tracing::warn!(
+                        "goal extension set failed; falling back to the nori-client goal loop: {error:#}"
+                    );
+                }
+                Err(error) => {
+                    return Err(error.context(
+                        "the agent rejected the goal extension request and the nori-client fallback is unavailable",
+                    ));
+                }
+            }
+        }
+        self.goal_ext_driving
+            .store(ext_driving, std::sync::atomic::Ordering::Relaxed);
+        let goal = {
+            let mut state = self.thread_goal_state.lock().await;
+            let mirrored = ext_driving
+                .then(|| state.snapshot(now_seconds()))
+                .flatten()
+                .filter(|existing| existing.objective == objective);
+            match mirrored {
+                // The agent already published a snapshot for this goal while
+                // the extension request was in flight; that mirror is
+                // authoritative, so don't clobber its status.
+                Some(existing) => existing,
+                None => state
+                    .set_objective(objective, status, now_seconds())
+                    .map_err(anyhow::Error::msg)?,
+            }
+        };
+        let should_start = goal.status == GoalStatus::Active && !ext_driving;
         let goal = goal.into_client_goal();
         self.emit_goal_changed(Some(goal.clone())).await;
         if should_start {
@@ -426,8 +464,22 @@ impl AcpBackend {
     }
 
     pub(crate) async fn clear_goal(&self) -> Result<()> {
-        if !self.goal_automation_available().await {
+        let ext = self.goal_ext_capability();
+        if ext.is_none() && !self.goal_automation_available().await {
             anyhow::bail!("goal management is unavailable for this session");
+        }
+        if self
+            .goal_ext_driving
+            .swap(false, std::sync::atomic::Ordering::Relaxed)
+            && let Some(capability) = &ext
+            && let Err(error) = self
+                .drive_goal_ext(capability, goal_ext::GoalExtAction::Clear, None)
+                .await
+        {
+            // The local clear still proceeds: the mirrored goal is gone either
+            // way, and a failed native clear only leaves the agent loop to
+            // wind down on its own.
+            tracing::warn!("goal extension clear failed: {error:#}");
         }
         if self.thread_goal_state.lock().await.clear() {
             self.emit_goal_changed(None).await;
@@ -439,22 +491,111 @@ impl AcpBackend {
         &self,
         status: nori_protocol::ThreadGoalStatus,
     ) -> Result<nori_protocol::ThreadGoal> {
-        if !self.goal_automation_available().await {
+        let internal_status = status_from_client(status);
+        let ext = self.goal_ext_capability();
+        if ext.is_none() && !self.goal_automation_available().await {
             anyhow::bail!("goal management is unavailable for this session");
+        }
+        let ext_driving = self
+            .goal_ext_driving
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if ext_driving {
+            let action = match internal_status {
+                GoalStatus::Paused => Some(goal_ext::GoalExtAction::Pause),
+                GoalStatus::Active => Some(goal_ext::GoalExtAction::Resume),
+                GoalStatus::Blocked
+                | GoalStatus::UsageLimited
+                | GoalStatus::BudgetLimited
+                | GoalStatus::Complete => None,
+            };
+            match (&ext, action) {
+                (Some(capability), Some(action)) if capability.supports(action) => {
+                    // Failing hard keeps the harness mirror from silently
+                    // diverging from the agent's native goal loop.
+                    self.drive_goal_ext(capability, action, None).await?;
+                }
+                (Some(_), Some(_)) | (Some(_), None) | (None, _) => {
+                    anyhow::bail!(
+                        "the active agent's goal extension does not support this status change"
+                    );
+                }
+            }
         }
         let goal = self
             .thread_goal_state
             .lock()
             .await
-            .set_status(status_from_client(status), now_seconds())
+            .set_status(internal_status, now_seconds())
             .map_err(anyhow::Error::msg)?;
-        let should_start = goal.status == GoalStatus::Active;
+        let should_start = goal.status == GoalStatus::Active && !ext_driving;
         let goal = goal.into_client_goal();
         self.emit_goal_changed(Some(goal.clone())).await;
         if should_start {
             self.submit_goal_continuation_if_idle().await;
         }
         Ok(goal)
+    }
+
+    /// Parses the goal extension capability the agent advertised at
+    /// initialize, if any.
+    pub(super) fn goal_ext_capability(&self) -> Option<goal_ext::GoalExtCapability> {
+        goal_ext::GoalExtCapability::from_initialize_meta(self.connection.initialize_meta())
+    }
+
+    async fn drive_goal_ext(
+        &self,
+        capability: &goal_ext::GoalExtCapability,
+        action: goal_ext::GoalExtAction,
+        objective: Option<&str>,
+    ) -> Result<()> {
+        let session_id = self.session_id.read().await.clone();
+        let mut params = serde_json::json!({
+            "sessionId": session_id,
+            "action": action.wire_name(),
+        });
+        if let Some(objective) = objective {
+            params["objective"] = serde_json::Value::String(objective.to_string());
+        }
+        self.connection
+            .send_ext_request(&capability.control_method, params)
+            .await
+            .map(|_| ())
+    }
+
+    /// Mirrors goal snapshots the agent publishes on `session_info_update`
+    /// notifications into the harness goal store. A non-null snapshot proves
+    /// the agent's native goal loop owns continuation for this goal.
+    pub(super) async fn observe_session_update_for_goal_ext(&self, update: &acp::SessionUpdate) {
+        let acp::SessionUpdate::SessionInfoUpdate(info) = update else {
+            return;
+        };
+        let Some(goal_update) = goal_ext::goal_update_from_session_info_meta(info.meta.as_ref())
+        else {
+            return;
+        };
+        let outcome = {
+            let mut state = self.thread_goal_state.lock().await;
+            goal_ext::mirror_update(&mut state, &goal_update, now_seconds())
+        };
+        match outcome {
+            goal_ext::GoalMirrorOutcome::Unchanged => {
+                if matches!(goal_update, goal_ext::GoalExtUpdate::Snapshot(_)) {
+                    self.goal_ext_driving
+                        .store(true, std::sync::atomic::Ordering::Relaxed);
+                }
+            }
+            goal_ext::GoalMirrorOutcome::Updated(snapshot) => {
+                self.goal_ext_driving
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                self.emit_goal_changed(Some(snapshot.into_client_goal()))
+                    .await;
+            }
+            goal_ext::GoalMirrorOutcome::Cleared => {
+                self.goal_ext_driving
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
+                self.emit_goal_changed(None).await;
+            }
+        }
     }
 
     pub(super) async fn thread_goal_update_from_client_event(
@@ -476,6 +617,14 @@ impl AcpBackend {
     }
 
     pub(super) async fn prepend_goal_context_to_prompt(&self, prompt: String) -> String {
+        // While the agent's native goal loop drives, it owns goal context and
+        // the nori-client instructions would point at the wrong control plane.
+        if self
+            .goal_ext_driving
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return prompt;
+        }
         if !self.goal_automation_available().await {
             return prompt;
         }

--- a/nori-rs/harness/tests/goal_ext_bridge.rs
+++ b/nori-rs/harness/tests/goal_ext_bridge.rs
@@ -1,0 +1,225 @@
+//! End-to-end behavior of the `_session/goal` extension bridge.
+//!
+//! Drives a real harness session against the mock ACP agent with the goal
+//! extension advertised and observes only external behavior: emitted
+//! `SessionEvent`s and the recorded ACP wire log. Verifies that the harness
+//! drives the goal through the extension, mirrors agent-published snapshots,
+//! and never starts its own goal-continuation loop while the agent's native
+//! loop owns the goal.
+
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use nori_config::NoriConfig;
+use nori_harness::runtime::LaunchedSession;
+use nori_harness::runtime::SessionLaunchSpec;
+use nori_harness::runtime::launch_session;
+use nori_protocol::NoriEvent;
+use nori_protocol::SessionEvent;
+use nori_protocol::ThreadGoal;
+use nori_protocol::ThreadGoalStatus;
+use pretty_assertions::assert_eq;
+use serial_test::serial;
+
+struct EnvGuard(&'static str);
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: tests that mutate the mock-agent environment run serially.
+        unsafe { std::env::remove_var(self.0) };
+    }
+}
+
+fn set_mock_env(name: &'static str) -> EnvGuard {
+    // SAFETY: tests that mutate the mock-agent environment run serially.
+    unsafe { std::env::set_var(name, "1") };
+    EnvGuard(name)
+}
+
+fn launch_with_wire_log(cwd: &Path, wire_log_dir: &Path) -> LaunchedSession {
+    let config = NoriConfig {
+        active_agent: "mock-model".to_string(),
+        cwd: cwd.to_path_buf(),
+        nori_home: cwd.to_path_buf(),
+        acp_proxy: nori_config::AcpProxyConfig {
+            enabled: true,
+            log_dir: wire_log_dir.to_path_buf(),
+        },
+        ..Default::default()
+    };
+    launch_session(SessionLaunchSpec {
+        config: Arc::new(config),
+        cli_version: "goal-ext-bridge-test".to_string(),
+        session_context: None,
+        initial_context: None,
+        resume: None,
+    })
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "focused failures for a missing bootstrap"
+)]
+async fn wait_for_started(session: &mut LaunchedSession) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            match session.events.recv().await.expect("event stream closed") {
+                SessionEvent::Nori(NoriEvent::SessionStarted(_)) => return,
+                SessionEvent::Nori(NoriEvent::RequestFailed(failure)) => {
+                    panic!("session bootstrap failed: {failure:?}");
+                }
+                SessionEvent::Acp(_) | SessionEvent::Nori(_) => {}
+            }
+        }
+    })
+    .await
+    .expect("session should start");
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "focused failures for a missing goal event"
+)]
+async fn wait_for_goal_status(
+    session: &mut LaunchedSession,
+    status: ThreadGoalStatus,
+) -> ThreadGoal {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            match session.events.recv().await.expect("event stream closed") {
+                SessionEvent::Nori(NoriEvent::GoalChanged(Some(goal))) if goal.status == status => {
+                    return goal;
+                }
+                SessionEvent::Acp(_) | SessionEvent::Nori(_) => {}
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("goal should reach status {status:?}"))
+}
+
+#[expect(
+    clippy::expect_used,
+    reason = "focused failures for a missing goal event"
+)]
+async fn wait_for_goal_cleared(session: &mut LaunchedSession) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            match session.events.recv().await.expect("event stream closed") {
+                SessionEvent::Nori(NoriEvent::GoalChanged(None)) => return,
+                SessionEvent::Acp(_) | SessionEvent::Nori(_) => {}
+            }
+        }
+    })
+    .await
+    .expect("goal should clear");
+}
+
+/// The recorded `session/prompt` params that reached the agent, in order.
+#[expect(
+    clippy::expect_used,
+    reason = "focused failures for a missing wire log"
+)]
+fn recorded_prompts(wire_log_dir: &Path) -> Vec<serde_json::Value> {
+    let mut wire_logs = std::fs::read_dir(wire_log_dir)
+        .expect("wire log directory")
+        .map(|entry| entry.expect("wire log entry").path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "jsonl")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        wire_logs.len(),
+        1,
+        "one ACP child should produce one wire log"
+    );
+    let wire_log = wire_logs.pop().expect("ACP wire log");
+    std::fs::read_to_string(wire_log)
+        .expect("read ACP wire log")
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("valid wire log line"))
+        .filter(|record| {
+            record["direction"] == "client_to_agent"
+                && record["message"]["method"] == "session/prompt"
+        })
+        .map(|record| record["message"]["params"].clone())
+        .collect()
+}
+
+#[expect(clippy::expect_used, reason = "focused failure for a missing tempdir")]
+fn temp_dirs() -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::tempdir().expect("create session directory");
+    let wire_log_dir = temp.path().join("wire-logs");
+    (temp, wire_log_dir)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn goal_extension_drives_goal_and_suppresses_harness_continuation() {
+    let _goal_ext = set_mock_env("MOCK_AGENT_GOAL_EXT");
+    let _autocomplete = set_mock_env("MOCK_AGENT_GOAL_EXT_AUTOCOMPLETE");
+    let (temp, wire_log_dir) = temp_dirs();
+
+    let mut session = launch_with_wire_log(temp.path(), &wire_log_dir);
+    wait_for_started(&mut session).await;
+
+    // Setting the goal drives the extension. The mock completes the goal the
+    // moment it accepts it, so the returned mirror may already be past
+    // `Active`; the objective is what set_goal guarantees.
+    let goal = session
+        .handle
+        .set_goal("finish the demo".to_string(), None)
+        .await
+        .expect("set_goal should succeed via the goal extension");
+    assert_eq!(goal.objective, "finish the demo");
+
+    // The mock's native loop completes the goal on its own; the harness
+    // mirrors the published snapshot into its store and event stream.
+    let completed = wait_for_goal_status(&mut session, ThreadGoalStatus::Complete).await;
+    assert_eq!(completed.objective, "finish the demo");
+    let current = session.handle.goal().await.expect("goal query");
+    assert_eq!(
+        current.map(|goal| goal.status),
+        Some(ThreadGoalStatus::Complete)
+    );
+
+    // The harness continuation loop stayed off while the extension drove the
+    // goal: no prompt of any kind (goal continuations included) reached the
+    // agent.
+    assert_eq!(
+        recorded_prompts(&wire_log_dir),
+        Vec::<serde_json::Value>::new()
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial]
+async fn goal_extension_clear_round_trips() {
+    let _goal_ext = set_mock_env("MOCK_AGENT_GOAL_EXT");
+    let (temp, wire_log_dir) = temp_dirs();
+
+    let mut session = launch_with_wire_log(temp.path(), &wire_log_dir);
+    wait_for_started(&mut session).await;
+
+    let goal = session
+        .handle
+        .set_goal("keep going".to_string(), None)
+        .await
+        .expect("set_goal should succeed via the goal extension");
+    assert_eq!(goal.status, ThreadGoalStatus::Active);
+    // Drain the agent's "active" snapshot through the relay before clearing,
+    // so the mirrored snapshot cannot resurrect the goal after the clear.
+    wait_for_goal_status(&mut session, ThreadGoalStatus::Active).await;
+
+    session.handle.clear_goal().await.expect("clear_goal");
+    wait_for_goal_cleared(&mut session).await;
+    let current = session.handle.goal().await.expect("goal query");
+    assert_eq!(current, None);
+    assert_eq!(
+        recorded_prompts(&wire_log_dir),
+        Vec::<serde_json::Value>::new()
+    );
+}

--- a/nori-rs/mock-acp-agent/src/main.rs
+++ b/nori-rs/mock-acp-agent/src/main.rs
@@ -1446,6 +1446,20 @@ async fn main() -> acp::Result<()> {
                     response = response.agent_capabilities(capabilities);
                 }
 
+                if std::env::var("MOCK_AGENT_GOAL_EXT").is_ok() {
+                    eprintln!("Mock agent: advertising the _session/goal goal extension");
+                    let mut meta = serde_json::Map::new();
+                    meta.insert(
+                        "goal".to_string(),
+                        serde_json::json!({
+                            "version": 1,
+                            "controlMethod": "_session/goal",
+                            "actions": ["set", "pause", "resume", "clear"],
+                        }),
+                    );
+                    response.meta = Some(meta);
+                }
+
                 responder.respond(response)
             },
             agent_client_protocol::on_receive_request!(),
@@ -1749,6 +1763,81 @@ async fn main() -> acp::Result<()> {
                             .respond(acp::SetSessionConfigOptionResponse::new(options)),
                         Err(error) => responder.respond_with_error(error),
                     }
+                }
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                // Native goal store for the `_session/goal` extension. Matches
+                // any method (untyped fallback), so it must stay registered
+                // after every typed request handler.
+                let goal_objective: Arc<std::sync::Mutex<Option<String>>> =
+                    Arc::new(std::sync::Mutex::new(None));
+                async move |arguments: agent_client_protocol::UntypedMessage,
+                            responder: Responder<serde_json::Value>,
+                            cx: ConnectionTo<Client>| {
+                    // The crate strips the leading underscore from ext methods
+                    // on some parse paths; accept both spellings.
+                    let is_goal_method =
+                        matches!(arguments.method(), "_session/goal" | "session/goal");
+                    if !is_goal_method || std::env::var("MOCK_AGENT_GOAL_EXT").is_err() {
+                        return responder.respond_with_error(acp::Error::method_not_found());
+                    }
+                    let params = arguments.params.clone();
+                    let session_id = params
+                        .get("sessionId")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    let action = params
+                        .get("action")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    eprintln!("Mock agent: _session/goal action={action}");
+                    if action == "set" {
+                        *goal_objective.lock().unwrap() = params
+                            .get("objective")
+                            .and_then(serde_json::Value::as_str)
+                            .map(str::to_string);
+                    }
+                    let objective = goal_objective.lock().unwrap().clone().unwrap_or_default();
+                    let goal_value = match action.as_str() {
+                        "set" | "resume" => {
+                            serde_json::json!({ "objective": objective, "status": "active" })
+                        }
+                        "pause" => {
+                            serde_json::json!({ "objective": objective, "status": "paused" })
+                        }
+                        "clear" => {
+                            goal_objective.lock().unwrap().take();
+                            serde_json::Value::Null
+                        }
+                        _ => return responder.respond_with_error(acp::Error::invalid_params()),
+                    };
+                    let snapshot_update = |goal: serde_json::Value| {
+                        let mut meta = serde_json::Map::new();
+                        meta.insert("goal".to_string(), goal);
+                        let mut info = acp::SessionInfoUpdate::new();
+                        info.meta = Some(meta);
+                        acp::SessionUpdate::SessionInfoUpdate(info)
+                    };
+                    let _ = cx.send_notification(acp::SessionNotification::new(
+                        acp::SessionId::new(session_id.clone()),
+                        snapshot_update(goal_value),
+                    ));
+                    if action == "set" && std::env::var("MOCK_AGENT_GOAL_EXT_AUTOCOMPLETE").is_ok()
+                    {
+                        eprintln!("Mock agent: auto-completing goal");
+                        let _ = cx.send_notification(acp::SessionNotification::new(
+                            acp::SessionId::new(session_id),
+                            snapshot_update(
+                                serde_json::json!({ "objective": objective, "status": "complete" }),
+                            ),
+                        ));
+                    }
+                    responder.respond(serde_json::json!({}))
                 }
             },
             agent_client_protocol::on_receive_request!(),


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- When an ACP agent advertises the goal extension (`goal: {version: 1, controlMethod: "_session/goal", actions}` in the top-level `_meta` of its initialize response), `/goal` drives the agent's native goal loop through `_session/goal` and the harness suppresses its own goal-continuation loop and `<goal_context>`/`<goal_control>` prompt injection. `ThreadGoalState` stays the source of truth: agent-published snapshots (`session_info_update` `_meta.goal`) are mirrored into it and re-emitted as `GoalChanged` events. In-flight-snapshot races are handled (`set_goal` defers to the mirror if the agent already published for the same objective).
- The nori-client MCP goal loop (#576) is unchanged and remains the fallback: agents without the extension behave exactly as before, and an extension call failure falls back to the MCP loop when available. Codex (native goals disabled via `CODEX_CONFIG`) keeps routing through nori-client; extension-capable agents without HTTP MCP now get `/goal` instead of a disabled command. `/goal pause`/`resume` map to extension actions and fail explicitly when the agent doesn't advertise them.
- Plumbing: acp-host retains the initialize response's top-level `_meta` (`initialize_meta()`) and gains a generic `send_ext_request()`; the mock ACP agent gains env-gated goal-extension support (`MOCK_AGENT_GOAL_EXT`, `MOCK_AGENT_GOAL_EXT_AUTOCOMPLETE`) used by two new end-to-end tests that assert (via the recorded ACP wire log) that zero prompts reach the agent while the native loop drives.

## Test Plan
- [x] `cargo test -p nori-harness` — 291 lib tests (17 new goal_ext unit tests, 2 new capability-gating tests) + integration suites, all passing
- [x] `cargo test -p nori-harness --test goal_ext_bridge` — new end-to-end coverage: extension-driven set→auto-complete mirroring with continuation suppression, and clear round-trip
- [x] `cargo test -p nori-acp-host` — 73 passing
- [x] `cargo build --bin nori && cargo test -p tui-pty-e2e` — passing
- [x] `just fmt` + `just fix -p` on all three touched crates — clean

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets