### PR TITLE
feat(skills): add reproducible TUI capture workflow

### DIFF
--- a/.claude/skills/capture-tui/.nori-version
+++ b/.claude/skills/capture-tui/.nori-version
@@ -1,0 +1,4 @@
+{
+  "version": "1.0.0",
+  "registryUrl": "https://noriskillsets.dev"
+}

--- a/.claude/skills/capture-tui/SKILL.md
+++ b/.claude/skills/capture-tui/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: capture-tui
+description: Run, drive, inspect, and refresh real terminal UI and storybook sessions through isolated PTYs, libghostty-vt semantic state, and ghostty-web PNG rendering. Use when Codex needs to test a TUI or interactive CLI, renew a storybook screenshot, attach terminal visual evidence to a PR, compare layouts at fixed terminal sizes, or replace a synthetic terminal mockup with reproducible rendered output.
+---
+
+# Capture TUI
+
+Produce reviewable evidence from the application running in a real PTY. Treat
+the text snapshot and PNG as two views of the same recorded terminal state.
+
+## Capture contract
+
+- Run the production command rather than reconstructing its output.
+- Set explicit columns and rows; record both in the result.
+- Wait for observable text or stable screen state instead of sleeping.
+- Clear inherited `NO_COLOR` only inside the capture shell and advertise
+  true-color support there.
+- Use `libghostty-vt` for semantic screen inspection when available and
+  `ghostty-web` for reference PNG rendering.
+- Describe the PNG as Ghostty-backed reference rendering, not pixel-identical
+  native Ghostty output.
+- Destroy every PTY session, including failed runs.
+
+## One-shot or refreshed capture
+
+Create an agent-tty batch file. A batch should launch the TUI without waiting,
+wait for its initial screen, send the minimum input needed to reach the target,
+and wait for a label unique to that target.
+
+Example for the Nori component storybook:
+
+```json
+[
+  {
+    "run": "cargo run --manifest-path tui-components/Cargo.toml --example nori_storybook",
+    "noWait": true
+  },
+  {
+    "wait": {
+      "text": "Nori component storybook",
+      "timeout": 30000
+    }
+  },
+  {
+    "sendKeys": ["5"]
+  },
+  {
+    "wait": {
+      "text": "Handroll-style bottom panel",
+      "timeout": 10000
+    }
+  }
+]
+```
+
+Run the bundled script from the repository root or pass an explicit working
+directory:
+
+```bash
+SKILL_DIR=.claude/skills/capture-tui
+"$SKILL_DIR/scripts/capture-tui.sh" \
+  --cwd nori-rs \
+  --steps /tmp/nori-storybook-steps.json \
+  --out /tmp/nori-storybook.png \
+  --snapshot-out /tmp/nori-storybook.txt \
+  --metadata-out /tmp/nori-storybook.capture.json \
+  --cols 120 \
+  --rows 36
+```
+
+The first run may install the pinned Playwright Chromium build. The script
+prints a JSON result containing the semantic backend, visual backend, terminal
+dimensions, screen hash, PNG SHA-256, and output path. Re-run it with the same
+`--out` path to atomically refresh the view after code changes.
+
+## Review the result
+
+1. Read the text snapshot and confirm the expected target state is present.
+2. Inspect the PNG with the available image-viewing tool.
+3. Check truncation, wrapping, colors, focus, selection, and terminal edges.
+4. Repeat at a narrow size when responsive behavior is in scope.
+5. Include the image inline when reporting visual evidence.
+
+Do not commit generated screenshots unless the user requests repository-owned
+fixtures or documentation. Uploading an image or posting a PR comment remains
+an external side effect and requires the user's authorization.
+
+## Iterative sessions and native-terminal bugs
+
+Use the one-shot script for normal refreshes and PR evidence. Read
+[references/live-sessions.md](references/live-sessions.md) when a single TUI
+must remain alive across several input/capture cycles or when diagnosing a
+renderer-specific difference.
+
+If a bug depends on native Ghostty font shaping, Metal rendering, DPI, window
+chrome, or another native surface detail, keep this reference artifact and add
+a separate native-window capture. Do not present either artifact as the other.

--- a/.claude/skills/capture-tui/agents/openai.yaml
+++ b/.claude/skills/capture-tui/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Capture TUI"
+  short_description: "Capture reproducible TUI screenshots"
+  default_prompt: "Use $capture-tui to run this storybook in a real PTY and refresh its Ghostty-backed screenshot."

--- a/.claude/skills/capture-tui/nori.json
+++ b/.claude/skills/capture-tui/nori.json
@@ -1,0 +1,7 @@
+{
+  "name": "capture-tui",
+  "version": "1.0.0",
+  "type": "skill",
+  "description": "Run, inspect, and refresh reproducible Ghostty-backed terminal UI and storybook captures.",
+  "registryURL": "https://noriskillsets.dev"
+}

--- a/.claude/skills/capture-tui/references/live-sessions.md
+++ b/.claude/skills/capture-tui/references/live-sessions.md
@@ -1,0 +1,72 @@
+# Live and renderer-specific TUI capture
+
+## Renderer boundary
+
+`libghostty-vt` parses terminal sequences, maintains terminal state, and
+supports semantic snapshots. It does not define canonical headless RGBA pixels.
+`agent-tty` therefore uses `ghostty-web` through Playwright for PNG and WebM
+artifacts. The upstream tools describe this as a reference visual renderer,
+not a pixel guarantee for a native Ghostty window.
+
+Primary references:
+
+- <https://github.com/coder/agent-tty#how-it-works>
+- <https://github.com/coder/agent-tty/blob/main/docs/USAGE.md>
+- <https://github.com/ghostty-org/ghostty/discussions/12610>
+
+## Keep one session alive
+
+Use raw `agent-tty` commands when input and screenshots must be refreshed
+several times without restarting the TUI. Use an isolated home and the same
+home for every command.
+
+```bash
+ATTY=(npx -y -p node@24 -p agent-tty@0.5.0 agent-tty)
+CAPTURE_HOME=$(mktemp -d /tmp/capture-tui-live.XXXXXX)
+"${ATTY[@]}" --home "$CAPTURE_HOME" doctor --json
+
+SESSION_ID=$("${ATTY[@]}" --home "$CAPTURE_HOME" create \
+  --cols 120 --rows 36 --cwd "$PWD" --json -- /bin/bash \
+  | jq -r '.result.sessionId')
+```
+
+If `doctor` reports a missing browser cache, install the renderer-matched build
+once with `npx -y -p playwright@1.60.0 playwright install chromium`, then rerun
+`doctor` before creating the session.
+
+Drive the session with `batch` so each wait is anchored after its preceding
+input. Prefix the first run command with:
+
+```bash
+unset NO_COLOR; export COLORTERM=truecolor
+```
+
+Inspect before capturing:
+
+```bash
+"${ATTY[@]}" --home "$CAPTURE_HOME" snapshot "$SESSION_ID" \
+  --format text --json
+"${ATTY[@]}" --home "$CAPTURE_HOME" screenshot "$SESSION_ID" \
+  --profile reference-dark --hide-cursor --json
+```
+
+After a code change, stop or exit the program inside the same session, rerun
+the production command, wait for the target state, and capture again. Do not
+reuse an old screenshot after a failed rebuild.
+
+Always stop the session and remove its isolated home:
+
+```bash
+"${ATTY[@]}" --home "$CAPTURE_HOME" destroy "$SESSION_ID" --json
+case "$CAPTURE_HOME" in
+  /tmp/capture-tui-live.*) rm -rf -- "$CAPTURE_HOME" ;;
+esac
+```
+
+## When native capture is required
+
+Add a separate native-terminal capture when investigating font fallback,
+ligatures, GPU composition, DPI scaling, window decorations, native clipboard
+behavior, or a bug reproduced only by a named emulator. Record the emulator,
+version, font, scale, theme, and viewport. Keep the Ghostty-backed reference
+artifact because it remains deterministic and replayable.

--- a/.claude/skills/capture-tui/scripts/capture-tui.sh
+++ b/.claude/skills/capture-tui/scripts/capture-tui.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly AGENT_TTY_VERSION="0.5.0"
+readonly PLAYWRIGHT_VERSION="1.60.0"
+
+usage() {
+  cat <<'EOF'
+Usage: capture-tui.sh --cwd DIR --steps FILE --out FILE [options]
+
+Required:
+  --cwd DIR             Working directory for the captured terminal
+  --steps FILE          agent-tty batch steps as a JSON array
+  --out FILE            Destination PNG, replaced atomically
+
+Options:
+  --cols N              Terminal columns (default: 120)
+  --rows N              Terminal rows (default: 36)
+  --profile NAME        agent-tty render profile (default: reference-dark)
+  --shell PATH          Session shell (default: /bin/bash)
+  --snapshot-out FILE   Write the semantic text snapshot
+  --metadata-out FILE   Write the capture result JSON
+  -h, --help            Show this help
+EOF
+}
+
+capture_cwd=""
+steps_file=""
+output_path=""
+snapshot_output=""
+metadata_output=""
+capture_cols=120
+capture_rows=36
+capture_profile="reference-dark"
+capture_shell="/bin/bash"
+
+while (($# > 0)); do
+  case "$1" in
+    --cwd)
+      capture_cwd=${2:?"--cwd requires a directory"}
+      shift 2
+      ;;
+    --steps)
+      steps_file=${2:?"--steps requires a file"}
+      shift 2
+      ;;
+    --out)
+      output_path=${2:?"--out requires a file"}
+      shift 2
+      ;;
+    --cols)
+      capture_cols=${2:?"--cols requires a number"}
+      shift 2
+      ;;
+    --rows)
+      capture_rows=${2:?"--rows requires a number"}
+      shift 2
+      ;;
+    --profile)
+      capture_profile=${2:?"--profile requires a name"}
+      shift 2
+      ;;
+    --shell)
+      capture_shell=${2:?"--shell requires a path"}
+      shift 2
+      ;;
+    --snapshot-out)
+      snapshot_output=${2:?"--snapshot-out requires a file"}
+      shift 2
+      ;;
+    --metadata-out)
+      metadata_output=${2:?"--metadata-out requires a file"}
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$capture_cwd" || -z "$steps_file" || -z "$output_path" ]]; then
+  usage >&2
+  exit 2
+fi
+
+for required_command in npx jq; do
+  if ! command -v "$required_command" >/dev/null 2>&1; then
+    echo "Required command not found: $required_command" >&2
+    exit 2
+  fi
+done
+
+if [[ ! -d "$capture_cwd" ]]; then
+  echo "Capture working directory does not exist: $capture_cwd" >&2
+  exit 2
+fi
+if [[ ! -f "$steps_file" ]]; then
+  echo "Steps file does not exist: $steps_file" >&2
+  exit 2
+fi
+if [[ ! -x "$capture_shell" ]]; then
+  echo "Capture shell is not executable: $capture_shell" >&2
+  exit 2
+fi
+if [[ ! "$capture_cols" =~ ^[1-9][0-9]*$ || ! "$capture_rows" =~ ^[1-9][0-9]*$ ]]; then
+  echo "--cols and --rows must be positive integers" >&2
+  exit 2
+fi
+if ! jq -e 'type == "array" and length > 0' "$steps_file" >/dev/null; then
+  echo "Steps file must contain a non-empty JSON array" >&2
+  exit 2
+fi
+
+capture_cwd=$(cd "$capture_cwd" && pwd)
+steps_file=$(cd "$(dirname "$steps_file")" && pwd)/$(basename "$steps_file")
+
+mkdir -p "$(dirname "$output_path")"
+output_path=$(cd "$(dirname "$output_path")" && pwd)/$(basename "$output_path")
+if [[ -n "$snapshot_output" ]]; then
+  mkdir -p "$(dirname "$snapshot_output")"
+  snapshot_output=$(cd "$(dirname "$snapshot_output")" && pwd)/$(basename "$snapshot_output")
+fi
+if [[ -n "$metadata_output" ]]; then
+  mkdir -p "$(dirname "$metadata_output")"
+  metadata_output=$(cd "$(dirname "$metadata_output")" && pwd)/$(basename "$metadata_output")
+fi
+
+capture_home=$(mktemp -d /tmp/capture-tui.XXXXXX)
+session_id=""
+agent_tty=(npx -y -p node@24 -p "agent-tty@${AGENT_TTY_VERSION}" agent-tty)
+
+cleanup() {
+  if [[ -n "$session_id" ]]; then
+    "${agent_tty[@]}" --home "$capture_home" destroy "$session_id" --json \
+      >/dev/null 2>&1 || true
+  fi
+  case "$capture_home" in
+    /tmp/capture-tui.*)
+      rm -rf -- "$capture_home"
+      ;;
+  esac
+}
+trap cleanup EXIT
+
+doctor_json="$capture_home/doctor.json"
+doctor_status=0
+"${agent_tty[@]}" --home "$capture_home" doctor --json >"$doctor_json" \
+  || doctor_status=$?
+if [[ ! -s "$doctor_json" ]]; then
+  echo "agent-tty doctor failed without returning diagnostics (exit $doctor_status)" >&2
+  exit 1
+fi
+if ! jq -e '.result.ok == true' "$doctor_json" >/dev/null; then
+  browser_missing=$(jq -r '
+    any(.result.checks.renderer[]?;
+      (.name == "browser_cache_accessible" or .name == "browser_launch")
+      and .status == "fail")
+  ' "$doctor_json")
+  if [[ "$browser_missing" == "true" ]]; then
+    echo "Installing the pinned Playwright Chromium build..." >&2
+    npx -y -p "playwright@${PLAYWRIGHT_VERSION}" playwright install chromium >&2
+    doctor_status=0
+    "${agent_tty[@]}" --home "$capture_home" doctor --json >"$doctor_json" \
+      || doctor_status=$?
+    if [[ ! -s "$doctor_json" ]]; then
+      echo "agent-tty doctor failed without returning diagnostics (exit $doctor_status)" >&2
+      exit 1
+    fi
+  fi
+fi
+if ! jq -e '.result.ok == true' "$doctor_json" >/dev/null; then
+  echo "agent-tty environment checks failed:" >&2
+  jq '.result.checks' "$doctor_json" >&2
+  exit 1
+fi
+
+normalized_steps="$capture_home/steps.json"
+jq '
+  map(
+    if (.run? | type) == "string" then
+      .run = ("unset NO_COLOR; export COLORTERM=truecolor; " + .run)
+    else
+      .
+    end
+  )
+' "$steps_file" >"$normalized_steps"
+
+create_json="$capture_home/create.json"
+"${agent_tty[@]}" --home "$capture_home" create \
+  --cols "$capture_cols" \
+  --rows "$capture_rows" \
+  --cwd "$capture_cwd" \
+  --name capture-tui \
+  --json \
+  -- "$capture_shell" >"$create_json"
+session_id=$(jq -er '.result.sessionId' "$create_json")
+
+batch_json="$capture_home/batch.json"
+batch_status=0
+"${agent_tty[@]}" --home "$capture_home" batch "$session_id" \
+  --file "$normalized_steps" \
+  --json >"$batch_json" || batch_status=$?
+if ! jq -e '.ok == true and (.result.failedIndices | length == 0)' "$batch_json" >/dev/null; then
+  echo "TUI interaction batch failed:" >&2
+  jq '.' "$batch_json" >&2
+  if ((batch_status > 0)); then
+    exit "$batch_status"
+  fi
+  exit 1
+fi
+
+snapshot_json="$capture_home/snapshot.json"
+"${agent_tty[@]}" --home "$capture_home" snapshot "$session_id" \
+  --format text \
+  --json >"$snapshot_json"
+
+screenshot_json="$capture_home/screenshot.json"
+"${agent_tty[@]}" --home "$capture_home" screenshot "$session_id" \
+  --profile "$capture_profile" \
+  --hide-cursor \
+  --json >"$screenshot_json"
+
+artifact_path=$(jq -er '.result.artifactPath' "$screenshot_json")
+staged_png=$(mktemp "${output_path}.tmp.XXXXXX")
+cp "$artifact_path" "$staged_png"
+mv "$staged_png" "$output_path"
+
+if [[ -n "$snapshot_output" ]]; then
+  staged_snapshot=$(mktemp "${snapshot_output}.tmp.XXXXXX")
+  jq -r '.result.text' "$snapshot_json" >"$staged_snapshot"
+  mv "$staged_snapshot" "$snapshot_output"
+fi
+
+semantic_backend=$(jq -r '
+  if any(.result.checks.renderer[]?;
+    .name == "libghostty_vt_available" and .status == "pass")
+  then "libghostty-vt"
+  else "ghostty-web"
+  end
+' "$doctor_json")
+
+capture_result=$(jq -n \
+  --arg outputPath "$output_path" \
+  --arg semanticBackend "$semantic_backend" \
+  --slurpfile snapshot "$snapshot_json" \
+  --slurpfile screenshot "$screenshot_json" \
+  '{
+    ok: true,
+    outputPath: $outputPath,
+    semanticBackend: $semanticBackend,
+    visualBackend: $screenshot[0].result.rendererBackend,
+    profileName: $screenshot[0].result.profileName,
+    cols: $screenshot[0].result.cols,
+    rows: $screenshot[0].result.rows,
+    pixelWidth: $screenshot[0].result.pixelWidth,
+    pixelHeight: $screenshot[0].result.pixelHeight,
+    screenHash: $snapshot[0].result.screenHash,
+    pngSha256: $screenshot[0].result.sha256,
+    capturedAtSeq: $screenshot[0].result.capturedAtSeq
+  }')
+
+if [[ -n "$metadata_output" ]]; then
+  staged_metadata=$(mktemp "${metadata_output}.tmp.XXXXXX")
+  printf '%s\n' "$capture_result" >"$staged_metadata"
+  mv "$staged_metadata" "$metadata_output"
+fi
+
+printf '%s\n' "$capture_result"


### PR DESCRIPTION
## Summary

- add a repository-owned `capture-tui` skill, discoverable through the existing `.agents/skills` bridge
- provide a pinned, isolated `agent-tty` wrapper for real PTY execution, observable waits, semantic snapshots, Ghostty-backed PNG rendering, atomic refreshes, and guaranteed session cleanup
- document persistent live-session use and the boundary between deterministic `ghostty-web` reference artifacts and native Ghostty window pixels
- include Nori Skillsets and Codex UI metadata

## Validation

- `quick_validate.py .claude/skills/capture-tui`
- `bash -n .claude/skills/capture-tui/scripts/capture-tui.sh`
- parsed both JSON manifests with `jq`
- ran the merged Nori component storybook in a 120×36 PTY and navigated to page 5
  - semantic backend: `libghostty-vt`
  - visual backend: `ghostty-web`
  - screen hash: `3e0803530e5c5a5f8ee6df67926bc444460d67e5589ba77816aa5f65239af118`
  - PNG SHA-256: `ef72d7e29241a354a4e91d2847e18599d8bb053d708e37142b6356935e2c9001`
- repeated the capture to the same output path and reproduced both hashes
- forced a wait timeout, confirmed exit code `11`, no PNG publication, and no leaked capture session

## Notes

The PNG renderer is intentionally described as Ghostty-backed reference rendering. It is not a claim of pixel-identical native Ghostty output; native font, Metal, DPI, or window-specific bugs still require separate native-window evidence.
