### PR TITLE
refactor(harness): move goal-ext driving state under the goal mutex

### DIFF
--- a/nori-rs/harness/src/backend/goal_ext.rs
+++ b/nori-rs/harness/src/backend/goal_ext.rs
@@ -16,7 +16,7 @@ use super::thread_goal::ThreadGoalSnapshot;
 use super::thread_goal::ThreadGoalState;
 
 /// Wire value of the only extension version this bridge understands.
-const SUPPORTED_GOAL_EXTENSION_VERSION: u64 = 1;
+const SUPPORTED_GOAL_EXTENSION_VERSION: i64 = 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum GoalExtAction {
@@ -61,7 +61,7 @@ impl GoalExtCapability {
     pub(super) fn from_initialize_meta(meta: Option<&acp::v1::Meta>) -> Option<Self> {
         #[derive(Deserialize)]
         struct WireCapability {
-            version: u64,
+            version: i64,
             #[serde(rename = "controlMethod")]
             control_method: String,
             actions: Vec<String>,
@@ -154,13 +154,26 @@ pub(super) enum GoalMirrorOutcome {
 /// Mirrors an agent-published goal update into the harness goal store.
 /// A status change on the same objective updates the stored goal in place
 /// (preserving time/token accounting); a new objective replaces it.
+///
+/// Guards keep a stale or competing native loop from corrupting the store:
+/// nothing is mirrored while snapshots are blocked (harness stopped driving),
+/// a snapshot for a different objective is ignored unless the extension
+/// already owns the goal, and a null snapshot only clears extension-owned
+/// goals.
 pub(super) fn mirror_update(
     state: &mut ThreadGoalState,
     update: &GoalExtUpdate,
     now: i64,
 ) -> GoalMirrorOutcome {
+    if state.ext_snapshots_blocked() {
+        return GoalMirrorOutcome::Unchanged;
+    }
     match update {
         GoalExtUpdate::Cleared => {
+            if !state.ext_driven() {
+                return GoalMirrorOutcome::Unchanged;
+            }
+            state.ext_cleared_by_agent();
             if state.clear() {
                 GoalMirrorOutcome::Cleared
             } else {
@@ -169,9 +182,17 @@ pub(super) fn mirror_update(
         }
         GoalExtUpdate::Snapshot(snapshot) => {
             let existing = state.snapshot(now);
+            if !state.ext_driven()
+                && existing
+                    .as_ref()
+                    .is_some_and(|existing| existing.objective != snapshot.objective)
+            {
+                return GoalMirrorOutcome::Unchanged;
+            }
             let result = match existing {
                 Some(existing) if existing.objective == snapshot.objective => {
                     if existing.status == snapshot.status {
+                        state.mark_ext_driven();
                         return GoalMirrorOutcome::Unchanged;
                     }
                     state.set_status(snapshot.status, now)
@@ -181,7 +202,10 @@ pub(super) fn mirror_update(
                 }
             };
             match result {
-                Ok(updated) => GoalMirrorOutcome::Updated(updated),
+                Ok(updated) => {
+                    state.mark_ext_driven();
+                    GoalMirrorOutcome::Updated(updated)
+                }
                 Err(error) => {
                     tracing::warn!("ignoring unusable agent goal snapshot: {error}");
                     GoalMirrorOutcome::Unchanged
@@ -402,6 +426,57 @@ mod tests {
         assert!(matches!(
             mirror_update(&mut state, &GoalExtUpdate::Cleared, 170),
             GoalMirrorOutcome::Unchanged
+        ));
+    }
+
+    #[test]
+    fn mirror_blocked_ignores_snapshots_and_clears() {
+        let mut state = ThreadGoalState::default();
+        mirror_update(&mut state, &snapshot("ship it", GoalStatus::Active), 100);
+        state.stop_ext_driving();
+        assert!(matches!(
+            mirror_update(&mut state, &snapshot("ship it", GoalStatus::Complete), 160),
+            GoalMirrorOutcome::Unchanged
+        ));
+        assert!(matches!(
+            mirror_update(&mut state, &GoalExtUpdate::Cleared, 170),
+            GoalMirrorOutcome::Unchanged
+        ));
+        assert!(state.snapshot(170).is_some());
+        assert!(!state.ext_driven());
+    }
+
+    #[test]
+    fn mirror_does_not_hijack_foreign_goal() {
+        let mut state = ThreadGoalState::default();
+        state
+            .set_objective("mcp goal".to_string(), None, 100)
+            .expect("set local goal");
+        // Not ext-driven: a snapshot for a different objective must not steal
+        // the goal, and a null snapshot must not clear it.
+        assert!(matches!(
+            mirror_update(&mut state, &snapshot("other goal", GoalStatus::Active), 160),
+            GoalMirrorOutcome::Unchanged
+        ));
+        assert!(!state.ext_driven());
+        assert!(matches!(
+            mirror_update(&mut state, &GoalExtUpdate::Cleared, 170),
+            GoalMirrorOutcome::Unchanged
+        ));
+        assert!(state.snapshot(170).is_some());
+    }
+
+    #[test]
+    fn mirror_marks_ext_driven_and_agent_clear_reopens() {
+        let mut state = ThreadGoalState::default();
+        mirror_update(&mut state, &snapshot("ship it", GoalStatus::Active), 100);
+        assert!(state.ext_driven());
+        mirror_update(&mut state, &GoalExtUpdate::Cleared, 160);
+        assert!(!state.ext_driven());
+        assert!(!state.ext_snapshots_blocked());
+        assert!(matches!(
+            mirror_update(&mut state, &snapshot("next", GoalStatus::Active), 170),
+            GoalMirrorOutcome::Updated(_)
         ));
     }
 

--- a/nori-rs/harness/src/backend/mod.rs
+++ b/nori-rs/harness/src/backend/mod.rs
@@ -266,13 +266,9 @@ pub struct AcpBackend {
     goal_mcp_connected: Arc<AtomicBool>,
     /// Loopback HTTP server exposing the backend-owned `nori-client` MCP tools.
     goal_mcp_http_server: Arc<Mutex<Option<nori_client_mcp::NoriClientServer>>>,
-    /// True while the agent's native goal loop, driven via the `_session/goal`
-    /// ACP extension, owns continuation for the current goal. While set, the
-    /// harness mirrors agent goal snapshots instead of running its own
-    /// continuation loop.
-    goal_ext_driving: Arc<AtomicBool>,
-    /// Transcript recorder cell used by local MCP tools created before the
-    /// recorder's session ID is known.
+    /// Goal extension capability the agent advertised at initialize, parsed
+    /// once. `Some` enables driving goals via `_session/goal`.
+    goal_ext_capability: Option<goal_ext::GoalExtCapability>,
     /// Accumulated context from hook `::context::` lines, prepended to next prompt
     pending_hook_context: Arc<Mutex<Option<String>>>,
     /// Transcript recorder for session persistence.

--- a/nori-rs/harness/src/backend/session.rs
+++ b/nori-rs/harness/src/backend/session.rs
@@ -618,6 +618,8 @@ impl AcpBackend {
             .and_then(|recorder| ConversationId::from_string(recorder.session_id()).ok())
             .unwrap_or_default();
         let pending_hook_context = session_context_for_connection(config, &connection);
+        let goal_ext_capability =
+            goal_ext::GoalExtCapability::from_initialize_meta(connection.initialize_meta());
         let backend = Self {
             connection,
             session_id: Arc::new(RwLock::new(session_id)),
@@ -636,7 +638,7 @@ impl AcpBackend {
             thread_goal_state,
             goal_mcp_connected,
             goal_mcp_http_server,
-            goal_ext_driving: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            goal_ext_capability,
             pending_hook_context: Arc::new(Mutex::new(pending_hook_context)),
             transcript_recorder: Arc::new(RwLock::new(transcript_recorder)),
             session_event_tx: session_event_tx.clone(),

--- a/nori-rs/harness/src/backend/session_runtime_driver.rs
+++ b/nori-rs/harness/src/backend/session_runtime_driver.rs
@@ -558,10 +558,7 @@ impl AcpBackend {
 
         // The agent's native goal loop owns continuation while the
         // `_session/goal` extension drives this goal.
-        if self
-            .goal_ext_driving
-            .load(std::sync::atomic::Ordering::Relaxed)
-        {
+        if self.thread_goal_state.lock().await.ext_driven() {
             return;
         }
 
@@ -587,10 +584,7 @@ impl AcpBackend {
     }
 
     pub(super) async fn submit_goal_continuation_if_idle(&self) {
-        if self
-            .goal_ext_driving
-            .load(std::sync::atomic::Ordering::Relaxed)
-        {
+        if self.thread_goal_state.lock().await.ext_driven() {
             return;
         }
         if self.goal_mcp_http_server.lock().await.is_none() {

--- a/nori-rs/harness/src/backend/session_swap.rs
+++ b/nori-rs/harness/src/backend/session_swap.rs
@@ -86,6 +86,12 @@ impl AcpBackend {
                     server.commit(&self.goal_mcp_http_server).await;
                 }
                 debug!("Swapped active ACP session: {:?}", new_session_id);
+                // An extension-driven goal belongs to the previous ACP
+                // session; its native loop cannot follow the swap. Stop
+                // mirroring (and best-effort clear the old loop, while
+                // `session_id` still names the old session) so the
+                // nori-client loop can take the local goal back over.
+                self.stop_stale_ext_goal().await;
                 *self.session_id.write().await = new_session_id.clone();
                 if matches!(mode, SessionSwapMode::ForkFromHead { .. }) {
                     self.fork_transcript(&new_session_id).await;

--- a/nori-rs/harness/src/backend/spawn_and_relay.rs
+++ b/nori-rs/harness/src/backend/spawn_and_relay.rs
@@ -231,6 +231,8 @@ impl AcpBackend {
             .and_then(|recorder| ConversationId::from_string(recorder.session_id()).ok())
             .unwrap_or_default();
         let pending_hook_context = session_context_for_connection(config, &connection);
+        let goal_ext_capability =
+            goal_ext::GoalExtCapability::from_initialize_meta(connection.initialize_meta());
         let backend = Self {
             connection,
             session_id: Arc::new(RwLock::new(session_id)),
@@ -249,7 +251,7 @@ impl AcpBackend {
             thread_goal_state,
             goal_mcp_connected,
             goal_mcp_http_server,
-            goal_ext_driving: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            goal_ext_capability,
             pending_hook_context: Arc::new(Mutex::new(pending_hook_context)),
             transcript_recorder: Arc::new(RwLock::new(transcript_recorder)),
             session_event_tx: session_event_tx.clone(),

--- a/nori-rs/harness/src/backend/thread_goal.rs
+++ b/nori-rs/harness/src/backend/thread_goal.rs
@@ -91,6 +91,13 @@ struct StoredThreadGoal {
 pub(crate) struct ThreadGoalState {
     goal: Option<StoredThreadGoal>,
     last_session_used_tokens: Option<i64>,
+    /// True while the agent's native goal loop (driven via the
+    /// `_session/goal` extension) owns continuation for the current goal.
+    ext_driven: bool,
+    /// True from the moment the harness stops extension-driving (clear, swap,
+    /// or fallback) until the next extension-driven goal; snapshots from a
+    /// stale native loop are ignored while set.
+    ext_snapshots_blocked: bool,
 }
 
 pub(crate) fn unavailable_notice() -> SessionUpdateInfo {
@@ -98,7 +105,7 @@ pub(crate) fn unavailable_notice() -> SessionUpdateInfo {
         kind: SessionUpdateKind::SessionInfo,
         message: "/goal is unavailable for this session.".to_string(),
         hint: Some(
-            "The active agent does not advertise HTTP MCP support, so it cannot use the nori-client goal tools to close the loop."
+            "The active agent advertises neither HTTP MCP support nor the goal extension, so it cannot close the goal loop."
                 .to_string(),
         ),
         usage: None,
@@ -287,6 +294,34 @@ Before deciding that the goal is achieved, treat completion as unproven and veri
         self.goal.take().is_some()
     }
 
+    pub(crate) fn ext_driven(&self) -> bool {
+        self.ext_driven
+    }
+
+    pub(crate) fn ext_snapshots_blocked(&self) -> bool {
+        self.ext_snapshots_blocked
+    }
+
+    /// The extension now owns the current goal; agent snapshots are mirrored.
+    pub(crate) fn mark_ext_driven(&mut self) {
+        self.ext_driven = true;
+        self.ext_snapshots_blocked = false;
+    }
+
+    /// The harness stops extension-driving (clear, swap, or fallback). Blocks
+    /// mirroring so a stale native loop cannot resurrect or hijack the goal.
+    pub(crate) fn stop_ext_driving(&mut self) {
+        self.ext_driven = false;
+        self.ext_snapshots_blocked = true;
+    }
+
+    /// The agent's native loop reported its goal cleared; mirroring stays
+    /// open for the next extension-driven goal.
+    pub(crate) fn ext_cleared_by_agent(&mut self) {
+        self.ext_driven = false;
+        self.ext_snapshots_blocked = false;
+    }
+
     pub(crate) fn update_session_tokens(
         &mut self,
         used_tokens: i64,
@@ -414,7 +449,7 @@ impl AcpBackend {
             Some(_) => None,
         };
         let mcp_available = self.goal_automation_available().await;
-        if ext.is_none() && !mcp_available {
+        if self.goal_ext_capability.is_none() && !mcp_available {
             anyhow::bail!("goal management is unavailable for this session");
         }
         let mut ext_driving = false;
@@ -436,22 +471,32 @@ impl AcpBackend {
                 }
             }
         }
-        self.goal_ext_driving
-            .store(ext_driving, std::sync::atomic::Ordering::Relaxed);
+        if !ext_driving {
+            self.stop_stale_ext_goal().await;
+        }
         let goal = {
             let mut state = self.thread_goal_state.lock().await;
-            let mirrored = ext_driving
-                .then(|| state.snapshot(now_seconds()))
-                .flatten()
-                .filter(|existing| existing.objective == objective);
-            match mirrored {
-                // The agent already published a snapshot for this goal while
-                // the extension request was in flight; that mirror is
-                // authoritative, so don't clobber its status.
-                Some(existing) => existing,
-                None => state
+            if ext_driving {
+                let mirrored = state
+                    .snapshot(now_seconds())
+                    .filter(|existing| existing.objective == objective);
+                let goal = match mirrored {
+                    // The agent already published a snapshot for this goal
+                    // while the extension request was in flight; that mirror
+                    // is authoritative, so don't clobber its status.
+                    Some(existing) => existing,
+                    None => state
+                        .set_objective(objective, status, now_seconds())
+                        .map_err(anyhow::Error::msg)?,
+                };
+                state.mark_ext_driven();
+                goal
+            } else {
+                let goal = state
                     .set_objective(objective, status, now_seconds())
-                    .map_err(anyhow::Error::msg)?,
+                    .map_err(anyhow::Error::msg)?;
+                state.stop_ext_driving();
+                goal
             }
         };
         let should_start = goal.status == GoalStatus::Active && !ext_driving;
@@ -468,19 +513,7 @@ impl AcpBackend {
         if ext.is_none() && !self.goal_automation_available().await {
             anyhow::bail!("goal management is unavailable for this session");
         }
-        if self
-            .goal_ext_driving
-            .swap(false, std::sync::atomic::Ordering::Relaxed)
-            && let Some(capability) = &ext
-            && let Err(error) = self
-                .drive_goal_ext(capability, goal_ext::GoalExtAction::Clear, None)
-                .await
-        {
-            // The local clear still proceeds: the mirrored goal is gone either
-            // way, and a failed native clear only leaves the agent loop to
-            // wind down on its own.
-            tracing::warn!("goal extension clear failed: {error:#}");
-        }
+        self.stop_stale_ext_goal().await;
         if self.thread_goal_state.lock().await.clear() {
             self.emit_goal_changed(None).await;
         }
@@ -496,9 +529,15 @@ impl AcpBackend {
         if ext.is_none() && !self.goal_automation_available().await {
             anyhow::bail!("goal management is unavailable for this session");
         }
-        let ext_driving = self
-            .goal_ext_driving
-            .load(std::sync::atomic::Ordering::Relaxed);
+        let mcp_available = self.goal_automation_available().await;
+        let (ext_driving, current_objective) = {
+            let state = self.thread_goal_state.lock().await;
+            (
+                state.ext_driven(),
+                state.snapshot(now_seconds()).map(|goal| goal.objective),
+            )
+        };
+        let mut drives_after = ext_driving;
         if ext_driving {
             let action = match internal_status {
                 GoalStatus::Paused => Some(goal_ext::GoalExtAction::Pause),
@@ -520,14 +559,28 @@ impl AcpBackend {
                     );
                 }
             }
+        } else if internal_status == GoalStatus::Active
+            && !mcp_available
+            && let (Some(capability), Some(objective)) = (&ext, &current_objective)
+        {
+            // Resuming a mirrored or replayed goal on an extension-only
+            // agent: the native loop knows nothing about this goal on the
+            // current session, so re-drive it with a fresh set.
+            self.drive_goal_ext(capability, goal_ext::GoalExtAction::Set, Some(objective))
+                .await?;
+            drives_after = true;
         }
-        let goal = self
-            .thread_goal_state
-            .lock()
-            .await
-            .set_status(internal_status, now_seconds())
-            .map_err(anyhow::Error::msg)?;
-        let should_start = goal.status == GoalStatus::Active && !ext_driving;
+        let goal = {
+            let mut state = self.thread_goal_state.lock().await;
+            let goal = state
+                .set_status(internal_status, now_seconds())
+                .map_err(anyhow::Error::msg)?;
+            if drives_after {
+                state.mark_ext_driven();
+            }
+            goal
+        };
+        let should_start = goal.status == GoalStatus::Active && !drives_after;
         let goal = goal.into_client_goal();
         self.emit_goal_changed(Some(goal.clone())).await;
         if should_start {
@@ -536,10 +589,34 @@ impl AcpBackend {
         Ok(goal)
     }
 
-    /// Parses the goal extension capability the agent advertised at
-    /// initialize, if any.
+    /// The goal extension capability the agent advertised at initialize, if
+    /// any (parsed once at backend construction).
     pub(super) fn goal_ext_capability(&self) -> Option<goal_ext::GoalExtCapability> {
-        goal_ext::GoalExtCapability::from_initialize_meta(self.connection.initialize_meta())
+        self.goal_ext_capability.clone()
+    }
+
+    /// If the extension currently drives a goal, stop mirroring it and
+    /// best-effort clear the agent's native loop so a stale loop cannot fight
+    /// whatever owns the goal store next.
+    pub(super) async fn stop_stale_ext_goal(&self) {
+        let was_driven = {
+            let mut state = self.thread_goal_state.lock().await;
+            let was_driven = state.ext_driven();
+            if was_driven {
+                state.stop_ext_driving();
+            }
+            was_driven
+        };
+        if was_driven
+            && let Some(capability) = self.goal_ext_capability()
+            && let Err(error) = self
+                .drive_goal_ext(&capability, goal_ext::GoalExtAction::Clear, None)
+                .await
+        {
+            // Snapshot mirroring is already blocked, so a loop that failed to
+            // clear can only wind down on its own without corrupting state.
+            tracing::warn!("goal extension clear failed: {error:#}");
+        }
     }
 
     async fn drive_goal_ext(
@@ -578,21 +655,12 @@ impl AcpBackend {
             goal_ext::mirror_update(&mut state, &goal_update, now_seconds())
         };
         match outcome {
-            goal_ext::GoalMirrorOutcome::Unchanged => {
-                if matches!(goal_update, goal_ext::GoalExtUpdate::Snapshot(_)) {
-                    self.goal_ext_driving
-                        .store(true, std::sync::atomic::Ordering::Relaxed);
-                }
-            }
+            goal_ext::GoalMirrorOutcome::Unchanged => {}
             goal_ext::GoalMirrorOutcome::Updated(snapshot) => {
-                self.goal_ext_driving
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
                 self.emit_goal_changed(Some(snapshot.into_client_goal()))
                     .await;
             }
             goal_ext::GoalMirrorOutcome::Cleared => {
-                self.goal_ext_driving
-                    .store(false, std::sync::atomic::Ordering::Relaxed);
                 self.emit_goal_changed(None).await;
             }
         }
@@ -617,23 +685,19 @@ impl AcpBackend {
     }
 
     pub(super) async fn prepend_goal_context_to_prompt(&self, prompt: String) -> String {
-        // While the agent's native goal loop drives, it owns goal context and
-        // the nori-client instructions would point at the wrong control plane.
-        if self
-            .goal_ext_driving
-            .load(std::sync::atomic::Ordering::Relaxed)
-        {
-            return prompt;
-        }
+        let goal_context = {
+            let state = self.thread_goal_state.lock().await;
+            // While the agent's native goal loop drives, it owns goal context
+            // and the nori-client instructions would point at the wrong
+            // control plane.
+            if state.ext_driven() {
+                return prompt;
+            }
+            state.prompt_context(now_seconds())
+        };
         if !self.goal_automation_available().await {
             return prompt;
         }
-
-        let goal_context = self
-            .thread_goal_state
-            .lock()
-            .await
-            .prompt_context(now_seconds());
         match goal_context {
             Some(goal_context) => format!("{goal_context}\n\n{prompt}"),
             None => prompt,

--- a/nori-rs/mock-acp-agent/src/main.rs
+++ b/nori-rs/mock-acp-agent/src/main.rs
@@ -1777,8 +1777,11 @@ async fn main() -> acp::Result<()> {
                 async move |arguments: agent_client_protocol::UntypedMessage,
                             responder: Responder<serde_json::Value>,
                             cx: ConnectionTo<Client>| {
-                    // The crate strips the leading underscore from ext methods
-                    // on some parse paths; accept both spellings.
+                    // Direct `UntypedMessage` dispatch preserves the wire
+                    // method (`_session/goal`); the crate's enum-fallback path
+                    // (agent-client-protocol schema/mod.rs `parse_message`)
+                    // strips the leading underscore instead. Accept both so
+                    // the mock does not depend on which path dispatched it.
                     let is_goal_method =
                         matches!(arguments.method(), "_session/goal" | "session/goal");
                     if !is_goal_method || std::env::var("MOCK_AGENT_GOAL_EXT").is_err() {


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

Follow-up to #578, addressing self-review findings on the goal extension bridge:

- **Atomicity**: `ext_driven` (and a new `ext_snapshots_blocked` guard) now live inside `ThreadGoalState` under the existing mutex, replacing the session-global `AtomicBool` whose store/lock ordering raced the snapshot observer (stall scenarios: harness thinking the ext drives a goal the agent dropped, or an ext goal getting an MCP continuation loop).
- **Session swap**: `/compact` and `/fork` now stop mirroring and best-effort `clear` the old session's native loop (while `session_id` still names it), so an extension-driven goal falls back to the nori-client loop after a swap instead of silently stalling; the snapshot block also stops cross-session snapshot bleed.
- **Stale-loop hygiene**: falling back to the MCP loop mid-set (or setting a non-active goal) clears a previously driving native loop; `/goal clear`'s resurrect window is closed by the snapshot block.
- **Resume**: `/goal resume` on an extension-only agent re-drives the mirrored goal with a fresh `set` (the native loop knows nothing about it on the new session).
- **Mirror guards**: blocked snapshots ignored; a foreign-objective snapshot can no longer hijack an MCP-driven goal; a null snapshot only clears extension-owned goals.
- Idioms: capability parsed once at backend construction, extension version fields `i64`, stale doc/hint text fixed.

## Test Plan
- [x] 294 lib tests (3 new mirror-guard tests) + full `cargo test -p nori-harness` suites passing
- [x] `cargo test -p nori-harness --test goal_ext_bridge` e2e passing
- [x] `just fmt` + `just fix -p nori-harness -p mock-acp-agent` clean

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets