### PR TITLE
feat(tui,harness): run out-of-catalog models via spawn-time injection

### DIFF
--- a/nori-rs/acp-host/docs.md
+++ b/nori-rs/acp-host/docs.md
@@ -51,6 +51,20 @@ The host is the only client-side product crate that directly uses the
   `features.goals = false`, leaving Nori-owned goal state to the `nori-client`
   MCP server. `error_category.rs` preserves structured ACP errors before
   falling back to message classification.
+- `registry.rs` also owns spawn-time **model injection**. Runtime model changes
+  normally go over the live ACP `session/set_config_option` RPC, but adapters
+  advertise only a subset of the models they can run and reject anything outside
+  that catalog. `ModelInjection` ({ `Env { var }`, `Arg { flag }`, `CodexConfig`,
+  `None` }) forces a chosen model through the agent's own out-of-band channel at
+  spawn, so the model becomes the adapter's advertised `currentValue` (which ACP
+  always treats as valid), bypassing the catalog. `AgentKind::model_injection()`
+  maps built-in agents to their channel (Claude → `ANTHROPIC_MODEL` env, Gemini
+  → `GEMINI_MODEL` env, Codex → merge `model` into the `CODEX_CONFIG` JSON).
+  Custom/BYO agents resolve their strategy from `[[agents]].model_override` in
+  `nori-config`; the default is `None` (no channel → live RPC only).
+  `AcpAgentConfig::inject_model` applies the resolved strategy to the spawn env
+  or args and is a no-op for `None`, so callers (the harness) may invoke it
+  unconditionally; `supports_model_injection()` reports whether a channel exists.
 
 ### Things to Know
 
@@ -62,6 +76,13 @@ The host is the only client-side product crate that directly uses the
 - Ambient `CODEX_CONFIG` must be a JSON object whose `features` value, when
   present, is also an object. Invalid JSON or incompatible shapes fail built-in
   Codex configuration explicitly instead of silently discarding user settings.
+  Codex model injection merges only the `model` key into that same object,
+  preserving the goals-disabled flag.
+- Model injection does not validate the model id: an invalid model is accepted at
+  spawn and only fails at the first prompt. For env-based channels, nori's
+  injected value takes precedence over the agent's own configured model (e.g.
+  `~/.claude/settings.json`) for nori-spawned sessions — nori's `[default_models]`
+  is authoritative here by design.
 - Terminal and extension request families are not advertised by the current
   host. Adding them requires an explicit host-policy decision, not a generic
   protocol mirror.

--- a/nori-rs/acp-host/docs.md
+++ b/nori-rs/acp-host/docs.md
@@ -83,6 +83,11 @@ The host is the only client-side product crate that directly uses the
   injected value takes precedence over the agent's own configured model (e.g.
   `~/.claude/settings.json`) for nori-spawned sessions — nori's `[default_models]`
   is authoritative here by design.
+- `set_config_option` mirrors only a *successful* response onto the public event
+  boundary. Its error is returned to the caller (the `/model` flow renders a
+  friendly message and may persist-and-restart), so mirroring the raw JSON-RPC
+  error too would surface a confusing duplicate "Internal error" cell. Raw wire
+  errors are still captured by ACP wire recording, which taps stdio separately.
 - Terminal and extension request families are not advertised by the current
   host. Adding them requires an explicit host-policy decision, not a generic
   protocol mirror.

--- a/nori-rs/acp-host/src/connection/acp_connection.rs
+++ b/nori-rs/acp-host/src/connection/acp_connection.rs
@@ -972,15 +972,23 @@ impl AcpConnection {
             ));
         let request_id = schema_request_id(request.id());
         let response = request.block_task().await;
-        let _ = self
-            .event_tx
-            .send(ConnectionEvent::Acp(Box::new(AcpEvent::Response {
-                request_id,
-                response: response
-                    .clone()
-                    .map(acp::AgentResponse::SetSessionConfigOptionResponse),
-            })))
-            .await;
+        // Only mirror a successful response onto the public boundary. Unlike
+        // prompt/new-session requests (whose raw errors are the user-facing
+        // surface), a config-option request's outcome is returned to the caller
+        // and rendered by the `/model` flow — which shows a friendly message and
+        // may persist-and-restart. Mirroring the raw JSON-RPC error here too
+        // would surface a confusing duplicate "Internal error" cell.
+        if let Ok(ok_response) = &response {
+            let _ = self
+                .event_tx
+                .send(ConnectionEvent::Acp(Box::new(AcpEvent::Response {
+                    request_id,
+                    response: Ok(acp::AgentResponse::SetSessionConfigOptionResponse(
+                        ok_response.clone(),
+                    )),
+                })))
+                .await;
+        }
         let response = response.context("Failed to set ACP session config option")?;
 
         if let Ok(mut state) = self.session_config_state.write() {

--- a/nori-rs/acp-host/src/connection/acp_connection_tests.rs
+++ b/nori-rs/acp-host/src/connection/acp_connection_tests.rs
@@ -837,6 +837,7 @@ fn script_agent_config(dir: &std::path::Path, body: &str) -> crate::registry::Ac
         auth_hint: "run: script-agent login".to_string(),
         display_name: "Script Agent".to_string(),
         install_hint: "none".to_string(),
+        model_injection: crate::registry::ModelInjection::None,
     }
 }
 

--- a/nori-rs/acp-host/src/registry.rs
+++ b/nori-rs/acp-host/src/registry.rs
@@ -48,6 +48,52 @@ fn codex_config_with_native_goals_disabled(config: Option<&str>) -> Result<Strin
     serde_json::to_string(config).context("failed to serialize CODEX_CONFIG")
 }
 
+/// Merge a `model` key into a `CODEX_CONFIG` JSON object, preserving any other
+/// keys already present (e.g. the goals-disabled flag).
+fn codex_config_with_model(config: Option<&str>, model: &str) -> Result<String> {
+    let mut value = match config {
+        Some(config) => serde_json::from_str::<serde_json::Value>(config)
+            .context("CODEX_CONFIG must be valid JSON")?,
+        None => serde_json::json!({}),
+    };
+    value
+        .as_object_mut()
+        .context("CODEX_CONFIG must contain a JSON object")?
+        .insert("model".to_string(), model.into());
+    serde_json::to_string(&value).context("failed to serialize CODEX_CONFIG")
+}
+
+/// How a chosen model id is delivered to an agent subprocess at spawn time.
+///
+/// Runtime model changes go over the live ACP `session/set_config_option` RPC,
+/// but adapters reject models outside their advertised catalog. To run such a
+/// model, nori forces it through the agent's own out-of-band channel at spawn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModelInjection {
+    /// Set an environment variable to the model id.
+    Env { var: String },
+    /// Append a CLI flag followed by the model id.
+    Arg { flag: String },
+    /// Merge the model id into the `CODEX_CONFIG` JSON object.
+    CodexConfig,
+    /// No known channel; the model can only be set via the live ACP RPC.
+    None,
+}
+
+impl ModelInjection {
+    /// Resolve a custom agent's declared model-override config into a strategy.
+    /// `env` wins if both `env` and `arg` are set.
+    fn from_override(over: &nori_config::ModelOverrideToml) -> Self {
+        if let Some(var) = &over.env {
+            ModelInjection::Env { var: var.clone() }
+        } else if let Some(flag) = &over.arg {
+            ModelInjection::Arg { flag: flag.clone() }
+        } else {
+            ModelInjection::None
+        }
+    }
+}
+
 // =============================================================================
 // Core Enums
 // =============================================================================
@@ -129,6 +175,22 @@ impl AgentKind {
     /// Get all agent variants
     pub fn all() -> &'static [AgentKind] {
         &[AgentKind::ClaudeCode, AgentKind::Codex, AgentKind::Gemini]
+    }
+
+    /// The out-of-band channel this built-in agent uses to receive a forced
+    /// model id at spawn time. Verified against each adapter: Claude honors
+    /// `ANTHROPIC_MODEL`, Gemini honors `GEMINI_MODEL` (both in ACP mode), and
+    /// Codex reads the `model` key from its `CODEX_CONFIG` JSON.
+    pub fn model_injection(&self) -> ModelInjection {
+        match self {
+            AgentKind::ClaudeCode => ModelInjection::Env {
+                var: "ANTHROPIC_MODEL".to_string(),
+            },
+            AgentKind::Gemini => ModelInjection::Env {
+                var: "GEMINI_MODEL".to_string(),
+            },
+            AgentKind::Codex => ModelInjection::CodexConfig,
+        }
     }
 
     /// Get the base directory for transcript files, relative to home directory.
@@ -265,6 +327,9 @@ pub struct RegisteredAgent {
     pub auth_hint: Option<String>,
     /// Transcript base directory (relative to home)
     pub transcript_base_dir: Option<String>,
+    /// How to force a model on this agent at spawn time (custom agents only;
+    /// built-in agents derive this from their `AgentKind`).
+    pub model_injection: ModelInjection,
 }
 
 /// Global agent registry. Protected by RwLock so tests can reset it.
@@ -282,6 +347,7 @@ pub fn build_default_agents() -> Vec<RegisteredAgent> {
             context_window_size: Some(kind.context_window_size()),
             auth_hint: Some(kind.auth_hint().to_string()),
             transcript_base_dir: Some(kind.transcript_base_dir().to_string()),
+            model_injection: kind.model_injection(),
         })
         .collect()
 }
@@ -317,6 +383,11 @@ pub fn build_registry(custom_agents: Vec<AgentConfigToml>) -> Result<Vec<Registe
             context_window_size: custom.context_window_size,
             auth_hint: custom.auth_hint,
             transcript_base_dir: custom.transcript_base_dir,
+            model_injection: custom
+                .model_override
+                .as_ref()
+                .map(ModelInjection::from_override)
+                .unwrap_or(ModelInjection::None),
         };
 
         // Override built-in if slug matches, otherwise append
@@ -560,9 +631,40 @@ pub struct AcpAgentConfig {
     pub display_name: String,
     /// Install command hint for error messages (e.g. "npm install -g @pkg" or "ensure /usr/bin/x is in PATH")
     pub install_hint: String,
+    /// How to force a model on this agent at spawn time.
+    pub model_injection: ModelInjection,
 }
 
 impl AcpAgentConfig {
+    /// Force `model` into this agent's spawn configuration via its out-of-band
+    /// channel (env var, CLI flag, or `CODEX_CONFIG` merge). A no-op for agents
+    /// with no known channel, so callers may apply it unconditionally.
+    pub fn inject_model(&mut self, model: &str) -> Result<()> {
+        match &self.model_injection {
+            ModelInjection::Env { var } => {
+                self.env.insert(var.clone(), model.to_string());
+            }
+            ModelInjection::Arg { flag } => {
+                if !self.args.iter().any(|arg| arg == flag) {
+                    self.args.push(flag.clone());
+                    self.args.push(model.to_string());
+                }
+            }
+            ModelInjection::CodexConfig => {
+                let current = self.env.get("CODEX_CONFIG").cloned();
+                let merged = codex_config_with_model(current.as_deref(), model)?;
+                self.env.insert("CODEX_CONFIG".to_string(), merged);
+            }
+            ModelInjection::None => {}
+        }
+        Ok(())
+    }
+
+    /// Whether this agent has a spawn-time channel to force a model.
+    pub fn supports_model_injection(&self) -> bool {
+        !matches!(self.model_injection, ModelInjection::None)
+    }
+
     /// Context window size for this agent, if known.
     pub fn context_window_size(&self) -> Option<i64> {
         // Check registry first (may have custom override)
@@ -716,6 +818,7 @@ pub fn get_agent_config(agent_name: &str) -> Result<AcpAgentConfig> {
             auth_hint: registered.auth_hint.clone().unwrap_or_default(),
             display_name: registered.name.clone(),
             install_hint,
+            model_injection: registered.model_injection.clone(),
         });
     }
 
@@ -775,6 +878,7 @@ pub fn get_agent_config(agent_name: &str) -> Result<AcpAgentConfig> {
             auth_hint: agent.auth_hint().to_string(),
             display_name: agent.display_name().to_string(),
             install_hint: format!("npm install -g {}", agent.npm_package()),
+            model_injection: agent.model_injection(),
         });
     }
 
@@ -871,6 +975,9 @@ fn get_mock_agent_config(normalized: &str) -> Option<AcpAgentConfig> {
                 auth_hint: "Mock agent - no authentication required.".to_string(),
                 display_name: "Mock ACP".to_string(),
                 install_hint: "Mock agent - no installation required".to_string(),
+                model_injection: ModelInjection::Env {
+                    var: "MOCK_AGENT_INJECTED_MODEL".to_string(),
+                },
             })
         }
         "mock-model-alt" => {
@@ -919,6 +1026,9 @@ fn get_mock_agent_config(normalized: &str) -> Option<AcpAgentConfig> {
                 auth_hint: "Mock agent - no authentication required.".to_string(),
                 display_name: "Mock ACP Alt".to_string(),
                 install_hint: "Mock agent - no installation required".to_string(),
+                model_injection: ModelInjection::Env {
+                    var: "MOCK_AGENT_INJECTED_MODEL".to_string(),
+                },
             })
         }
         _ => None,
@@ -1105,6 +1215,185 @@ mod tests {
                 .to_string()
                 .contains("CODEX_CONFIG must be valid JSON")
         );
