### PR TITLE
fix(acp-host): clean stale @zed-industries ACP cache entries before spawning

### DIFF
--- a/nori-rs/Cargo.lock
+++ b/nori-rs/Cargo.lock
@@ -3596,6 +3596,7 @@ dependencies = [
  "codex-rmcp-client",
  "codex-utils-string",
  "diffy",
+ "dirs",
  "futures",
  "libc",
  "nori-config",

--- a/nori-rs/acp-host/Cargo.toml
+++ b/nori-rs/acp-host/Cargo.toml
@@ -23,6 +23,7 @@ base64 = { workspace = true }
 codex-rmcp-client = { workspace = true }
 codex-utils-string = { workspace = true }
 diffy = { workspace = true }
+dirs = { workspace = true }
 futures = { workspace = true }
 libc = { workspace = true }
 nori-config = { workspace = true }

--- a/nori-rs/acp-host/src/registry.rs
+++ b/nori-rs/acp-host/src/registry.rs
@@ -632,6 +632,32 @@ pub fn list_available_agents() -> Vec<AcpAgentInfo> {
     agents
 }
 
+/// Remove stale `@zed-industries/claude-agent-acp*` and `codex-acp*` entries
+/// from bun's install cache. These packages were renamed to the
+/// `@agentclientprotocol` scope but leftover cache entries under the old scope
+/// can interfere with resolution.
+fn clean_stale_acp_cache(cache_dir: &std::path::Path) {
+    let zed_scope = cache_dir.join("@zed-industries");
+    let entries = match std::fs::read_dir(&zed_scope) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with("claude-agent-acp") || name.starts_with("codex-acp") {
+            let path = entry.path();
+            tracing::info!("removing stale ACP cache entry: {}", path.display());
+            if let Err(e) = std::fs::remove_dir_all(&path) {
+                tracing::warn!(
+                    "failed to remove stale ACP cache entry {}: {e}",
+                    path.display()
+                );
+            }
+        }
+    }
+}
+
 /// Get ACP agent configuration for a given agent name
 ///
 /// # Arguments
@@ -722,6 +748,23 @@ pub fn get_agent_config(agent_name: &str) -> Result<AcpAgentConfig> {
     // Try to parse as a built-in AgentKind (auto-detection path)
     if let Some(agent) = AgentKind::from_slug(&normalized) {
         let package_manager = detect_preferred_package_manager();
+
+        if matches!(agent, AgentKind::ClaudeCode | AgentKind::Codex)
+            && package_manager == PackageManager::Bun
+        {
+            let cache_dir = std::env::var("BUN_INSTALL_CACHE_DIR")
+                .map(std::path::PathBuf::from)
+                .or_else(|_| {
+                    std::env::var("BUN_INSTALL")
+                        .map(|p| std::path::PathBuf::from(p).join("install/cache"))
+                })
+                .unwrap_or_else(|_| {
+                    dirs::home_dir()
+                        .unwrap_or_default()
+                        .join(".bun/install/cache")
+                });
+            clean_stale_acp_cache(&cache_dir);
+        }
 
         let (command, args) = match agent {
             // Claude and Codex use external ACP adapters
@@ -1500,6 +1543,52 @@ mod tests {
     #[test]
     fn test_claude_code_context_window_is_1m() {
         assert_eq!(AgentKind::ClaudeCode.context_window_size(), 1_000_000);
+    }
+
+    #[test]
+    fn test_clean_stale_acp_cache_removes_zed_entries() {
+        let cache_dir = tempfile::tempdir().unwrap();
+        let zed_scope = cache_dir.path().join("@zed-industries");
+        std::fs::create_dir_all(zed_scope.join("claude-agent-acp@0.23.1@@@1")).unwrap();
+        std::fs::create_dir_all(zed_scope.join("claude-agent-acp@0.20.0@@@1")).unwrap();
+        std::fs::create_dir_all(zed_scope.join("codex-acp@0.5.0@@@1")).unwrap();
+        // Unrelated package under the same scope should be preserved
+        std::fs::create_dir_all(zed_scope.join("some-other-package@1.0.0@@@1")).unwrap();
+
+        let acp_scope = cache_dir.path().join("@agentclientprotocol");
+        std::fs::create_dir_all(acp_scope.join("claude-agent-acp@0.70.0@@@1")).unwrap();
+        std::fs::create_dir_all(acp_scope.join("codex-acp@0.10.0@@@1")).unwrap();
+
+        clean_stale_acp_cache(cache_dir.path());
+
+        // Stale @zed-industries entries should be gone
+        assert!(!zed_scope.join("claude-agent-acp@0.23.1@@@1").exists());
+        assert!(!zed_scope.join("claude-agent-acp@0.20.0@@@1").exists());
+        assert!(!zed_scope.join("codex-acp@0.5.0@@@1").exists());
+        // Unrelated package should be preserved
+        assert!(zed_scope.join("some-other-package@1.0.0@@@1").exists());
+        // @agentclientprotocol entries should be untouched
+        assert!(acp_scope.join("claude-agent-acp@0.70.0@@@1").exists());
+        assert!(acp_scope.join("codex-acp@0.10.0@@@1").exists());
+    }
+
+    #[test]
+    fn test_clean_stale_acp_cache_noop_when_no_zed_scope() {
+        let cache_dir = tempfile::tempdir().unwrap();
+        let acp_scope = cache_dir.path().join("@agentclientprotocol");
+        std::fs::create_dir_all(acp_scope.join("claude-agent-acp@0.70.0@@@1")).unwrap();
+
+        // Should not panic or error when @zed-industries doesn't exist
+        clean_stale_acp_cache(cache_dir.path());
+
+        assert!(acp_scope.join("claude-agent-acp@0.70.0@@@1").exists());
+    }
+
+    #[test]
+    fn test_clean_stale_acp_cache_noop_when_cache_dir_missing() {
+        let cache_dir = std::path::PathBuf::from("/tmp/nonexistent-bun-cache-test-dir");
+        // Should not panic or error
+        clean_stale_acp_cache(&cache_dir);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- Removes stale `@zed-industries/claude-agent-acp*` and `codex-acp*` entries from bun's install cache before spawning the ACP agent subprocess
- Fixes `/model claude-opus-4-8` failing with "Invalid value for config option model" because bun resolved the old package version (SDK 0.2.83) instead of the current one (SDK 0.3.238 which knows about opus 4.8)
- Respects `BUN_INSTALL_CACHE_DIR` and `BUN_INSTALL` env vars for non-default cache locations

## Test Plan
- [x] Unit tests verify stale entries are removed while unrelated packages are preserved
- [x] No-op when cache dir or `@zed-industries/` scope doesn't exist
- [x] All 76 existing tests in nori-acp-host pass
- [ ] Manual: after applying, run nori with bun, verify `/model claude-opus-4-8` works

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets