### PR TITLE
feat(tui): add reusable detail pane

### DIFF
--- a/nori-rs/tui-components/DESIGN.md
+++ b/nori-rs/tui-components/DESIGN.md
@@ -63,6 +63,10 @@ key handling, loading, routing, and application actions. It intentionally does
 not make breakpoints or overlay decisions. Handroll adoption is deferred to a
 separate consumer migration.
 
+Callers may choose a transparent pane, a complete neutral pane surface, or a
+smaller heading, label-gutter, or row surface. These are presentation layers
+only; the caller still owns the surrounding page and placement.
+
 ## Verification
 
 25. Snapshot every component at representative wide and narrow widths.

--- a/nori-rs/tui-components/DESIGN.md
+++ b/nori-rs/tui-components/DESIGN.md
@@ -65,7 +65,9 @@ separate consumer migration.
 
 Callers may choose a transparent pane, a complete neutral pane surface, or a
 smaller heading, label-gutter, or row surface. These are presentation layers
-only; the caller still owns the surrounding page and placement.
+only; the caller still owns the surrounding page and placement. The storybook
+also carries rail, underline, and value-side experiments while the final
+visual treatment is selected.
 
 ## Verification
 

--- a/nori-rs/tui-components/DESIGN.md
+++ b/nori-rs/tui-components/DESIGN.md
@@ -63,11 +63,10 @@ key handling, loading, routing, and application actions. It intentionally does
 not make breakpoints or overlay decisions. Handroll adoption is deferred to a
 separate consumer migration.
 
-Callers may choose a transparent pane, a complete neutral pane surface, or a
-smaller heading, label-gutter, or row surface. These are presentation layers
-only; the caller still owns the surrounding page and placement. The storybook
-also carries rail, underline, and value-side experiments while the final
-visual treatment is selected.
+The body stays transparent. When the caller supplies the optional heading, the
+component renders it on one neutral heading band and leaves one row of space
+before the definition list. The caller still owns the surrounding page and
+placement.
 
 ## Verification
 

--- a/nori-rs/tui-components/DESIGN.md
+++ b/nori-rs/tui-components/DESIGN.md
@@ -55,6 +55,14 @@ as they move into this crate.
     value, or explicit phrase such as `Not reported`.
 24. Use sentence case and concise action labels.
 
+## Detail panes
+
+`DetailPane` is a presentation-only definition-list widget. Callers provide
+its rectangle, choose side or bottom placement, and retain scrolling, focus,
+key handling, loading, routing, and application actions. It intentionally does
+not make breakpoints or overlay decisions. Handroll adoption is deferred to a
+separate consumer migration.
+
 ## Verification
 
 25. Snapshot every component at representative wide and narrow widths.

--- a/nori-rs/tui-components/examples/nori_storybook.rs
+++ b/nori-rs/tui-components/examples/nori_storybook.rs
@@ -73,7 +73,7 @@ fn main() -> Result<()> {
     let mut density = PickerDensity::Normal;
     let mut state = picker_state();
     let mut notice = "Resize the terminal to exercise responsive layout".to_string();
-    let mut detail_background = DetailBackground::Transparent;
+    let mut detail_background = DetailBackground::Heading;
 
     loop {
         terminal.terminal.draw(|frame| {
@@ -406,27 +406,42 @@ fn next_detail_background(background: DetailBackground) -> DetailBackground {
         DetailBackground::Pane => DetailBackground::Heading,
         DetailBackground::Heading => DetailBackground::LabelGutter,
         DetailBackground::LabelGutter => DetailBackground::Rows,
-        DetailBackground::Rows => DetailBackground::Transparent,
+        DetailBackground::Rows => DetailBackground::AccentRail,
+        DetailBackground::AccentRail => DetailBackground::EdgeRails,
+        DetailBackground::EdgeRails => DetailBackground::HeadingRule,
+        DetailBackground::HeadingRule => DetailBackground::ValuePanel,
+        DetailBackground::ValuePanel => DetailBackground::SectionRails,
+        DetailBackground::SectionRails => DetailBackground::Transparent,
     }
 }
 
 fn previous_detail_background(background: DetailBackground) -> DetailBackground {
     match background {
-        DetailBackground::Transparent => DetailBackground::Rows,
+        DetailBackground::Transparent => DetailBackground::SectionRails,
         DetailBackground::Pane => DetailBackground::Transparent,
         DetailBackground::Heading => DetailBackground::Pane,
         DetailBackground::LabelGutter => DetailBackground::Heading,
         DetailBackground::Rows => DetailBackground::LabelGutter,
+        DetailBackground::AccentRail => DetailBackground::Rows,
+        DetailBackground::EdgeRails => DetailBackground::AccentRail,
+        DetailBackground::HeadingRule => DetailBackground::EdgeRails,
+        DetailBackground::ValuePanel => DetailBackground::HeadingRule,
+        DetailBackground::SectionRails => DetailBackground::ValuePanel,
     }
 }
 
 fn detail_background_name(background: DetailBackground) -> &'static str {
     match background {
-        DetailBackground::Transparent => "1/5 transparent",
-        DetailBackground::Pane => "2/5 full pane",
-        DetailBackground::Heading => "3/5 heading band",
-        DetailBackground::LabelGutter => "4/5 label rail",
-        DetailBackground::Rows => "5/5 row bands",
+        DetailBackground::Transparent => "1/10 transparent",
+        DetailBackground::Pane => "2/10 full pane",
+        DetailBackground::Heading => "3/10 heading band",
+        DetailBackground::LabelGutter => "4/10 label rail",
+        DetailBackground::Rows => "5/10 row bands",
+        DetailBackground::AccentRail => "6/10 accent rail",
+        DetailBackground::EdgeRails => "7/10 open edge rails",
+        DetailBackground::HeadingRule => "8/10 heading underline",
+        DetailBackground::ValuePanel => "9/10 value-side surface",
+        DetailBackground::SectionRails => "10/10 segmented rails",
     }
 }
 

--- a/nori-rs/tui-components/examples/nori_storybook.rs
+++ b/nori-rs/tui-components/examples/nori_storybook.rs
@@ -1,6 +1,9 @@
 mod support;
 
 use anyhow::Result;
+use codex_tui_components::DetailEntry;
+use codex_tui_components::DetailPane;
+use codex_tui_components::DetailTone;
 use codex_tui_components::EmptyState;
 use codex_tui_components::KeyHint;
 use codex_tui_components::KeyHints;
@@ -17,6 +20,7 @@ use codex_tui_components::PickerLoadState;
 use codex_tui_components::PickerMode;
 use codex_tui_components::PickerOutcome;
 use codex_tui_components::PickerState;
+use codex_tui_components::ProviderKind;
 use codex_tui_components::SearchMode;
 use codex_tui_components::SemanticMessage;
 use codex_tui_components::Theme;
@@ -58,6 +62,7 @@ enum Page {
     Markdown,
     Primitives,
     States,
+    Details,
 }
 
 fn main() -> Result<()> {
@@ -85,6 +90,7 @@ fn main() -> Result<()> {
                 Page::Markdown => render_markdown(content, frame.buffer_mut(), theme),
                 Page::Primitives => render_primitives(content, frame.buffer_mut(), theme),
                 Page::States => render_states(content, frame.buffer_mut(), theme),
+                Page::Details => render_details(content, frame.buffer_mut(), theme),
             }
         })?;
 
@@ -100,6 +106,7 @@ fn main() -> Result<()> {
             KeyCode::Char('2') => page = Page::Markdown,
             KeyCode::Char('3') => page = Page::Primitives,
             KeyCode::Char('4') => page = Page::States,
+            KeyCode::Char('5') => page = Page::Details,
             KeyCode::Char('d') if page == Page::Picker => {
                 density = match density {
                     PickerDensity::Compact => PickerDensity::Normal,
@@ -154,6 +161,7 @@ fn render_navigation(area: Rect, buf: &mut ratatui::buffer::Buffer, page: Page, 
         (Page::Markdown, "2 Markdown"),
         (Page::Primitives, "3 Primitives"),
         (Page::States, "4 States"),
+        (Page::Details, "5 Details"),
     ];
     let spans = labels
         .into_iter()
@@ -299,6 +307,63 @@ fn render_states(area: Rect, buf: &mut ratatui::buffer::Buffer, theme: Theme) {
     render_page_footer(area, buf, theme);
 }
 
+fn render_details(area: Rect, buf: &mut ratatui::buffer::Buffer, theme: Theme) {
+    let inner = page_frame(area, buf, "Detail pane placements", theme);
+    let areas =
+        Layout::vertical([Constraint::Percentage(52), Constraint::Percentage(48)]).split(inner);
+    let cli = Layout::horizontal([
+        Constraint::Percentage(58),
+        Constraint::Length(2),
+        Constraint::Percentage(42),
+    ])
+    .split(areas[0]);
+    Paragraph::new(vec![
+        Line::styled("Nori CLI session picker", theme.title),
+        Line::styled("Caller owns the side-pane split", theme.muted),
+        Line::from(""),
+        Line::from("› Fix parser recovery"),
+        Line::styled("  nori-cli · 2m ago · working", theme.muted),
+    ])
+    .render(cli[0], buf);
+    DetailPane::new(&detail_entries())
+        .heading("Session details")
+        .theme(theme)
+        .render(cli[2], buf);
+    Paragraph::new(Line::styled(
+        "Handroll-style bottom panel - caller owns its reserved rows",
+        theme.muted,
+    ))
+    .render(areas[1], buf);
+    let bottom = Rect::new(
+        areas[1].x,
+        areas[1].y.saturating_add(2),
+        areas[1].width,
+        areas[1].height.saturating_sub(2),
+    );
+    DetailPane::new(&detail_entries())
+        .heading("Current session")
+        .theme(theme)
+        .render(bottom, buf);
+    render_page_footer(area, buf, theme);
+}
+
+fn detail_entries() -> Vec<DetailEntry> {
+    vec![
+        DetailEntry::key_value("Thread", "Fix parser recovery"),
+        DetailEntry::key_value("Agent", "Codex").tone(DetailTone::Provider(ProviderKind::Codex)),
+        DetailEntry::key_value("Origin", "Local · nori-cli"),
+        DetailEntry::Rule,
+        DetailEntry::muted(
+            "Latest prompt",
+            "Recover malformed session transcripts without changing user-visible behavior.",
+        ),
+        DetailEntry::muted(
+            "Latest response",
+            "Inspecting parser recovery fixtures and structured error handling.",
+        ),
+    ]
+}
+
 fn page_frame(area: Rect, buf: &mut ratatui::buffer::Buffer, title: &str, theme: Theme) -> Rect {
     Block::default().style(theme.surface).render(area, buf);
     let inner = area.inner(Margin {
@@ -316,7 +381,7 @@ fn page_frame(area: Rect, buf: &mut ratatui::buffer::Buffer, title: &str, theme:
 }
 
 fn render_page_footer(area: Rect, buf: &mut ratatui::buffer::Buffer, theme: Theme) {
-    KeyHints::new([KeyHint::new("1-4", "page"), KeyHint::new("q", "close")])
+    KeyHints::new([KeyHint::new("1-5", "page"), KeyHint::new("q", "close")])
         .theme(theme)
         .render(
             Rect::new(

--- a/nori-rs/tui-components/examples/nori_storybook.rs
+++ b/nori-rs/tui-components/examples/nori_storybook.rs
@@ -1,7 +1,6 @@
 mod support;
 
 use anyhow::Result;
-use codex_tui_components::DetailBackground;
 use codex_tui_components::DetailEntry;
 use codex_tui_components::DetailPane;
 use codex_tui_components::DetailTone;
@@ -73,7 +72,6 @@ fn main() -> Result<()> {
     let mut density = PickerDensity::Normal;
     let mut state = picker_state();
     let mut notice = "Resize the terminal to exercise responsive layout".to_string();
-    let mut detail_background = DetailBackground::Heading;
 
     loop {
         terminal.terminal.draw(|frame| {
@@ -92,9 +90,7 @@ fn main() -> Result<()> {
                 Page::Markdown => render_markdown(content, frame.buffer_mut(), theme),
                 Page::Primitives => render_primitives(content, frame.buffer_mut(), theme),
                 Page::States => render_states(content, frame.buffer_mut(), theme),
-                Page::Details => {
-                    render_details(content, frame.buffer_mut(), theme, detail_background)
-                }
+                Page::Details => render_details(content, frame.buffer_mut(), theme),
             }
         })?;
 
@@ -111,12 +107,6 @@ fn main() -> Result<()> {
             KeyCode::Char('3') => page = Page::Primitives,
             KeyCode::Char('4') => page = Page::States,
             KeyCode::Char('5') => page = Page::Details,
-            KeyCode::Left | KeyCode::Char('[') if page == Page::Details => {
-                detail_background = previous_detail_background(detail_background);
-            }
-            KeyCode::Right | KeyCode::Char(']') if page == Page::Details => {
-                detail_background = next_detail_background(detail_background);
-            }
             KeyCode::Char('d') if page == Page::Picker => {
                 density = match density {
                     PickerDensity::Compact => PickerDensity::Normal,
@@ -317,14 +307,8 @@ fn render_states(area: Rect, buf: &mut ratatui::buffer::Buffer, theme: Theme) {
     render_page_footer(area, buf, theme);
 }
 
-fn render_details(
-    area: Rect,
-    buf: &mut ratatui::buffer::Buffer,
-    theme: Theme,
-    background: DetailBackground,
-) {
-    let title = format!("Detail pane · {}", detail_background_name(background));
-    let inner = page_frame(area, buf, &title, theme);
+fn render_details(area: Rect, buf: &mut ratatui::buffer::Buffer, theme: Theme) {
+    let inner = page_frame(area, buf, "Detail pane", theme);
     let areas =
         Layout::vertical([Constraint::Percentage(52), Constraint::Percentage(48)]).split(inner);
     let cli = Layout::horizontal([
@@ -344,7 +328,6 @@ fn render_details(
     DetailPane::new(&detail_entries())
         .heading("Session details")
         .theme(theme)
-        .background(background)
         .render(cli[2], buf);
     Paragraph::new(Line::styled(
         "Handroll-style bottom panel - caller owns its reserved rows",
@@ -360,23 +343,8 @@ fn render_details(
     DetailPane::new(&detail_entries())
         .heading("Current session")
         .theme(theme)
-        .background(background)
         .render(bottom, buf);
-    KeyHints::new([
-        KeyHint::new("←→", "background option"),
-        KeyHint::new("1-5", "page"),
-        KeyHint::new("q", "close"),
-    ])
-    .theme(theme)
-    .render(
-        Rect::new(
-            area.x.saturating_add(2),
-            area.bottom().saturating_sub(2),
-            area.width.saturating_sub(4),
-            1,
-        ),
-        buf,
-    );
+    render_page_footer(area, buf, theme);
 }
 
 fn detail_entries() -> Vec<DetailEntry> {
@@ -398,51 +366,6 @@ fn detail_entries() -> Vec<DetailEntry> {
             "Inspecting parser recovery fixtures and structured error handling.",
         ),
     ]
-}
-
-fn next_detail_background(background: DetailBackground) -> DetailBackground {
-    match background {
-        DetailBackground::Transparent => DetailBackground::Pane,
-        DetailBackground::Pane => DetailBackground::Heading,
-        DetailBackground::Heading => DetailBackground::LabelGutter,
-        DetailBackground::LabelGutter => DetailBackground::Rows,
-        DetailBackground::Rows => DetailBackground::AccentRail,
-        DetailBackground::AccentRail => DetailBackground::EdgeRails,
-        DetailBackground::EdgeRails => DetailBackground::HeadingRule,
-        DetailBackground::HeadingRule => DetailBackground::ValuePanel,
-        DetailBackground::ValuePanel => DetailBackground::SectionRails,
-        DetailBackground::SectionRails => DetailBackground::Transparent,
-    }
-}
-
-fn previous_detail_background(background: DetailBackground) -> DetailBackground {
-    match background {
-        DetailBackground::Transparent => DetailBackground::SectionRails,
-        DetailBackground::Pane => DetailBackground::Transparent,
-        DetailBackground::Heading => DetailBackground::Pane,
-        DetailBackground::LabelGutter => DetailBackground::Heading,
-        DetailBackground::Rows => DetailBackground::LabelGutter,
-        DetailBackground::AccentRail => DetailBackground::Rows,
-        DetailBackground::EdgeRails => DetailBackground::AccentRail,
-        DetailBackground::HeadingRule => DetailBackground::EdgeRails,
-        DetailBackground::ValuePanel => DetailBackground::HeadingRule,
-        DetailBackground::SectionRails => DetailBackground::ValuePanel,
-    }
-}
-
-fn detail_background_name(background: DetailBackground) -> &'static str {
-    match background {
-        DetailBackground::Transparent => "1/10 transparent",
-        DetailBackground::Pane => "2/10 full pane",
-        DetailBackground::Heading => "3/10 heading band",
-        DetailBackground::LabelGutter => "4/10 label rail",
-        DetailBackground::Rows => "5/10 row bands",
-        DetailBackground::AccentRail => "6/10 accent rail",
-        DetailBackground::EdgeRails => "7/10 open edge rails",
-        DetailBackground::HeadingRule => "8/10 heading underline",
-        DetailBackground::ValuePanel => "9/10 value-side surface",
-        DetailBackground::SectionRails => "10/10 segmented rails",
-    }
 }
 
 fn page_frame(area: Rect, buf: &mut ratatui::buffer::Buffer, title: &str, theme: Theme) -> Rect {

--- a/nori-rs/tui-components/examples/nori_storybook.rs
+++ b/nori-rs/tui-components/examples/nori_storybook.rs
@@ -1,6 +1,7 @@
 mod support;
 
 use anyhow::Result;
+use codex_tui_components::DetailBackground;
 use codex_tui_components::DetailEntry;
 use codex_tui_components::DetailPane;
 use codex_tui_components::DetailTone;
@@ -72,6 +73,7 @@ fn main() -> Result<()> {
     let mut density = PickerDensity::Normal;
     let mut state = picker_state();
     let mut notice = "Resize the terminal to exercise responsive layout".to_string();
+    let mut detail_background = DetailBackground::Transparent;
 
     loop {
         terminal.terminal.draw(|frame| {
@@ -90,7 +92,9 @@ fn main() -> Result<()> {
                 Page::Markdown => render_markdown(content, frame.buffer_mut(), theme),
                 Page::Primitives => render_primitives(content, frame.buffer_mut(), theme),
                 Page::States => render_states(content, frame.buffer_mut(), theme),
-                Page::Details => render_details(content, frame.buffer_mut(), theme),
+                Page::Details => {
+                    render_details(content, frame.buffer_mut(), theme, detail_background)
+                }
             }
         })?;
 
@@ -107,6 +111,12 @@ fn main() -> Result<()> {
             KeyCode::Char('3') => page = Page::Primitives,
             KeyCode::Char('4') => page = Page::States,
             KeyCode::Char('5') => page = Page::Details,
+            KeyCode::Left | KeyCode::Char('[') if page == Page::Details => {
+                detail_background = previous_detail_background(detail_background);
+            }
+            KeyCode::Right | KeyCode::Char(']') if page == Page::Details => {
+                detail_background = next_detail_background(detail_background);
+            }
             KeyCode::Char('d') if page == Page::Picker => {
                 density = match density {
                     PickerDensity::Compact => PickerDensity::Normal,
@@ -307,8 +317,14 @@ fn render_states(area: Rect, buf: &mut ratatui::buffer::Buffer, theme: Theme) {
     render_page_footer(area, buf, theme);
 }
 
-fn render_details(area: Rect, buf: &mut ratatui::buffer::Buffer, theme: Theme) {
-    let inner = page_frame(area, buf, "Detail pane placements", theme);
+fn render_details(
+    area: Rect,
+    buf: &mut ratatui::buffer::Buffer,
+    theme: Theme,
+    background: DetailBackground,
+) {
+    let title = format!("Detail pane · {}", detail_background_name(background));
+    let inner = page_frame(area, buf, &title, theme);
     let areas =
         Layout::vertical([Constraint::Percentage(52), Constraint::Percentage(48)]).split(inner);
     let cli = Layout::horizontal([
@@ -328,6 +344,7 @@ fn render_details(area: Rect, buf: &mut ratatui::buffer::Buffer, theme: Theme) {
     DetailPane::new(&detail_entries())
         .heading("Session details")
         .theme(theme)
+        .background(background)
         .render(cli[2], buf);
     Paragraph::new(Line::styled(
         "Handroll-style bottom panel - caller owns its reserved rows",
@@ -343,8 +360,23 @@ fn render_details(area: Rect, buf: &mut ratatui::buffer::Buffer, theme: Theme) {
     DetailPane::new(&detail_entries())
         .heading("Current session")
         .theme(theme)
+        .background(background)
         .render(bottom, buf);
-    render_page_footer(area, buf, theme);
+    KeyHints::new([
+        KeyHint::new("←→", "background option"),
+        KeyHint::new("1-5", "page"),
+        KeyHint::new("q", "close"),
+    ])
+    .theme(theme)
+    .render(
+        Rect::new(
+            area.x.saturating_add(2),
+            area.bottom().saturating_sub(2),
+            area.width.saturating_sub(4),
+            1,
+        ),
+        buf,
+    );
 }
 
 fn detail_entries() -> Vec<DetailEntry> {
@@ -352,6 +384,10 @@ fn detail_entries() -> Vec<DetailEntry> {
         DetailEntry::key_value("Thread", "Fix parser recovery"),
         DetailEntry::key_value("Agent", "Codex").tone(DetailTone::Provider(ProviderKind::Codex)),
         DetailEntry::key_value("Origin", "Local · nori-cli"),
+        DetailEntry::key_value("Created", "Aug 16, 2026 · 9:42 AM"),
+        DetailEntry::key_value("Modified", "Aug 17, 2026 · 11:08 AM"),
+        DetailEntry::key_value("Turns", "48"),
+        DetailEntry::key_value("Transcript", "1.8 MB"),
         DetailEntry::Rule,
         DetailEntry::muted(
             "Latest prompt",
@@ -362,6 +398,36 @@ fn detail_entries() -> Vec<DetailEntry> {
             "Inspecting parser recovery fixtures and structured error handling.",
         ),
     ]
+}
+
+fn next_detail_background(background: DetailBackground) -> DetailBackground {
+    match background {
+        DetailBackground::Transparent => DetailBackground::Pane,
+        DetailBackground::Pane => DetailBackground::Heading,
+        DetailBackground::Heading => DetailBackground::LabelGutter,
+        DetailBackground::LabelGutter => DetailBackground::Rows,
+        DetailBackground::Rows => DetailBackground::Transparent,
+    }
+}
+
+fn previous_detail_background(background: DetailBackground) -> DetailBackground {
+    match background {
+        DetailBackground::Transparent => DetailBackground::Rows,
+        DetailBackground::Pane => DetailBackground::Transparent,
+        DetailBackground::Heading => DetailBackground::Pane,
+        DetailBackground::LabelGutter => DetailBackground::Heading,
+        DetailBackground::Rows => DetailBackground::LabelGutter,
+    }
+}
+
+fn detail_background_name(background: DetailBackground) -> &'static str {
+    match background {
+        DetailBackground::Transparent => "1/5 transparent",
+        DetailBackground::Pane => "2/5 full pane",
+        DetailBackground::Heading => "3/5 heading band",
+        DetailBackground::LabelGutter => "4/5 label rail",
+        DetailBackground::Rows => "5/5 row bands",
+    }
 }
 
 fn page_frame(area: Rect, buf: &mut ratatui::buffer::Buffer, title: &str, theme: Theme) -> Rect {

--- a/nori-rs/tui-components/src/detail.rs
+++ b/nori-rs/tui-components/src/detail.rs
@@ -94,6 +94,22 @@ pub enum LabelWidth {
     Fixed(u16),
 }
 
+/// Which neutral surface layer the pane paints inside its caller-owned area.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DetailBackground {
+    /// Leave the caller's background untouched.
+    Transparent,
+    /// Shade the complete pane area.
+    #[default]
+    Pane,
+    /// Shade only the optional heading row.
+    Heading,
+    /// Shade only the label gutter and separator column.
+    LabelGutter,
+    /// Shade each key-value row, including wrapped continuation lines.
+    Rows,
+}
+
 impl Default for LabelWidth {
     fn default() -> Self {
         Self::Auto { max: 14 }
@@ -106,6 +122,7 @@ pub struct DetailPane<'a> {
     heading: Option<Line<'static>>,
     theme: Theme,
     label_width: LabelWidth,
+    background: DetailBackground,
 }
 
 impl<'a> DetailPane<'a> {
@@ -115,6 +132,7 @@ impl<'a> DetailPane<'a> {
             heading: None,
             theme: Theme::default(),
             label_width: LabelWidth::default(),
+            background: DetailBackground::default(),
         }
     }
 
@@ -132,6 +150,11 @@ impl<'a> DetailPane<'a> {
         self.label_width = label_width;
         self
     }
+
+    pub fn background(mut self, background: DetailBackground) -> Self {
+        self.background = background;
+        self
+    }
 }
 
 impl Widget for DetailPane<'_> {
@@ -139,9 +162,17 @@ impl Widget for DetailPane<'_> {
         if area.width < 4 || area.height == 0 {
             return;
         }
-        buf.set_style(area, self.theme.detail_surface);
+        if self.background == DetailBackground::Pane {
+            buf.set_style(area, self.theme.detail_surface);
+        }
         let mut y = area.y;
         if let Some(heading) = self.heading {
+            if self.background == DetailBackground::Heading {
+                buf.set_style(
+                    Rect::new(area.x, y, area.width, 1),
+                    self.theme.detail_surface,
+                );
+            }
             Paragraph::new(heading)
                 .style(self.theme.title)
                 .render(Rect::new(area.x, y, area.width, 1), buf);
@@ -168,6 +199,26 @@ impl Widget for DetailPane<'_> {
                     tone,
                     wrap,
                 } => {
+                    let value_width = area.width.saturating_sub(gutter).saturating_sub(3);
+                    let row_height = if *wrap {
+                        line_height(value, value_width as usize)
+                    } else {
+                        1
+                    }
+                    .min(area.bottom().saturating_sub(y));
+                    match self.background {
+                        DetailBackground::LabelGutter => buf.set_style(
+                            Rect::new(area.x, y, gutter.saturating_add(2), row_height),
+                            self.theme.detail_surface,
+                        ),
+                        DetailBackground::Rows => buf.set_style(
+                            Rect::new(area.x, y, area.width, row_height),
+                            self.theme.detail_surface,
+                        ),
+                        DetailBackground::Transparent
+                        | DetailBackground::Pane
+                        | DetailBackground::Heading => {}
+                    }
                     let label = pad_left(&truncate(label, gutter as usize), gutter as usize);
                     buf.set_string(area.x, y, label, self.theme.muted);
                     let separator_x = area.x.saturating_add(gutter).saturating_add(1);
@@ -188,11 +239,7 @@ impl Widget for DetailPane<'_> {
                         .style(tone_style(*tone, self.theme))
                         .wrap(ratatui::widgets::Wrap { trim: false })
                         .render(value_area, buf);
-                    y = y.saturating_add(if *wrap {
-                        line_height(value, value_width as usize).min(value_area.height)
-                    } else {
-                        1
-                    });
+                    y = y.saturating_add(row_height);
                 }
             }
         }

--- a/nori-rs/tui-components/src/detail.rs
+++ b/nori-rs/tui-components/src/detail.rs
@@ -94,32 +94,6 @@ pub enum LabelWidth {
     Fixed(u16),
 }
 
-/// Which neutral surface layer the pane paints inside its caller-owned area.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum DetailBackground {
-    /// Leave the caller's background untouched.
-    Transparent,
-    /// Shade the complete pane area.
-    #[default]
-    Pane,
-    /// Shade only the optional heading row.
-    Heading,
-    /// Shade only the label gutter and separator column.
-    LabelGutter,
-    /// Shade each key-value row, including wrapped continuation lines.
-    Rows,
-    /// Draw a strong accent rail outside transparently rendered content.
-    AccentRail,
-    /// Inset transparent content between open vertical edge rails.
-    EdgeRails,
-    /// Separate a transparent heading and body with a horizontal rule.
-    HeadingRule,
-    /// Shade only the value side of each key-value row.
-    ValuePanel,
-    /// Inset transparent content beside rails broken into semantic sections.
-    SectionRails,
-}
-
 impl Default for LabelWidth {
     fn default() -> Self {
         Self::Auto { max: 14 }
@@ -132,7 +106,6 @@ pub struct DetailPane<'a> {
     heading: Option<Line<'static>>,
     theme: Theme,
     label_width: LabelWidth,
-    background: DetailBackground,
 }
 
 impl<'a> DetailPane<'a> {
@@ -142,7 +115,6 @@ impl<'a> DetailPane<'a> {
             heading: None,
             theme: Theme::default(),
             label_width: LabelWidth::default(),
-            background: DetailBackground::default(),
         }
     }
 
@@ -160,11 +132,6 @@ impl<'a> DetailPane<'a> {
         self.label_width = label_width;
         self
     }
-
-    pub fn background(mut self, background: DetailBackground) -> Self {
-        self.background = background;
-        self
-    }
 }
 
 impl Widget for DetailPane<'_> {
@@ -172,86 +139,30 @@ impl Widget for DetailPane<'_> {
         if area.width < 4 || area.height == 0 {
             return;
         }
-        if self.background == DetailBackground::Pane {
-            buf.set_style(area, self.theme.detail_surface);
-        }
-        let content = match self.background {
-            DetailBackground::AccentRail => {
-                for y in area.y..area.bottom() {
-                    buf.set_string(area.x, y, "▎", self.theme.accent);
-                }
-                Rect::new(
-                    area.x.saturating_add(2),
-                    area.y,
-                    area.width.saturating_sub(2),
-                    area.height,
-                )
-            }
-            DetailBackground::EdgeRails => {
-                for y in area.y..area.bottom() {
-                    buf.set_string(area.x, y, "│", self.theme.separator);
-                    buf.set_string(area.right().saturating_sub(1), y, "│", self.theme.separator);
-                }
-                Rect::new(
-                    area.x.saturating_add(2),
-                    area.y,
-                    area.width.saturating_sub(4),
-                    area.height,
-                )
-            }
-            DetailBackground::SectionRails => Rect::new(
-                area.x.saturating_add(2),
-                area.y,
-                area.width.saturating_sub(2),
-                area.height,
-            ),
-            DetailBackground::Transparent
-            | DetailBackground::Pane
-            | DetailBackground::Heading
-            | DetailBackground::LabelGutter
-            | DetailBackground::Rows
-            | DetailBackground::HeadingRule
-            | DetailBackground::ValuePanel => area,
-        };
-        let mut y = content.y;
+        let mut y = area.y;
         if let Some(heading) = self.heading {
-            if self.background == DetailBackground::Heading {
-                buf.set_style(
-                    Rect::new(content.x, y, content.width, 1),
-                    self.theme.detail_surface,
-                );
-            }
+            buf.set_style(
+                Rect::new(area.x, y, area.width, 1),
+                self.theme.detail_surface,
+            );
             Paragraph::new(heading)
                 .style(self.theme.title)
-                .render(Rect::new(content.x, y, content.width, 1), buf);
-            if self.background == DetailBackground::HeadingRule && y + 1 < content.bottom() {
-                buf.set_string(
-                    content.x,
-                    y.saturating_add(1),
-                    "─".repeat(content.width as usize),
-                    self.theme.separator,
-                );
-            }
+                .render(Rect::new(area.x, y, area.width, 1), buf);
             y = y.saturating_add(2);
         }
-        let gutter = gutter_width(self.entries, self.label_width, content.width);
-        let mut primary_section = true;
+        let gutter = gutter_width(self.entries, self.label_width, area.width);
         for entry in self.entries {
-            if y >= content.bottom() {
+            if y >= area.bottom() {
                 break;
             }
             match entry {
                 DetailEntry::Rule => {
                     buf.set_string(
-                        content.x,
+                        area.x,
                         y,
-                        "─".repeat(content.width as usize),
+                        "─".repeat(area.width as usize),
                         self.theme.separator,
                     );
-                    if self.background == DetailBackground::SectionRails {
-                        buf.set_string(area.x, y, "├─", self.theme.separator);
-                        primary_section = false;
-                    }
                     y = y.saturating_add(1);
                 }
                 DetailEntry::KeyValue {
@@ -260,58 +171,19 @@ impl Widget for DetailPane<'_> {
                     tone,
                     wrap,
                 } => {
-                    let value_width = content.width.saturating_sub(gutter).saturating_sub(3);
+                    let value_width = area.width.saturating_sub(gutter).saturating_sub(3);
                     let row_height = if *wrap {
                         line_height(value, value_width as usize)
                     } else {
                         1
                     }
-                    .min(content.bottom().saturating_sub(y));
-                    match self.background {
-                        DetailBackground::LabelGutter => buf.set_style(
-                            Rect::new(content.x, y, gutter.saturating_add(2), row_height),
-                            self.theme.detail_surface,
-                        ),
-                        DetailBackground::Rows => buf.set_style(
-                            Rect::new(content.x, y, content.width, row_height),
-                            self.theme.detail_surface,
-                        ),
-                        DetailBackground::ValuePanel => {
-                            let value_x = content.x.saturating_add(gutter).saturating_add(3);
-                            buf.set_style(
-                                Rect::new(
-                                    value_x.saturating_sub(1),
-                                    y,
-                                    content.right().saturating_sub(value_x.saturating_sub(1)),
-                                    row_height,
-                                ),
-                                self.theme.detail_surface,
-                            );
-                        }
-                        DetailBackground::Transparent
-                        | DetailBackground::Pane
-                        | DetailBackground::Heading
-                        | DetailBackground::AccentRail
-                        | DetailBackground::EdgeRails
-                        | DetailBackground::HeadingRule
-                        | DetailBackground::SectionRails => {}
-                    }
-                    if self.background == DetailBackground::SectionRails {
-                        let style = if primary_section {
-                            self.theme.accent
-                        } else {
-                            self.theme.separator
-                        };
-                        for rail_y in y..y.saturating_add(row_height) {
-                            buf.set_string(area.x, rail_y, "│", style);
-                        }
-                    }
+                    .min(area.bottom().saturating_sub(y));
                     let label = pad_left(&truncate(label, gutter as usize), gutter as usize);
-                    buf.set_string(content.x, y, label, self.theme.muted);
-                    let separator_x = content.x.saturating_add(gutter).saturating_add(1);
+                    buf.set_string(area.x, y, label, self.theme.muted);
+                    let separator_x = area.x.saturating_add(gutter).saturating_add(1);
                     buf.set_string(separator_x, y, "│", self.theme.separator);
                     let value_x = separator_x.saturating_add(2);
-                    let value_width = content.right().saturating_sub(value_x);
+                    let value_width = area.right().saturating_sub(value_x);
                     if value_width == 0 {
                         break;
                     }

--- a/nori-rs/tui-components/src/detail.rs
+++ b/nori-rs/tui-components/src/detail.rs
@@ -1,0 +1,261 @@
+//! Stateless definition-list rendering for caller-owned panes and overlays.
+//!
+//! `DetailPane` deliberately accepts a caller-provided rectangle. It does not
+//! choose a side or bottom placement, manage focus, collect input, or retain
+//! scrolling state.
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::Line;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::Widget;
+use unicode_width::UnicodeWidthStr;
+
+use crate::Theme;
+
+/// Semantic emphasis for a detail value.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DetailTone {
+    #[default]
+    Default,
+    Muted,
+    Info,
+    Success,
+    Warning,
+    Error,
+    Provider(ProviderKind),
+}
+
+/// Known agent/provider identities, with an extensible fallback.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ProviderKind {
+    Claude,
+    Codex,
+    Pi,
+    Nori,
+    #[default]
+    Other,
+}
+
+/// A semantic line in a detail pane.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DetailEntry {
+    KeyValue {
+        label: String,
+        value: Line<'static>,
+        tone: DetailTone,
+        wrap: bool,
+    },
+    Rule,
+}
+
+impl DetailEntry {
+    pub fn key_value(label: impl Into<String>, value: impl Into<Line<'static>>) -> Self {
+        Self::KeyValue {
+            label: label.into().trim_end_matches(':').to_string(),
+            value: value.into(),
+            tone: DetailTone::Default,
+            wrap: false,
+        }
+    }
+
+    pub fn muted(label: impl Into<String>, value: impl Into<Line<'static>>) -> Self {
+        Self::key_value(label, value)
+            .tone(DetailTone::Muted)
+            .wrap(true)
+    }
+
+    pub fn tone(mut self, tone: DetailTone) -> Self {
+        if let Self::KeyValue {
+            tone: entry_tone, ..
+        } = &mut self
+        {
+            *entry_tone = tone;
+        }
+        self
+    }
+
+    pub fn wrap(mut self, wrap: bool) -> Self {
+        if let Self::KeyValue {
+            wrap: entry_wrap, ..
+        } = &mut self
+        {
+            *entry_wrap = wrap;
+        }
+        self
+    }
+}
+
+/// Label-gutter sizing policy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LabelWidth {
+    Auto { max: u16 },
+    Fixed(u16),
+}
+
+impl Default for LabelWidth {
+    fn default() -> Self {
+        Self::Auto { max: 14 }
+    }
+}
+
+/// A presentation-only definition-list widget.
+pub struct DetailPane<'a> {
+    entries: &'a [DetailEntry],
+    heading: Option<Line<'static>>,
+    theme: Theme,
+    label_width: LabelWidth,
+}
+
+impl<'a> DetailPane<'a> {
+    pub fn new(entries: &'a [DetailEntry]) -> Self {
+        Self {
+            entries,
+            heading: None,
+            theme: Theme::default(),
+            label_width: LabelWidth::default(),
+        }
+    }
+
+    pub fn heading(mut self, heading: impl Into<Line<'static>>) -> Self {
+        self.heading = Some(heading.into());
+        self
+    }
+
+    pub fn theme(mut self, theme: Theme) -> Self {
+        self.theme = theme;
+        self
+    }
+
+    pub fn label_width(mut self, label_width: LabelWidth) -> Self {
+        self.label_width = label_width;
+        self
+    }
+}
+
+impl Widget for DetailPane<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        if area.width < 4 || area.height == 0 {
+            return;
+        }
+        buf.set_style(area, self.theme.detail_surface);
+        let mut y = area.y;
+        if let Some(heading) = self.heading {
+            Paragraph::new(heading)
+                .style(self.theme.title)
+                .render(Rect::new(area.x, y, area.width, 1), buf);
+            y = y.saturating_add(2);
+        }
+        let gutter = gutter_width(self.entries, self.label_width, area.width);
+        for entry in self.entries {
+            if y >= area.bottom() {
+                break;
+            }
+            match entry {
+                DetailEntry::Rule => {
+                    buf.set_string(
+                        area.x,
+                        y,
+                        "─".repeat(area.width as usize),
+                        self.theme.separator,
+                    );
+                    y = y.saturating_add(1);
+                }
+                DetailEntry::KeyValue {
+                    label,
+                    value,
+                    tone,
+                    wrap,
+                } => {
+                    let label = pad_left(&truncate(label, gutter as usize), gutter as usize);
+                    buf.set_string(area.x, y, label, self.theme.muted);
+                    let separator_x = area.x.saturating_add(gutter).saturating_add(1);
+                    buf.set_string(separator_x, y, "│", self.theme.separator);
+                    let value_x = separator_x.saturating_add(2);
+                    let value_width = area.right().saturating_sub(value_x);
+                    if value_width == 0 {
+                        break;
+                    }
+                    let value_area =
+                        Rect::new(value_x, y, value_width, area.bottom().saturating_sub(y));
+                    let rendered = if *wrap {
+                        value.clone()
+                    } else {
+                        truncate_line(value, value_width as usize)
+                    };
+                    Paragraph::new(rendered)
+                        .style(tone_style(*tone, self.theme))
+                        .wrap(ratatui::widgets::Wrap { trim: false })
+                        .render(value_area, buf);
+                    y = y.saturating_add(if *wrap {
+                        line_height(value, value_width as usize).min(value_area.height)
+                    } else {
+                        1
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn gutter_width(entries: &[DetailEntry], policy: LabelWidth, width: u16) -> u16 {
+    let available = width.saturating_sub(4) / 2;
+    match policy {
+        LabelWidth::Fixed(width) => width.min(available),
+        LabelWidth::Auto { max } => entries
+            .iter()
+            .filter_map(|entry| match entry {
+                DetailEntry::KeyValue { label, .. } => Some(label.width() as u16),
+                DetailEntry::Rule => None,
+            })
+            .max()
+            .unwrap_or(0)
+            .min(max)
+            .min(available),
+    }
+}
+
+fn tone_style(tone: DetailTone, theme: Theme) -> Style {
+    match tone {
+        DetailTone::Default => theme.text,
+        DetailTone::Muted => theme.muted,
+        DetailTone::Info
+        | DetailTone::Provider(ProviderKind::Codex)
+        | DetailTone::Provider(ProviderKind::Nori) => theme.info,
+        DetailTone::Success | DetailTone::Provider(ProviderKind::Claude) => theme.success,
+        DetailTone::Warning | DetailTone::Provider(ProviderKind::Pi) => theme.warning,
+        DetailTone::Error => theme.error,
+        DetailTone::Provider(ProviderKind::Other) => theme.text,
+    }
+}
+
+fn line_height(line: &Line<'_>, width: usize) -> u16 {
+    if width == 0 {
+        return 1;
+    }
+    let text = line.to_string();
+    ((text.width().saturating_add(width - 1) / width).max(1)) as u16
+}
+
+fn truncate(value: &str, width: usize) -> String {
+    if value.width() <= width {
+        return value.to_string();
+    }
+    value
+        .chars()
+        .take(width.saturating_sub(1))
+        .collect::<String>()
+        + "…"
+}
+
+fn truncate_line(line: &Line<'static>, width: usize) -> Line<'static> {
+    Line::from(truncate(&line.to_string(), width))
+}
+
+fn pad_left(value: &str, width: usize) -> String {
+    format!("{value:>width$}")
+}
+
+#[cfg(test)]
+mod tests;

--- a/nori-rs/tui-components/src/detail.rs
+++ b/nori-rs/tui-components/src/detail.rs
@@ -108,6 +108,16 @@ pub enum DetailBackground {
     LabelGutter,
     /// Shade each key-value row, including wrapped continuation lines.
     Rows,
+    /// Draw a strong accent rail outside transparently rendered content.
+    AccentRail,
+    /// Inset transparent content between open vertical edge rails.
+    EdgeRails,
+    /// Separate a transparent heading and body with a horizontal rule.
+    HeadingRule,
+    /// Shade only the value side of each key-value row.
+    ValuePanel,
+    /// Inset transparent content beside rails broken into semantic sections.
+    SectionRails,
 }
 
 impl Default for LabelWidth {
@@ -165,32 +175,83 @@ impl Widget for DetailPane<'_> {
         if self.background == DetailBackground::Pane {
             buf.set_style(area, self.theme.detail_surface);
         }
-        let mut y = area.y;
+        let content = match self.background {
+            DetailBackground::AccentRail => {
+                for y in area.y..area.bottom() {
+                    buf.set_string(area.x, y, "▎", self.theme.accent);
+                }
+                Rect::new(
+                    area.x.saturating_add(2),
+                    area.y,
+                    area.width.saturating_sub(2),
+                    area.height,
+                )
+            }
+            DetailBackground::EdgeRails => {
+                for y in area.y..area.bottom() {
+                    buf.set_string(area.x, y, "│", self.theme.separator);
+                    buf.set_string(area.right().saturating_sub(1), y, "│", self.theme.separator);
+                }
+                Rect::new(
+                    area.x.saturating_add(2),
+                    area.y,
+                    area.width.saturating_sub(4),
+                    area.height,
+                )
+            }
+            DetailBackground::SectionRails => Rect::new(
+                area.x.saturating_add(2),
+                area.y,
+                area.width.saturating_sub(2),
+                area.height,
+            ),
+            DetailBackground::Transparent
+            | DetailBackground::Pane
+            | DetailBackground::Heading
+            | DetailBackground::LabelGutter
+            | DetailBackground::Rows
+            | DetailBackground::HeadingRule
+            | DetailBackground::ValuePanel => area,
+        };
+        let mut y = content.y;
         if let Some(heading) = self.heading {
             if self.background == DetailBackground::Heading {
                 buf.set_style(
-                    Rect::new(area.x, y, area.width, 1),
+                    Rect::new(content.x, y, content.width, 1),
                     self.theme.detail_surface,
                 );
             }
             Paragraph::new(heading)
                 .style(self.theme.title)
-                .render(Rect::new(area.x, y, area.width, 1), buf);
+                .render(Rect::new(content.x, y, content.width, 1), buf);
+            if self.background == DetailBackground::HeadingRule && y + 1 < content.bottom() {
+                buf.set_string(
+                    content.x,
+                    y.saturating_add(1),
+                    "─".repeat(content.width as usize),
+                    self.theme.separator,
+                );
+            }
             y = y.saturating_add(2);
         }
-        let gutter = gutter_width(self.entries, self.label_width, area.width);
+        let gutter = gutter_width(self.entries, self.label_width, content.width);
+        let mut primary_section = true;
         for entry in self.entries {
-            if y >= area.bottom() {
+            if y >= content.bottom() {
                 break;
             }
             match entry {
                 DetailEntry::Rule => {
                     buf.set_string(
-                        area.x,
+                        content.x,
                         y,
-                        "─".repeat(area.width as usize),
+                        "─".repeat(content.width as usize),
                         self.theme.separator,
                     );
+                    if self.background == DetailBackground::SectionRails {
+                        buf.set_string(area.x, y, "├─", self.theme.separator);
+                        primary_section = false;
+                    }
                     y = y.saturating_add(1);
                 }
                 DetailEntry::KeyValue {
@@ -199,32 +260,58 @@ impl Widget for DetailPane<'_> {
                     tone,
                     wrap,
                 } => {
-                    let value_width = area.width.saturating_sub(gutter).saturating_sub(3);
+                    let value_width = content.width.saturating_sub(gutter).saturating_sub(3);
                     let row_height = if *wrap {
                         line_height(value, value_width as usize)
                     } else {
                         1
                     }
-                    .min(area.bottom().saturating_sub(y));
+                    .min(content.bottom().saturating_sub(y));
                     match self.background {
                         DetailBackground::LabelGutter => buf.set_style(
-                            Rect::new(area.x, y, gutter.saturating_add(2), row_height),
+                            Rect::new(content.x, y, gutter.saturating_add(2), row_height),
                             self.theme.detail_surface,
                         ),
                         DetailBackground::Rows => buf.set_style(
-                            Rect::new(area.x, y, area.width, row_height),
+                            Rect::new(content.x, y, content.width, row_height),
                             self.theme.detail_surface,
                         ),
+                        DetailBackground::ValuePanel => {
+                            let value_x = content.x.saturating_add(gutter).saturating_add(3);
+                            buf.set_style(
+                                Rect::new(
+                                    value_x.saturating_sub(1),
+                                    y,
+                                    content.right().saturating_sub(value_x.saturating_sub(1)),
+                                    row_height,
+                                ),
+                                self.theme.detail_surface,
+                            );
+                        }
                         DetailBackground::Transparent
                         | DetailBackground::Pane
-                        | DetailBackground::Heading => {}
+                        | DetailBackground::Heading
+                        | DetailBackground::AccentRail
+                        | DetailBackground::EdgeRails
+                        | DetailBackground::HeadingRule
+                        | DetailBackground::SectionRails => {}
+                    }
+                    if self.background == DetailBackground::SectionRails {
+                        let style = if primary_section {
+                            self.theme.accent
+                        } else {
+                            self.theme.separator
+                        };
+                        for rail_y in y..y.saturating_add(row_height) {
+                            buf.set_string(area.x, rail_y, "│", style);
+                        }
                     }
                     let label = pad_left(&truncate(label, gutter as usize), gutter as usize);
-                    buf.set_string(area.x, y, label, self.theme.muted);
-                    let separator_x = area.x.saturating_add(gutter).saturating_add(1);
+                    buf.set_string(content.x, y, label, self.theme.muted);
+                    let separator_x = content.x.saturating_add(gutter).saturating_add(1);
                     buf.set_string(separator_x, y, "│", self.theme.separator);
                     let value_x = separator_x.saturating_add(2);
-                    let value_width = area.right().saturating_sub(value_x);
+                    let value_width = content.right().saturating_sub(value_x);
                     if value_width == 0 {
                         break;
                     }

--- a/nori-rs/tui-components/src/detail/snapshots/codex_tui_components__detail__tests__detail_pane_narrow_snapshot.snap
+++ b/nori-rs/tui-components/src/detail/snapshots/codex_tui_components__detail__tests__detail_pane_narrow_snapshot.snap
@@ -1,0 +1,16 @@
+---
+source: tui-components/src/detail/tests.rs
+expression: "snapshot(22, 12)"
+---
+"Session details       "
+"                      "
+"    Agent │ Codex     "
+"  Created │ 2026-08-1…"
+"──────────────────────"
+"Latest p… │ Investigat"
+"            e the     "
+"            reusable  "
+"            component "
+"            boundary  "
+"            without   "
+"            changing  "

--- a/nori-rs/tui-components/src/detail/snapshots/codex_tui_components__detail__tests__detail_pane_wide_snapshot.snap
+++ b/nori-rs/tui-components/src/detail/snapshots/codex_tui_components__detail__tests__detail_pane_wide_snapshot.snap
@@ -1,0 +1,16 @@
+---
+source: tui-components/src/detail/tests.rs
+expression: "snapshot(42, 12)"
+---
+"Session details                           "
+"                                          "
+"         Agent │ Codex                    "
+"       Created │ 2026-08-15 12:00         "
+"──────────────────────────────────────────"
+" Latest prompt │ Investigate the reusable "
+"                 component boundary       "
+"                 without changing         "
+"Latest respon… │ The component stays      "
+"                 stateless and            "
+"                 consumer-owned.          "
+"                                          "

--- a/nori-rs/tui-components/src/detail/tests.rs
+++ b/nori-rs/tui-components/src/detail/tests.rs
@@ -1,0 +1,65 @@
+use super::*;
+use insta::assert_snapshot;
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::style::Color;
+
+fn entries() -> Vec<DetailEntry> {
+    vec![
+        DetailEntry::key_value("Agent", "Codex").tone(DetailTone::Provider(ProviderKind::Codex)),
+        DetailEntry::key_value("Created", "2026-08-15 12:00"),
+        DetailEntry::Rule,
+        DetailEntry::muted(
+            "Latest prompt",
+            "Investigate the reusable component boundary without changing Handroll.",
+        ),
+        DetailEntry::muted(
+            "Latest response",
+            "The component stays stateless and consumer-owned.",
+        ),
+    ]
+}
+
+fn snapshot(width: u16, height: u16) -> String {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal
+        .draw(|frame| {
+            frame.render_widget(
+                DetailPane::new(&entries()).heading("Session details"),
+                frame.area(),
+            )
+        })
+        .expect("draw pane");
+    terminal.backend().to_string()
+}
+
+#[test]
+fn detail_pane_wide_snapshot() {
+    assert_snapshot!(snapshot(42, 12));
+}
+
+#[test]
+fn detail_pane_narrow_snapshot() {
+    assert_snapshot!(snapshot(22, 12));
+}
+
+#[test]
+fn detail_pane_respects_fixed_gutter_and_provider_tone() {
+    let backend = TestBackend::new(40, 4);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    let theme = Theme::default();
+    terminal
+        .draw(|frame| {
+            frame.render_widget(
+                DetailPane::new(&entries())
+                    .theme(theme)
+                    .label_width(LabelWidth::Fixed(10)),
+                frame.area(),
+            )
+        })
+        .expect("draw pane");
+    let buffer = terminal.backend().buffer();
+    assert_eq!(buffer[(11, 0)].symbol(), "│");
+    assert_eq!(buffer[(13, 0)].fg, Color::Cyan);
+}

--- a/nori-rs/tui-components/src/detail/tests.rs
+++ b/nori-rs/tui-components/src/detail/tests.rs
@@ -3,6 +3,7 @@ use insta::assert_snapshot;
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use ratatui::style::Color;
+use ratatui::style::Style;
 
 fn entries() -> Vec<DetailEntry> {
     vec![
@@ -62,4 +63,73 @@ fn detail_pane_respects_fixed_gutter_and_provider_tone() {
     let buffer = terminal.backend().buffer();
     assert_eq!(buffer[(11, 0)].symbol(), "│");
     assert_eq!(buffer[(13, 0)].fg, Color::Cyan);
+}
+
+#[test]
+fn detail_pane_background_options_only_shade_their_intended_layer() {
+    let cases = [
+        (
+            DetailBackground::Transparent,
+            Color::Reset,
+            Color::Reset,
+            Color::Reset,
+        ),
+        (
+            DetailBackground::Pane,
+            Color::Blue,
+            Color::Blue,
+            Color::Blue,
+        ),
+        (
+            DetailBackground::Heading,
+            Color::Blue,
+            Color::Reset,
+            Color::Reset,
+        ),
+        (
+            DetailBackground::LabelGutter,
+            Color::Reset,
+            Color::Blue,
+            Color::Reset,
+        ),
+        (
+            DetailBackground::Rows,
+            Color::Reset,
+            Color::Blue,
+            Color::Blue,
+        ),
+    ];
+    let entries = [DetailEntry::key_value("Agent", "Codex")];
+    for (background, heading_bg, label_bg, value_bg) in cases {
+        let backend = TestBackend::new(30, 5);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let theme = Theme {
+            detail_surface: Style::new().bg(Color::Blue),
+            ..Theme::default()
+        };
+        terminal
+            .draw(|frame| {
+                frame.render_widget(
+                    DetailPane::new(&entries)
+                        .heading("Details")
+                        .theme(theme)
+                        .background(background),
+                    frame.area(),
+                )
+            })
+            .expect("draw pane");
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(0, 0)].bg, heading_bg, "{background:?} heading");
+        assert_eq!(buffer[(0, 2)].bg, label_bg, "{background:?} label");
+        assert_eq!(buffer[(10, 2)].bg, value_bg, "{background:?} value");
+        assert_eq!(
+            buffer[(29, 4)].bg,
+            if background == DetailBackground::Pane {
+                Color::Blue
+            } else {
+                Color::Reset
+            },
+            "{background:?} unused area"
+        );
+    }
 }

--- a/nori-rs/tui-components/src/detail/tests.rs
+++ b/nori-rs/tui-components/src/detail/tests.rs
@@ -133,3 +133,54 @@ fn detail_pane_background_options_only_shade_their_intended_layer() {
         );
     }
 }
+
+#[test]
+fn detail_pane_structural_options_draw_open_lines_and_insets() {
+    let entries = [
+        DetailEntry::key_value("Agent", "Codex"),
+        DetailEntry::Rule,
+        DetailEntry::key_value("Turns", "48"),
+    ];
+    let theme = Theme {
+        detail_surface: Style::new().bg(Color::Blue),
+        ..Theme::default()
+    };
+    let render = |background| {
+        let backend = TestBackend::new(30, 7);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        terminal
+            .draw(|frame| {
+                frame.render_widget(
+                    DetailPane::new(&entries)
+                        .heading("Details")
+                        .theme(theme)
+                        .background(background),
+                    frame.area(),
+                )
+            })
+            .expect("draw pane");
+        terminal.backend().buffer().clone()
+    };
+
+    let accent = render(DetailBackground::AccentRail);
+    assert_eq!(accent[(0, 0)].symbol(), "▎");
+    assert_eq!(accent[(0, 0)].fg, Color::Cyan);
+    assert_eq!(accent[(2, 0)].symbol(), "D");
+
+    let edges = render(DetailBackground::EdgeRails);
+    assert_eq!(edges[(0, 0)].symbol(), "│");
+    assert_eq!(edges[(29, 0)].symbol(), "│");
+
+    let underline = render(DetailBackground::HeadingRule);
+    assert_eq!(underline[(0, 1)].symbol(), "─");
+
+    let values = render(DetailBackground::ValuePanel);
+    assert_eq!(values[(0, 2)].bg, Color::Reset);
+    assert_eq!(values[(10, 2)].bg, Color::Blue);
+
+    let sections = render(DetailBackground::SectionRails);
+    assert_eq!(sections[(0, 2)].symbol(), "│");
+    assert_eq!(sections[(0, 2)].fg, Color::Cyan);
+    assert_eq!(sections[(0, 3)].symbol(), "├");
+    assert_eq!(sections[(0, 4)].symbol(), "│");
+}

--- a/nori-rs/tui-components/src/detail/tests.rs
+++ b/nori-rs/tui-components/src/detail/tests.rs
@@ -66,41 +66,9 @@ fn detail_pane_respects_fixed_gutter_and_provider_tone() {
 }
 
 #[test]
-fn detail_pane_background_options_only_shade_their_intended_layer() {
-    let cases = [
-        (
-            DetailBackground::Transparent,
-            Color::Reset,
-            Color::Reset,
-            Color::Reset,
-        ),
-        (
-            DetailBackground::Pane,
-            Color::Blue,
-            Color::Blue,
-            Color::Blue,
-        ),
-        (
-            DetailBackground::Heading,
-            Color::Blue,
-            Color::Reset,
-            Color::Reset,
-        ),
-        (
-            DetailBackground::LabelGutter,
-            Color::Reset,
-            Color::Blue,
-            Color::Reset,
-        ),
-        (
-            DetailBackground::Rows,
-            Color::Reset,
-            Color::Blue,
-            Color::Blue,
-        ),
-    ];
+fn detail_pane_only_shades_the_optional_heading() {
     let entries = [DetailEntry::key_value("Agent", "Codex")];
-    for (background, heading_bg, label_bg, value_bg) in cases {
+    let render = |heading: Option<&'static str>| {
         let backend = TestBackend::new(30, 5);
         let mut terminal = Terminal::new(backend).expect("test terminal");
         let theme = Theme {
@@ -109,78 +77,25 @@ fn detail_pane_background_options_only_shade_their_intended_layer() {
         };
         terminal
             .draw(|frame| {
+                let pane = DetailPane::new(&entries).theme(theme);
                 frame.render_widget(
-                    DetailPane::new(&entries)
-                        .heading("Details")
-                        .theme(theme)
-                        .background(background),
+                    if let Some(heading) = heading {
+                        pane.heading(heading)
+                    } else {
+                        pane
+                    },
                     frame.area(),
-                )
-            })
-            .expect("draw pane");
-        let buffer = terminal.backend().buffer();
-        assert_eq!(buffer[(0, 0)].bg, heading_bg, "{background:?} heading");
-        assert_eq!(buffer[(0, 2)].bg, label_bg, "{background:?} label");
-        assert_eq!(buffer[(10, 2)].bg, value_bg, "{background:?} value");
-        assert_eq!(
-            buffer[(29, 4)].bg,
-            if background == DetailBackground::Pane {
-                Color::Blue
-            } else {
-                Color::Reset
-            },
-            "{background:?} unused area"
-        );
-    }
-}
-
-#[test]
-fn detail_pane_structural_options_draw_open_lines_and_insets() {
-    let entries = [
-        DetailEntry::key_value("Agent", "Codex"),
-        DetailEntry::Rule,
-        DetailEntry::key_value("Turns", "48"),
-    ];
-    let theme = Theme {
-        detail_surface: Style::new().bg(Color::Blue),
-        ..Theme::default()
-    };
-    let render = |background| {
-        let backend = TestBackend::new(30, 7);
-        let mut terminal = Terminal::new(backend).expect("test terminal");
-        terminal
-            .draw(|frame| {
-                frame.render_widget(
-                    DetailPane::new(&entries)
-                        .heading("Details")
-                        .theme(theme)
-                        .background(background),
-                    frame.area(),
-                )
+                );
             })
             .expect("draw pane");
         terminal.backend().buffer().clone()
     };
+    let with_heading = render(Some("Details"));
+    assert_eq!(with_heading[(0, 0)].bg, Color::Blue);
+    assert_eq!(with_heading[(0, 2)].bg, Color::Reset);
+    assert_eq!(with_heading[(29, 4)].bg, Color::Reset);
 
-    let accent = render(DetailBackground::AccentRail);
-    assert_eq!(accent[(0, 0)].symbol(), "▎");
-    assert_eq!(accent[(0, 0)].fg, Color::Cyan);
-    assert_eq!(accent[(2, 0)].symbol(), "D");
-
-    let edges = render(DetailBackground::EdgeRails);
-    assert_eq!(edges[(0, 0)].symbol(), "│");
-    assert_eq!(edges[(29, 0)].symbol(), "│");
-
-    let underline = render(DetailBackground::HeadingRule);
-    assert_eq!(underline[(0, 1)].symbol(), "─");
-
-    let values = render(DetailBackground::ValuePanel);
-    assert_eq!(values[(0, 2)].bg, Color::Reset);
-    assert_eq!(values[(10, 2)].bg, Color::Blue);
-
-    let sections = render(DetailBackground::SectionRails);
-    assert_eq!(sections[(0, 2)].symbol(), "│");
-    assert_eq!(sections[(0, 2)].fg, Color::Cyan);
-    assert_eq!(sections[(0, 3)].symbol(), "├");
-    assert_eq!(sections[(0, 4)].symbol(), "│");
+    let without_heading = render(None);
+    assert_eq!(without_heading[(0, 0)].bg, Color::Reset);
+    assert_eq!(without_heading[(0, 0)].symbol(), "A");
 }

--- a/nori-rs/tui-components/src/lib.rs
+++ b/nori-rs/tui-components/src/lib.rs
@@ -10,6 +10,7 @@ pub mod picker;
 pub mod primitives;
 pub mod theme;
 
+pub use detail::DetailBackground;
 pub use detail::DetailEntry;
 pub use detail::DetailPane;
 pub use detail::DetailTone;

--- a/nori-rs/tui-components/src/lib.rs
+++ b/nori-rs/tui-components/src/lib.rs
@@ -10,7 +10,6 @@ pub mod picker;
 pub mod primitives;
 pub mod theme;
 
-pub use detail::DetailBackground;
 pub use detail::DetailEntry;
 pub use detail::DetailPane;
 pub use detail::DetailTone;

--- a/nori-rs/tui-components/src/lib.rs
+++ b/nori-rs/tui-components/src/lib.rs
@@ -4,11 +4,17 @@
 //! Consumers translate their input events into component actions, update
 //! caller-owned state, and render the resulting widgets.
 
+pub mod detail;
 pub mod markdown;
 pub mod picker;
 pub mod primitives;
 pub mod theme;
 
+pub use detail::DetailEntry;
+pub use detail::DetailPane;
+pub use detail::DetailTone;
+pub use detail::LabelWidth;
+pub use detail::ProviderKind;
 pub use markdown::Markdown;
 pub use markdown::StreamingMarkdown;
 pub use picker::Picker;

--- a/nori-rs/tui-components/src/picker/render.rs
+++ b/nori-rs/tui-components/src/picker/render.rs
@@ -19,6 +19,8 @@ use super::PickerLoadState;
 use super::PickerMode;
 use super::PickerState;
 use super::SearchMode;
+use crate::DetailEntry;
+use crate::DetailPane;
 use crate::EmptyState;
 use crate::KeyHint;
 use crate::KeyHints;
@@ -385,9 +387,6 @@ impl<K: Clone + Eq> Picker<'_, K> {
         let Some(item) = self.state.selected_item() else {
             return;
         };
-        Block::default()
-            .style(self.theme.detail_surface)
-            .render(area, buf);
         let inner = area.inner(Margin {
             horizontal: 1,
             vertical: 1,
@@ -395,8 +394,6 @@ impl<K: Clone + Eq> Picker<'_, K> {
         if inner.height == 0 {
             return;
         }
-        Paragraph::new(Line::styled("Details", self.theme.title))
-            .render(Rect::new(inner.x, inner.y, inner.width, 1), buf);
         let content = Rect::new(
             inner.x,
             inner.y.saturating_add(2),
@@ -410,40 +407,15 @@ impl<K: Clone + Eq> Picker<'_, K> {
                 .render(content, buf);
             return;
         }
-        let label_width = item
+        let entries = item
             .details
             .iter()
-            .map(|detail| detail.label.width() as u16)
-            .max()
-            .unwrap_or(0)
-            .min(14)
-            .min(content.width.saturating_sub(4) / 2);
-        for (index, detail) in item
-            .details
-            .iter()
-            .take(content.height as usize)
-            .enumerate()
-        {
-            let y = content.y.saturating_add(index as u16);
-            let label = pad_left(
-                &truncate(&detail.label, label_width as usize),
-                label_width as usize,
-            );
-            buf.set_string(content.x, y, label, self.theme.muted);
-            let separator_x = content.x.saturating_add(label_width).saturating_add(1);
-            buf.set_string(separator_x, y, "│", self.theme.separator);
-            let value_area = Rect::new(
-                separator_x.saturating_add(2),
-                y,
-                content
-                    .right()
-                    .saturating_sub(separator_x.saturating_add(2)),
-                1,
-            );
-            Paragraph::new(truncate_line(&detail.value, value_area.width as usize))
-                .style(self.theme.text)
-                .render(value_area, buf);
-        }
+            .map(|detail| DetailEntry::key_value(detail.label.clone(), detail.value.clone()))
+            .collect::<Vec<_>>();
+        DetailPane::new(&entries)
+            .heading("Details")
+            .theme(self.theme)
+            .render(Rect::new(inner.x, inner.y, inner.width, inner.height), buf);
     }
 
     fn render_footer(&self, area: Rect, buf: &mut Buffer) {
@@ -559,58 +531,4 @@ fn truncate(value: &str, width: usize) -> String {
     }
     result.push('…');
     result
-}
-
-fn pad_left(value: &str, width: usize) -> String {
-    let padding = width.saturating_sub(value.width());
-    format!("{}{value}", " ".repeat(padding))
-}
-
-fn truncate_line(line: &Line<'_>, width: usize) -> Line<'static> {
-    if width == 0 {
-        return Line::default();
-    }
-    let line_width = line
-        .spans
-        .iter()
-        .map(|span| span.content.width())
-        .sum::<usize>();
-    if line_width <= width {
-        return Line::from(
-            line.spans
-                .iter()
-                .map(|span| Span::styled(span.content.to_string(), span.style))
-                .collect::<Vec<_>>(),
-        );
-    }
-    if width == 1 {
-        return Line::from("…");
-    }
-
-    let mut remaining = width - 1;
-    let mut spans = Vec::new();
-    let mut ellipsis_style = ratatui::style::Style::default();
-    for span in &line.spans {
-        if remaining == 0 {
-            break;
-        }
-        let mut content = String::new();
-        for character in span.content.chars() {
-            let character_width = character.width().unwrap_or(0);
-            if character_width > remaining {
-                break;
-            }
-            content.push(character);
-            remaining -= character_width;
-        }
-        if !content.is_empty() {
-            ellipsis_style = span.style;
-            spans.push(Span::styled(content, span.style));
-        }
-        if remaining == 0 {
-            break;
-        }
-    }
-    spans.push(Span::styled("…", ellipsis_style));
-    Line::from(spans)
 }


### PR DESCRIPTION
## Summary
- add a stateless, caller-rect `DetailPane` with key/value entries, rules, semantic tones, automatic/fixed gutters, and intentional wrap/truncation
- use the selected visual contract: transparent body plus one neutral heading band when the optional heading is supplied
- adapt the existing Picker right-side structured details without changing picker workflow, placement, or its 110-column breakpoint
- include a storybook page showing the same production component in CLI right-pane and Handroll-style bottom-panel allocations
- demonstrate session title, provider, origin, created/modified timestamps, turn count, transcript size, and subdued prompt/response metadata
- document caller ownership and defer Handroll adoption

## Storybook
```console
cd nori-rs
cargo run -p codex-tui-components --example nori_storybook
```
Press `5` for Details.

## Architecture
`DetailPane` renders only into the `Rect` supplied by its caller. It does not own placement, breakpoints, terminal or event-loop lifecycle, focus, scrolling policy, async loading, routing, or application actions. Handroll/Sessions are unchanged.

## Dependency
Rebased onto `main` after Ratatui 0.30.2 merged in #583.

## Validation
- `cargo test -p codex-tui-components` (25 passed)
- `cargo test -p nori-tui` (1,273 passed initially; the three mock-agent timeouts all passed after building the required `mock_acp_agent` fixture; 1 ignored)
- `cargo build --bin nori`
- `cargo build --bin mock_acp_agent`
- `cargo test -p tui-pty-e2e` (all enabled tests passed)
- `cargo build -p codex-tui-components --example nori_storybook`
- `just fmt`
- `just fix -p codex-tui-components`
- interactive 120×36 storybook smoke test

## Limitations
No Handroll/Sessions changes and no consumer workflow changes. Scrolling remains intentionally caller-owned and deferred until a concrete consumer requires it.