+    }
+
+    #[test]
+    fn claude_injects_model_via_anthropic_model_env() {
+        let mut config = get_agent_config("claude-code").expect("claude config");
+
+        config
+            .inject_model("claude-opus-4-6")
+            .expect("model injection should succeed");
+
+        assert_eq!(
+            config.env.get("ANTHROPIC_MODEL").map(String::as_str),
+            Some("claude-opus-4-6"),
+            "the spawned Claude subprocess must receive the model via ANTHROPIC_MODEL"
+        );
+    }
+
+    #[test]
+    fn gemini_injects_model_via_gemini_model_env() {
+        let mut config = get_agent_config("gemini").expect("gemini config");
+
+        config
+            .inject_model("gemini-2.5-pro")
+            .expect("model injection should succeed");
+
+        assert_eq!(
+            config.env.get("GEMINI_MODEL").map(String::as_str),
+            Some("gemini-2.5-pro"),
+            "the spawned Gemini subprocess must receive the model via GEMINI_MODEL"
+        );
+    }
+
+    #[test]
+    fn codex_injects_model_into_codex_config_preserving_goals_flag() {
+        let mut config = get_agent_config("codex").expect("codex config");
+
+        config
+            .inject_model("gpt-5.1-codex")
+            .expect("model injection should succeed");
+
+        let codex_config = config
+            .env
+            .get("CODEX_CONFIG")
+            .expect("CODEX_CONFIG should be present for codex");
+        let parsed: serde_json::Value =
+            serde_json::from_str(codex_config).expect("CODEX_CONFIG should be valid JSON");
+        assert_eq!(
+            parsed.get("model").and_then(serde_json::Value::as_str),
+            Some("gpt-5.1-codex"),
+            "the model must be merged into CODEX_CONFIG"
+        );
+        assert_eq!(
+            parsed.pointer("/features/goals"),
+            Some(&serde_json::Value::Bool(false)),
+            "injecting a model must not clobber the goals-disabled flag"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn custom_agent_env_override_injects_model() {
+        reset_registry();
+        use nori_config::AgentConfigToml;
+        use nori_config::AgentDistributionToml;
+        use nori_config::LocalDistribution;
+        use nori_config::ModelOverrideToml;
+        let custom = AgentConfigToml {
+            name: "Custom Env".to_string(),
+            slug: "custom-env".to_string(),
+            distribution: AgentDistributionToml {
+                local: Some(LocalDistribution {
+                    command: "/usr/bin/agent".to_string(),
+                    args: vec!["acp".to_string()],
+                    env: std::collections::HashMap::new(),
+                }),
+                ..Default::default()
+            },
+            context_window_size: None,
+            auth_hint: None,
+            transcript_base_dir: None,
+            model_override: Some(ModelOverrideToml {
+                env: Some("MY_MODEL".to_string()),
+                arg: None,
+            }),
+        };
+        initialize_registry(vec![custom]).unwrap();
+
+        let mut config = get_agent_config("custom-env").expect("custom-env config");
+        config.inject_model("some-model").expect("inject");
+
+        assert_eq!(
+            config.env.get("MY_MODEL").map(String::as_str),
+            Some("some-model"),
+            "a BYO agent declaring an env override must receive the model there"
+        );
+        reset_registry();
+    }
+
+    #[test]
+    #[serial]
+    fn custom_agent_arg_override_appends_model_flag() {
+        reset_registry();
+        use nori_config::AgentConfigToml;
+        use nori_config::AgentDistributionToml;
+        use nori_config::LocalDistribution;
+        use nori_config::ModelOverrideToml;
+        let custom = AgentConfigToml {
+            name: "Custom Arg".to_string(),
+            slug: "custom-arg".to_string(),
+            distribution: AgentDistributionToml {
+                local: Some(LocalDistribution {
+                    command: "/usr/bin/agent".to_string(),
+                    args: vec!["acp".to_string()],
+                    env: std::collections::HashMap::new(),
+                }),
+                ..Default::default()
+            },
+            context_window_size: None,
+            auth_hint: None,
+            transcript_base_dir: None,
+            model_override: Some(ModelOverrideToml {
+                env: None,
+                arg: Some("--model".to_string()),
+            }),
+        };
+        initialize_registry(vec![custom]).unwrap();
+
+        let mut config = get_agent_config("custom-arg").expect("custom-arg config");
+        config.inject_model("some-model").expect("inject");
+
+        assert_eq!(
+            config.args,
+            vec!["acp", "--model", "some-model"],
+            "a BYO agent declaring an arg override must receive the model as a CLI flag"
+        );
+        reset_registry();
+    }
+
+    #[test]
+    #[serial]
+    fn custom_agent_without_override_leaves_spawn_config_unchanged() {
+        reset_registry();
+        use nori_config::AgentConfigToml;
+        use nori_config::AgentDistributionToml;
+        use nori_config::LocalDistribution;
+        let custom = AgentConfigToml {
+            name: "Custom None".to_string(),
+            slug: "custom-none".to_string(),
+            distribution: AgentDistributionToml {
+                local: Some(LocalDistribution {
+                    command: "/usr/bin/agent".to_string(),
+                    args: vec!["acp".to_string()],
+                    env: std::collections::HashMap::from([("K".to_string(), "v".to_string())]),
+                }),
+                ..Default::default()
+            },
+            context_window_size: None,
+            auth_hint: None,
+            transcript_base_dir: None,
+            model_override: None,
+        };
+        initialize_registry(vec![custom]).unwrap();
+
+        let mut config = get_agent_config("custom-none").expect("custom-none config");
+        let env_before = config.env.clone();
+        let args_before = config.args.clone();
+        config
+            .inject_model("some-model")
+            .expect("inject should be a no-op");
+
+        assert_eq!(
+            config.env, env_before,
+            "an agent with no model channel must not have its env mutated"
+        );
+        assert_eq!(
+            config.args, args_before,
+            "an agent with no model channel must not have its args mutated"
+        );
+        reset_registry();
     }
 
     #[test]
@@ -1306,6 +1595,7 @@ mod tests {
             context_window_size: None,
             auth_hint: None,
             transcript_base_dir: None,
+            model_override: None,
         };
         let registry = build_registry(vec![custom]).unwrap();
         assert_eq!(registry.len(), 4);
@@ -1333,6 +1623,7 @@ mod tests {
             context_window_size: Some(300_000),
             auth_hint: Some("Use my auth".to_string()),
             transcript_base_dir: None,
+            model_override: None,
         };
         let registry = build_registry(vec![custom_claude]).unwrap();
         // Should still be 3 agents (override, not add)
@@ -1361,6 +1652,7 @@ mod tests {
                 context_window_size: None,
                 auth_hint: None,
                 transcript_base_dir: None,
+                model_override: None,
             },
             AgentConfigToml {
                 name: "Agent B".to_string(),
@@ -1375,6 +1667,7 @@ mod tests {
                 context_window_size: None,
                 auth_hint: None,
                 transcript_base_dir: None,
+                model_override: None,
             },
         ];
         let result = build_registry(agents);
@@ -1401,6 +1694,7 @@ mod tests {
             context_window_size: None,
             auth_hint: None,
             transcript_base_dir: None,
+            model_override: None,
         };
         initialize_registry(vec![custom]).unwrap();
         let config = get_agent_config("kimi").expect("should find kimi");
@@ -1431,6 +1725,7 @@ mod tests {
             context_window_size: None,
             auth_hint: Some("Set KEY env var".to_string()),
             transcript_base_dir: None,
+            model_override: None,
         };
         initialize_registry(vec![custom]).unwrap();
         let config = get_agent_config("local-test").expect("should find local-test");
@@ -1461,6 +1756,7 @@ mod tests {
             context_window_size: None,
             auth_hint: None,
             transcript_base_dir: None,
+            model_override: None,
         };
         initialize_registry(vec![custom]).unwrap();
         let agents = list_available_agents();
@@ -1491,6 +1787,7 @@ mod tests {
             context_window_size: None,
             auth_hint: None,
             transcript_base_dir: None,
+            model_override: None,
         };
         initialize_registry(vec![custom]).unwrap();
         assert_eq!(get_agent_display_name("my-custom"), "My Custom Agent");

--- a/nori-rs/cli/src/cloud.rs
+++ b/nori-rs/cli/src/cloud.rs
@@ -96,6 +96,7 @@ pub fn cloud_agent_config(
         context_window_size: None,
         auth_hint: Some("run: nori-handroll login".to_string()),
         transcript_base_dir: None,
+        model_override: None,
     }
 }
 

--- a/nori-rs/config.md
+++ b/nori-rs/config.md
@@ -1,6 +1,83 @@
-# Configuration docs moved
+# Nori configuration (`config.toml`)
 
-This file has moved. Please see the latest configuration documentation here:
+Nori reads one TOML file at `$NORI_HOME/config.toml` (default
+`~/.nori/cli/config.toml`). Launch flags and dotted overrides are layered on top
+at startup. The resolution architecture and the full set of runtime-policy types
+live in [`nori-config/docs.md`](nori-config/docs.md); this file documents the
+agent and model configuration surface, which is the most commonly hand-edited
+part of the file.
 
-- Full config docs: [docs/config.md](../docs/config.md)
-- MCP servers section: [docs/config.md#connecting-to-mcp-servers](../docs/config.md#connecting-to-mcp-servers)
+## Choosing an agent
+
+```toml
+# The ACP agent to launch (built-in slug or a custom [[agents]] slug).
+agent = "claude-code"
+```
+
+Built-in agents are `claude-code`, `codex`, and `gemini`.
+
+## Default models: `[default_models]`
+
+Maps an agent slug to the model id Nori applies when it starts a session with
+that agent:
+
+```toml
+[default_models]
+claude-code = "claude-opus-4-6"
+codex = "gpt-5.1-codex"
+```
+
+The value is **not** validated against the agent's advertised model catalog. ACP
+adapters advertise only a subset of the models they can actually run and reject
+anything outside that list over the live `session/set_config_option` RPC. To make
+an out-of-catalog model usable, Nori forces it through the agent's own
+out-of-band channel at spawn time (see model injection below), so it becomes the
+session's current model. An invalid id is only rejected at the first prompt;
+recovery is manual (pick another model via `/model`).
+
+When you pick a custom model with `/model` and the agent rejects it, Nori writes
+the value here and restarts the session so the model is injected on the next
+spawn.
+
+## Custom agents: `[[agents]]`
+
+Each `[[agents]]` block defines an additional ACP agent (bring-your-own).
+
+```toml
+[[agents]]
+name = "My Agent"            # display name in the picker
+slug = "my-agent"            # machine id used as a slug / cmdline value
+context_window_size = 200000 # optional token budget override
+auth_hint = "run: my-agent login"  # optional message shown on auth failure
+transcript_base_dir = ".my-agent"  # optional transcript dir, relative to home
+
+# Exactly one distribution variant must be set.
+[agents.distribution.local]
+command = "/usr/bin/my-agent"
+args = ["acp"]
+env = { MY_AGENT_KEY = "value" }   # extra env for the spawned subprocess
+
+# Optional: how to force a chosen model on this agent at spawn.
+model_override = { env = "MY_AGENT_MODEL" }   # or { arg = "--model" }
+```
+
+Distribution variants (choose one): `local` (`command`/`args`/`env`), or one of
+the package runners `npx`, `bunx`, `pipx`, `uvx` (each takes `package`/`args`).
+
+### `model_override`
+
+Custom agents advertise their own (possibly small) model catalog. `model_override`
+tells Nori which out-of-band channel carries a forced model id so a
+`[default_models]` entry the picker would reject can still be applied:
+
+| Field | Meaning |
+|-------|---------|
+| `env` | Environment variable set to the model id on the spawned subprocess |
+| `arg` | CLI flag appended, followed by the model id |
+
+Set exactly one; `env` wins if both are present. Built-in agents know their own
+channel (Claude → `ANTHROPIC_MODEL`, Gemini → `GEMINI_MODEL`, Codex → the `model`
+key of `CODEX_CONFIG`) and ignore this field. For env-based channels, Nori's
+injected value takes precedence over the agent's own configured model (for
+example `~/.claude/settings.json`) for Nori-spawned sessions — Nori's
+`[default_models]` is authoritative there by design.

--- a/nori-rs/harness/docs.md
+++ b/nori-rs/harness/docs.md
@@ -79,10 +79,22 @@ responses are all observable before the Nori session-start event; none is
 labeled as replay. Without a transcript, a failed `session/load` is surfaced
 and session setup ends without creating an empty replacement session.
 Setup follows the actual method response rather than assuming a fixed event
-count, so interleaved notifications and a configured default-model response
-also retain their transport order before session start. A raw ACP setup error
-precedes `SessionEnded(SpawnFailed)` and is not mirrored as
+count, so interleaved notifications and any post-spawn default-model config
+response also retain their transport order before session start. A raw ACP setup
+error precedes `SessionEnded(SpawnFailed)` and is not mirrored as
 `NoriEvent::RequestFailed`.
+
+The persisted `[default_models]` entry (`AcpBackendConfig.default_model`) is
+applied two ways in `harness/src/backend/spawn_and_relay.rs`. Before the subprocess
+starts, `AcpAgentConfig::inject_model` forces the model through the agent's
+spawn-time channel (see model injection in [`nori-acp-host`](../acp-host/docs.md));
+this is best-effort — a failure is logged and never blocks startup. After spawn,
+`session_defaults::apply_default_model` still issues the live
+`session/set_config_option` RPC for agents whose model differs from the advertised
+`currentValue`; when injection already made the model current, that RPC is skipped
+(no config response is emitted), and for agents with no injection channel the RPC
+remains the only mechanism. Injection is how an out-of-catalog model becomes the
+session's current model, because the post-spawn RPC would reject it.
 
 #### Typed control surface
 

--- a/nori-rs/harness/src/backend/session.rs
+++ b/nori-rs/harness/src/backend/session.rs
@@ -140,7 +140,8 @@ impl AcpBackend {
             acp_session_id, config.agent
         );
 
-        let agent_config = get_agent_config(&config.agent)?;
+        let mut agent_config = get_agent_config(&config.agent)?;
+        spawn_and_relay::inject_default_model(&mut agent_config, config.default_model.as_deref());
         let mut connection = spawn_and_relay::spawn_connection_with_public_initialize(
             &agent_config,
             &cwd,

--- a/nori-rs/harness/src/backend/spawn_and_relay.rs
+++ b/nori-rs/harness/src/backend/spawn_and_relay.rs
@@ -36,6 +36,23 @@ pub(super) async fn spawn_connection_with_public_initialize(
     }
 }
 
+/// Force the persisted default model into the agent's spawn configuration via
+/// its out-of-band channel (see `ModelInjection`). Best-effort: a failure is
+/// logged and never blocks startup. Both the fresh-spawn and resume paths call
+/// this because each spawns a new subprocess and env-based injection is
+/// per-process — a resumed session must re-apply it or it would silently run
+/// the adapter default instead of the persisted model.
+pub(super) fn inject_default_model(
+    agent_config: &mut crate::registry::AcpAgentConfig,
+    default_model: Option<&str>,
+) {
+    if let Some(default_model) = default_model
+        && let Err(err) = agent_config.inject_model(default_model)
+    {
+        warn!(%err, "failed to inject default model into agent spawn config");
+    }
+}
+
 async fn forward_setup_event(
     backend_event_tx: &mpsc::Sender<BackendEvent>,
     event: crate::connection::ConnectionEvent,
@@ -126,7 +143,8 @@ impl AcpBackend {
     ) -> Result<Self> {
         let cwd = config.cwd.clone();
 
-        let agent_config = get_agent_config(&config.agent)?;
+        let mut agent_config = get_agent_config(&config.agent)?;
+        inject_default_model(&mut agent_config, config.default_model.as_deref());
         debug!("Spawning ACP backend for agent: {}", config.agent);
         let mut connection = spawn_connection_with_public_initialize(
             &agent_config,

--- a/nori-rs/harness/tests/session_event_boundary.rs
+++ b/nori-rs/harness/tests/session_event_boundary.rs
@@ -444,6 +444,79 @@ async fn out_of_catalog_default_model_is_injected_when_resuming() {
 
 #[tokio::test]
 #[serial]
+async fn rejected_config_option_error_is_not_mirrored_on_public_boundary() {
+    let temp = tempfile::tempdir().expect("create session directory");
+    let config = NoriConfig {
+        active_agent: "mock-model".to_string(),
+        cwd: temp.path().to_path_buf(),
+        nori_home: temp.path().to_path_buf(),
+        ..Default::default()
+    };
+    let mut session = launch_session(SessionLaunchSpec {
+        config: Arc::new(config),
+        cli_version: "boundary-test".to_string(),
+        session_context: None,
+        initial_context: None,
+        resume: None,
+    });
+
+    // Drain setup until the session is running.
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let event = session
+                .events
+                .recv()
+                .await
+                .expect("setup event stream closed");
+            if matches!(event, SessionEvent::Nori(NoriEvent::SessionStarted(_))) {
+                return;
+            }
+        }
+    })
+    .await
+    .expect("session should start");
+
+    // The mock rejects this model; the error must reach the caller.
+    let set_result = session
+        .handle
+        .set_session_config_option("model".to_string(), "mock-model-rejected".to_string())
+        .await;
+    assert!(
+        set_result.is_err(),
+        "the mock must reject an out-of-catalog model over set_config_option"
+    );
+
+    // But the rejection must NOT be mirrored onto the public boundary as a raw
+    // error response — the `/model` flow renders the outcome itself, so a
+    // mirrored error would surface a confusing duplicate cell.
+    let mut saw_error_response = false;
+    loop {
+        match tokio::time::timeout(Duration::from_millis(500), session.events.recv()).await {
+            Ok(Some(event)) => {
+                if matches!(
+                    event,
+                    SessionEvent::Acp(AcpEvent::Response {
+                        response: Err(_),
+                        ..
+                    })
+                ) {
+                    saw_error_response = true;
+                }
+            }
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
+    assert!(
+        !saw_error_response,
+        "a rejected config-option error must not be mirrored on the public boundary"
+    );
+
+    session.handle.shutdown().await.expect("shutdown session");
+}
+
+#[tokio::test]
+#[serial]
 async fn public_boundary_preserves_bootstrap_and_prompt_acp_envelopes() {
     let temp = tempfile::tempdir().expect("create session directory");
     let config = NoriConfig {

--- a/nori-rs/harness/tests/session_event_boundary.rs
+++ b/nori-rs/harness/tests/session_event_boundary.rs
@@ -206,20 +206,17 @@ async fn resume_error_remains_raw_without_a_nori_failure_mirror() {
 
 #[tokio::test]
 #[serial]
-async fn setup_notifications_and_default_config_response_precede_session_start() {
+async fn setup_notifications_precede_session_start() {
     // SAFETY: tests that mutate the mock-agent environment run serially.
     unsafe { std::env::set_var("MOCK_AGENT_NEW_SESSION_NOTIFICATION", "1") };
     let _guard = EnvGuard("MOCK_AGENT_NEW_SESSION_NOTIFICATION");
     let temp = tempfile::tempdir().expect("create session directory");
-    let mut config = NoriConfig {
+    let config = NoriConfig {
         active_agent: "mock-model".to_string(),
         cwd: temp.path().to_path_buf(),
         nori_home: temp.path().to_path_buf(),
         ..Default::default()
     };
-    config
-        .default_models
-        .insert("mock-model".to_string(), "mock-model-fast".to_string());
     let mut session = launch_session(SessionLaunchSpec {
         config: Arc::new(config),
         cli_version: "boundary-test".to_string(),
@@ -284,33 +281,20 @@ async fn setup_notifications_and_default_config_response_precede_session_start()
         },
         "new-session response should be observable",
     );
-    let config_index = index_of(
-        &|event| {
-            matches!(
-                event,
-                SessionEvent::Acp(AcpEvent::Response {
-                    response: Ok(acp::v1::AgentResponse::SetSessionConfigOptionResponse(_)),
-                    ..
-                })
-            )
-        },
-        "default-model config response should be observable",
-    );
     let started_index = index_of(
         &|event| matches!(event, SessionEvent::Nori(NoriEvent::SessionStarted(_))),
         "session should start",
     );
     assert!(initialize_index < notification_index);
     assert!(notification_index < new_session_index);
-    assert!(new_session_index < config_index);
-    assert!(config_index < started_index);
+    assert!(new_session_index < started_index);
 
     session.handle.shutdown().await.expect("shutdown session");
 }
 
 #[tokio::test]
 #[serial]
-async fn unknown_default_model_is_attempted_on_session_start() {
+async fn out_of_catalog_default_model_is_injected_at_spawn() {
     let temp = tempfile::tempdir().expect("create session directory");
     let mut config = NoriConfig {
         active_agent: "mock-model".to_string(),
@@ -318,6 +302,9 @@ async fn unknown_default_model_is_attempted_on_session_start() {
         nori_home: temp.path().to_path_buf(),
         ..Default::default()
     };
+    // A model the agent does not advertise in its picker catalog. It can only
+    // become the session's current model by being forced through the spawn-time
+    // injection channel, not the post-spawn set_config_option RPC.
     config.default_models.insert(
         "mock-model".to_string(),
         "model-that-does-not-exist-yet".to_string(),
@@ -346,23 +333,110 @@ async fn unknown_default_model_is_attempted_on_session_start() {
         }
     })
     .await
-    .expect("session setup should complete even with an unknown default model");
+    .expect("session setup should complete even with an out-of-catalog default model");
 
-    assert!(
-        events.iter().any(|event| matches!(
-            event,
+    let new_session = events
+        .iter()
+        .find_map(|event| match event {
             SessionEvent::Acp(AcpEvent::Response {
-                response: Ok(acp::v1::AgentResponse::SetSessionConfigOptionResponse(_)),
+                response: Ok(acp::v1::AgentResponse::NewSessionResponse(resp)),
                 ..
-            })
-        )),
-        "set_config_option should be attempted for unknown models"
+            }) => Some(resp),
+            _ => None,
+        })
+        .expect("new-session response should be observable");
+
+    let current_model = new_session
+        .config_options
+        .iter()
+        .flatten()
+        .find(|option| option.category == Some(acp::v1::SessionConfigOptionCategory::Model))
+        .and_then(|option| match &option.kind {
+            acp::v1::SessionConfigKind::Select(select) => Some(select.current_value.to_string()),
+            _ => None,
+        })
+        .expect("model config option should be advertised");
+    assert_eq!(
+        current_model, "model-that-does-not-exist-yet",
+        "the out-of-catalog default model must be injected as the session's current model"
     );
-    assert!(
-        events
-            .iter()
-            .any(|event| matches!(event, SessionEvent::Nori(NoriEvent::SessionStarted(_)))),
-        "session should start regardless of model validation outcome"
+
+    session.handle.shutdown().await.expect("shutdown session");
+}
+
+#[tokio::test]
+#[serial]
+async fn out_of_catalog_default_model_is_injected_when_resuming() {
+    // SAFETY: tests that mutate the mock-agent environment run serially.
+    unsafe { std::env::set_var("MOCK_AGENT_SUPPORT_LOAD_SESSION", "1") };
+    let _load_guard = EnvGuard("MOCK_AGENT_SUPPORT_LOAD_SESSION");
+    let temp = tempfile::tempdir().expect("create session directory");
+    let mut config = NoriConfig {
+        active_agent: "mock-model".to_string(),
+        cwd: temp.path().to_path_buf(),
+        nori_home: temp.path().to_path_buf(),
+        ..Default::default()
+    };
+    // Resuming spawns a fresh subprocess, so env-based injection must be
+    // re-applied on the resume path or the resumed agent silently runs the
+    // adapter default instead of the persisted out-of-catalog model.
+    config.default_models.insert(
+        "mock-model".to_string(),
+        "model-that-does-not-exist-yet".to_string(),
+    );
+    let mut session = launch_session(SessionLaunchSpec {
+        config: Arc::new(config),
+        cli_version: "boundary-test".to_string(),
+        session_context: None,
+        initial_context: None,
+        resume: Some(SessionResume {
+            acp_session_id: Some("resume-inject-session".to_string()),
+            transcript: None,
+        }),
+    });
+
+    let events = tokio::time::timeout(Duration::from_secs(10), async {
+        let mut events = Vec::new();
+        loop {
+            let event = session
+                .events
+                .recv()
+                .await
+                .expect("resume event stream closed");
+            let started = matches!(event, SessionEvent::Nori(NoriEvent::SessionStarted(_)));
+            events.push(event);
+            if started {
+                return events;
+            }
+        }
+    })
+    .await
+    .expect("resume should complete with an out-of-catalog default model");
+
+    let load = events
+        .iter()
+        .find_map(|event| match event {
+            SessionEvent::Acp(AcpEvent::Response {
+                response: Ok(acp::v1::AgentResponse::LoadSessionResponse(resp)),
+                ..
+            }) => Some(resp),
+            _ => None,
+        })
+        .expect("load-session response should be observable");
+
+    let current_model = load
+        .config_options
+        .iter()
+        .flatten()
+        .find(|option| option.category == Some(acp::v1::SessionConfigOptionCategory::Model))
+        .and_then(|option| match &option.kind {
+            acp::v1::SessionConfigKind::Select(select) => Some(select.current_value.to_string()),
+            _ => None,
+        })
+        .expect("model config option should be advertised on resume");
+    assert_eq!(
+        current_model, "model-that-does-not-exist-yet",
+        "the out-of-catalog default model must be injected into the resumed session too"
     );
 
     session.handle.shutdown().await.expect("shutdown session");

--- a/nori-rs/mock-acp-agent/docs.md
+++ b/nori-rs/mock-acp-agent/docs.md
@@ -48,5 +48,9 @@ than calling host internals. This makes the public `AcpEvent::Request` and
   sweeps the inherited process group without relying on a shell wrapper.
 - Local tests expect `target/debug/mock_acp_agent` unless
   `MOCK_ACP_AGENT_BIN` is set.
+- The mock honors `MOCK_AGENT_INJECTED_MODEL` as its model config option's
+  current value (its own model-injection channel), so tests can verify that an
+  out-of-catalog model forced through spawn-time injection becomes the session's
+  current model.
 
 Created and maintained by Nori.

--- a/nori-rs/mock-acp-agent/src/main.rs
+++ b/nori-rs/mock-acp-agent/src/main.rs
@@ -1760,6 +1760,13 @@ async fn main() -> acp::Result<()> {
                             .or_insert_with(default_session_config);
 
                         match arguments.config_id.to_string().as_str() {
+                            // Simulate a real adapter rejecting a model outside
+                            // its advertised catalog, so tests can exercise the
+                            // rejection path.
+                            "model" if value == "mock-model-rejected" => Err(acp::Error::new(
+                                -32603,
+                                "Invalid value for config option model: mock-model-rejected",
+                            )),
                             "model" => {
                                 cfg.model_id = value;
                                 if cfg.model_id == "mock-model-fast" {

--- a/nori-rs/mock-acp-agent/src/main.rs
+++ b/nori-rs/mock-acp-agent/src/main.rs
@@ -105,8 +105,14 @@ struct MockSessionConfig {
 }
 
 fn default_session_config() -> MockSessionConfig {
+    // A model forced through the spawn-time injection channel (see
+    // `ModelInjection` in the registry) arrives as this env var. Honoring it
+    // lets integration tests verify that an out-of-catalog model injected at
+    // spawn becomes the session's current model.
+    let model_id = std::env::var("MOCK_AGENT_INJECTED_MODEL")
+        .unwrap_or_else(|_| "mock-model-default".to_string());
     MockSessionConfig {
-        model_id: "mock-model-default".to_string(),
+        model_id,
         thought_level: Some("medium".to_string()),
         speed: None,
     }

--- a/nori-rs/nori-config/docs.md
+++ b/nori-rs/nori-config/docs.md
@@ -17,7 +17,10 @@ the harness. Session launch, resume, and probing do not reload ambient config.
 
 The crate owns:
 
-- agent registry and distribution configuration;
+- agent registry and distribution configuration, including per-agent
+  `[default_models]` and the optional `[[agents]].model_override`
+  (`ModelOverrideToml { env, arg }`) declaring how a custom agent accepts a
+  forced model id at spawn time (see below);
 - `AskForApproval`, `SandboxPolicy`, `SandboxMode`, and `TrustLevel`;
 - `McpServerConfig` and MCP transport configuration;
 - `ShellEnvironmentPolicy` and related environment patterns;
@@ -32,6 +35,16 @@ file. Project trust resolves against the effective cwd and primary git root.
 scrollback after width changes. It defaults to `true`; the `/settings` toggle
 persists to this same key, so startup configuration and runtime changes share
 one source of truth.
+
+`[default_models]` maps an agent slug to a model id. This crate only stores the
+value; the id is not validated here (an agent may accept models its ACP picker
+never advertised). `nori-acp-host` reads `model_override` to build a
+`ModelInjection` strategy — `env` names an environment variable, `arg` a CLI
+flag, and `env` wins if both are set — so an out-of-catalog default model can be
+forced through the agent subprocess at spawn. Built-in agents (Claude, Codex,
+Gemini) know their own channel and ignore `model_override`. The user-facing
+`config.toml` schema, including these tables and the `[[agents]]` fields, is
+described in [`config.md`](../config.md).
 
 ### Things to Know
 

--- a/nori-rs/nori-config/src/lib.rs
+++ b/nori-rs/nori-config/src/lib.rs
@@ -52,6 +52,7 @@ pub use types::HotkeyBinding;
 pub use types::HotkeyConfig;
 pub use types::HotkeyConfigToml;
 pub use types::LocalDistribution;
+pub use types::ModelOverrideToml;
 pub use types::NoriConfig;
 pub use types::NoriConfigOverrides;
 pub use types::NoriConfigToml;

--- a/nori-rs/nori-config/src/types/mod.rs
+++ b/nori-rs/nori-config/src/types/mod.rs
@@ -102,6 +102,25 @@ pub struct AgentConfigToml {
     pub auth_hint: Option<String>,
     /// Optional transcript base directory (relative to home)
     pub transcript_base_dir: Option<String>,
+    /// Optional declaration of how to force a specific model on this agent at
+    /// spawn time. Custom ACP clients advertise only a subset of the models
+    /// they can actually run; this tells nori which out-of-band channel carries
+    /// the model id so a user-chosen model that the picker rejects can still be
+    /// applied by restarting the session. Built-in agents (Claude, Codex,
+    /// Gemini) know their own channel and ignore this field.
+    #[serde(default)]
+    pub model_override: Option<ModelOverrideToml>,
+}
+
+/// How a custom agent accepts a model id at spawn time. Set exactly one of
+/// `env` or `arg`; `env` wins if both are set.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ModelOverrideToml {
+    /// Environment variable name to set to the model id (e.g. "ANTHROPIC_MODEL").
+    pub env: Option<String>,
+    /// CLI flag to append followed by the model id (e.g. "--model").
+    pub arg: Option<String>,
 }
 
 /// Distribution configuration for an agent.

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -176,6 +176,20 @@ identifier: a `SettingsItem` enum for `/settings`, or the ACP option id for
   input for free-form model IDs. On submit it emits
   `AppEvent::SetAcpSessionConfigOption` and follows the same
   `session/set_config_option` path as selecting from the advertised list.
+- The config-set events (`SetAcpSessionConfigOption` and
+  `AcpSessionConfigSetResult` in `@/nori-rs/tui/src/app_event.rs`) carry an
+  `is_custom_model` flag that distinguishes a free-text custom entry from an
+  advertised picker choice. When the live RPC rejects a custom model and the
+  active agent `supports_model_injection()`, the handler in
+  `@/nori-rs/tui/src/app/event_handling.rs` treats the rejection as recoverable:
+  `persist_custom_default_model` (in
+  `@/nori-rs/tui/src/app/config_persistence.rs`) writes the value to
+  `[default_models]` unconditionally (no config-options snapshot to categorize —
+  it is a model by construction), an info message
+  ("Saved '<model>' as the default model for <agent> — restarting the session to
+  apply it.") is shown, and `AppEvent::NewSession` restarts the session so the
+  model is injected at spawn. If the agent has no injection channel, the original
+  error is surfaced instead.
 
 #### The `/browser` profile picker
 

--- a/nori-rs/tui/src/app/config_persistence.rs
+++ b/nori-rs/tui/src/app/config_persistence.rs
@@ -44,6 +44,22 @@ pub(super) async fn persist_default_model_selection(
     Ok(true)
 }
 
+/// Persist a model as the agent's default without inspecting the advertised
+/// config options. Used when the agent rejected a free-text custom model from
+/// its live picker: there is no options snapshot to categorize, but the value
+/// is a model by construction, and it will be forced through the agent's
+/// spawn-time injection channel on the next session start.
+pub(super) async fn persist_default_model_value(
+    nori_home: &Path,
+    agent: &str,
+    value: &str,
+) -> anyhow::Result<()> {
+    ConfigEditsBuilder::new(nori_home)
+        .set_default_model(agent, value)
+        .apply()
+        .await
+}
+
 impl App {
     fn sync_runtime_config(&mut self) {
         self.chat_widget.set_config(self.config.clone());
@@ -71,6 +87,27 @@ impl App {
             self.sync_runtime_config();
         }
         Ok(persisted)
+    }
+
+    /// Persist a custom model as the agent's default, unconditionally.
+    ///
+    /// Used when the agent rejected the model from its live picker: there is no
+    /// config-options snapshot to categorize, but the model came from the
+    /// free-text custom-model input, so it is a model by construction. On the
+    /// next session start it is forced through the agent's spawn-time injection
+    /// channel. Returns `true` when the value was persisted.
+    pub(super) async fn persist_custom_default_model(&mut self, agent: &str, value: &str) -> bool {
+        if let Err(err) = persist_default_model_value(&self.config.nori_home, agent, value).await {
+            tracing::error!(error = %err, "failed to persist custom default model");
+            self.chat_widget
+                .add_error_message(format!("Failed to save model '{value}': {err}"));
+            return false;
+        }
+        self.config
+            .default_models
+            .insert(agent.to_string(), value.to_string());
+        self.sync_runtime_config();
+        true
     }
 
     /// Persist a TUI config setting to config.toml and apply it immediately.
@@ -765,6 +802,28 @@ mod tests {
                 .and_then(|section| section.get("claude-code"))
                 .and_then(toml::Value::as_str),
             Some("opus")
+        );
+    }
+
+    #[tokio::test]
+    async fn rejected_custom_model_is_persisted_without_config_options() {
+        let temp = TempDir::new().expect("temp home");
+
+        persist_default_model_value(temp.path(), "claude-code", "claude-opus-4-6")
+            .await
+            .expect("persist rejected custom model");
+
+        let content = std::fs::read_to_string(temp.path().join("config.toml"))
+            .expect("read persisted config");
+        let parsed: toml::Value = toml::from_str(&content).expect("config toml");
+        assert_eq!(
+            parsed
+                .get("default_models")
+                .and_then(|section| section.get("claude-code"))
+                .and_then(toml::Value::as_str),
+            Some("claude-opus-4-6"),
+            "a custom model the agent rejected must still be saved as the default so the \
+             restart can inject it"
         );
     }
 

--- a/nori-rs/tui/src/app/event_handling.rs
+++ b/nori-rs/tui/src/app/event_handling.rs
@@ -775,12 +775,14 @@ impl App {
                 value,
                 option_name,
                 value_name,
+                is_custom_model,
             } => {
                 self.chat_widget.set_acp_session_config_option(
                     config_id,
                     value,
                     option_name,
                     value_name,
+                    is_custom_model,
                 );
             }
             AppEvent::AcpSessionConfigSetResult {
@@ -790,6 +792,7 @@ impl App {
                 value,
                 option_name,
                 value_name,
+                is_custom_model,
                 config_options,
                 error,
             } => {
@@ -820,6 +823,23 @@ impl App {
                     if let Some(config_options) = config_options {
                         self.chat_widget
                             .sync_acp_session_config_snapshot(&config_options);
+                    }
+                } else if is_custom_model
+                    && nori_harness::get_agent_config(&agent)
+                        .map(|config| config.supports_model_injection())
+                        .unwrap_or(false)
+                {
+                    // The agent rejected this model from its live picker, but we
+                    // can still run it: persist it as the default and restart so
+                    // it is forced through the agent's spawn-time channel.
+                    if self.persist_custom_default_model(&agent, &value).await {
+                        self.chat_widget.add_info_message(
+                            format!(
+                                "Saved '{value}' as the default model for {agent} — restarting the session to apply it."
+                            ),
+                            None,
+                        );
+                        self.app_event_tx.send(AppEvent::NewSession);
                     }
                 } else {
                     let error_msg = error.unwrap_or_else(|| "Unknown error".to_string());

--- a/nori-rs/tui/src/app_event.rs
+++ b/nori-rs/tui/src/app_event.rs
@@ -281,6 +281,11 @@ pub(crate) enum AppEvent {
         value: String,
         option_name: String,
         value_name: String,
+        /// True when the value came from the free-text "custom model" input
+        /// rather than an advertised picker choice. A custom model the agent
+        /// rejects can still be run by persisting it and restarting with the
+        /// model injected at spawn.
+        is_custom_model: bool,
     },
 
     /// Result of setting an ACP session config option.
@@ -293,6 +298,8 @@ pub(crate) enum AppEvent {
         value: String,
         option_name: String,
         value_name: String,
+        /// Whether the value came from the free-text custom model input.
+        is_custom_model: bool,
         config_options: Option<Vec<SessionConfigOption>>,
         error: Option<String>,
     },

--- a/nori-rs/tui/src/chatwidget/pickers.rs
+++ b/nori-rs/tui/src/chatwidget/pickers.rs
@@ -742,6 +742,7 @@ impl ChatWidget {
         value: String,
         option_name: String,
         value_name: String,
+        is_custom_model: bool,
     ) {
         if let Some(handle) = self.harness_handle.clone() {
             let app_event_tx = self.app_event_tx.clone();
@@ -774,6 +775,7 @@ impl ChatWidget {
                             value: value_for_result,
                             option_name: option_name_for_result,
                             value_name: value_name_for_result,
+                            is_custom_model,
                             config_options: Some(config_options),
                             error: None,
                         });
@@ -786,6 +788,7 @@ impl ChatWidget {
                             value: value_for_result,
                             option_name: option_name_for_result,
                             value_name: value_name_for_result,
+                            is_custom_model,
                             config_options: None,
                             error: Some(err.to_string()),
                         });

--- a/nori-rs/tui/src/chatwidget/session_config_mode.rs
+++ b/nori-rs/tui/src/chatwidget/session_config_mode.rs
@@ -105,6 +105,7 @@ impl ChatWidget {
                             value: value_for_result,
                             option_name: "Mode".to_string(),
                             value_name,
+                            is_custom_model: false,
                             config_options: Some(config_options),
                             error: None,
                         });
@@ -117,6 +118,7 @@ impl ChatWidget {
                             value: value_for_result,
                             option_name: "Mode".to_string(),
                             value_name: value_name.clone(),
+                            is_custom_model: false,
                             config_options: None,
                             error: Some(err.to_string()),
                         });
@@ -168,6 +170,7 @@ impl ChatWidget {
                         value: mode.next_value,
                         option_name: "Mode".to_string(),
                         value_name,
+                        is_custom_model: false,
                         config_options: Some(config_options),
                         error: None,
                     });
@@ -180,6 +183,7 @@ impl ChatWidget {
                         value: mode.next_value,
                         option_name: "Mode".to_string(),
                         value_name: mode.next_label,
+                        is_custom_model: false,
                         config_options: None,
                         error: Some(err.to_string()),
                     });

--- a/nori-rs/tui/src/chatwidget/tests/part10.rs
+++ b/nori-rs/tui/src/chatwidget/tests/part10.rs
@@ -1421,6 +1421,7 @@ async fn config_value_selection_reopens_panel_focused_on_edited_option() {
         "high".to_string(),
         "Thought Level".to_string(),
         "High".to_string(),
+        false,
     );
 
     let focus = tokio::time::timeout(std::time::Duration::from_secs(10), async {

--- a/nori-rs/tui/src/nori/custom_model_input.rs
+++ b/nori-rs/tui/src/nori/custom_model_input.rs
@@ -51,6 +51,7 @@ impl CustomModelInputView {
             value: value.clone(),
             option_name: self.option_name.clone(),
             value_name: value,
+            is_custom_model: true,
         });
         self.complete = true;
     }
@@ -175,10 +176,12 @@ mod tests {
                 value,
                 option_name,
                 value_name,
+                is_custom_model,
             } if config_id == "model"
                 && value == "claude-opus-4-8"
                 && option_name == "Model"
                 && value_name == "claude-opus-4-8"
+                && is_custom_model
         ));
     }
 

--- a/nori-rs/tui/src/nori/session_config_picker.rs
+++ b/nori-rs/tui/src/nori/session_config_picker.rs
@@ -221,6 +221,7 @@ fn value_item(
                 value: value.clone(),
                 option_name: option_name.clone(),
                 value_name: value_name.clone(),
+                is_custom_model: false,
             });
         })]
     };
@@ -396,10 +397,12 @@ mod tests {
                 value,
                 option_name,
                 value_name,
+                is_custom_model,
             } if config_id == "model"
                 && value == "mock-model-fast"
                 && option_name == "Model"
                 && value_name == "Mock Fast Model"
+                && !is_custom_model
         ));
         assert!(rx.try_recv().is_err(), "expected a single config event");
     }


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- The `/model` command let users type a custom model ID, but it was only sent over the live ACP `session/set_config_option` RPC, which adapters reject for any model outside their small advertised catalog — including valid ones like `claude-opus-4-6` or dated snapshots, with a generic "Internal error". This forces a chosen model through the agent's own out-of-band channel at **spawn time** so it becomes the session's `currentValue` (which ACP always accepts), bypassing the catalog.
- Generic, per-agent `ModelInjection` strategy: Claude → `ANTHROPIC_MODEL`, Gemini → `GEMINI_MODEL` (both verified against the adapters), Codex → merge `model` into `CODEX_CONFIG`; custom `[[agents]]` declare `model_override = { env = "…" }` or `{ arg = "…" }`. Injection is applied at both fresh spawn and resume (env injection is per-process).
- When a custom `/model` entry is rejected, nori persists it to `[default_models]` and restarts the session with the model injected, showing "Saved '<model>' as the default model for <agent> — restarting the session to apply it." No pre-flight validation (an invalid model surfaces at first prompt; recovery is via `/model`).

## Test Plan
- [x] `cargo test -p nori-acp-host` (6 new injection unit tests: Claude/Gemini env, Codex JSON-merge preserving `features.goals`, BYO env/arg, no-op)
- [x] `cargo test -p nori-harness` (end-to-end injection at spawn **and** on resume via the mock agent; 294+ others pass)
- [x] `cargo test -p nori-tui` (1290 lib tests incl. new persistence test + updated `is_custom_model` assertions)
- [x] `cargo test -p nori-config`, `cargo build --bin nori && cargo test -p tui-pty-e2e`
- [x] `just fmt` + `just fix` clean across changed crates
- [x] Drove the real Claude agent in tmux (isolated `NORI_HOME`): entering `claude-opus-4-6` (rejected by the live RPC) persisted it, restarted, and after restart the picker shows "Opus 4.6 (current)" — the injected model is active.

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets