### PR TITLE
feat(tui): split /model picker into Recommended and Other sections

### DIFF
--- a/nori-rs/acp-host/docs.md
+++ b/nori-rs/acp-host/docs.md
@@ -65,6 +65,15 @@ The host is the only client-side product crate that directly uses the
   `AcpAgentConfig::inject_model` applies the resolved strategy to the spawn env
   or args and is a no-op for `None`, so callers (the harness) may invoke it
   unconditionally; `supports_model_injection()` reports whether a channel exists.
+- `AgentKind::other_models()` returns a curated, per-agent
+  `&'static [OtherModel]` (`{ id, label }`) of real models the adapter does *not*
+  advertise but that generally run when forced through injection. It is the
+  durable complement to the advertised catalog: the advertised set is
+  agent/version/account-dependent and adapters do not hardcode it, so this static
+  list plus render-time dedup against the live catalog is how the TUI populates
+  the `/model` picker's "Other" section without a second source of truth.
+  Selecting one routes through injection exactly like a `[default_models]` custom
+  id. `OtherModel` is re-exported from `nori-harness` for that picker.
 
 ### Things to Know
 

--- a/nori-rs/acp-host/src/registry.rs
+++ b/nori-rs/acp-host/src/registry.rs
@@ -98,6 +98,17 @@ impl ModelInjection {
 // Core Enums
 // =============================================================================
 
+/// A model that an agent's ACP adapter does not advertise but that generally
+/// works when forced via spawn-time model injection. Surfaced under the model
+/// picker's "Other" section and deduplicated against the advertised catalog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OtherModel {
+    /// The model id forced through the agent's injection channel.
+    pub id: &'static str,
+    /// Friendly label shown in the picker.
+    pub label: &'static str,
+}
+
 /// ACP agent identifier
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AgentKind {
@@ -223,6 +234,51 @@ impl AgentKind {
             "codex" | "codex-acp" => Some(AgentKind::Codex),
             "gemini" | "gemini-acp" | "gemini-2.5-flash" => Some(AgentKind::Gemini),
             _ => None,
+        }
+    }
+
+    /// Curated models this agent's ACP adapter does not advertise but that
+    /// generally work when forced via spawn-time injection. Shown under the
+    /// model picker's "Other" section; deduplicated at render time against the
+    /// agent's advertised catalog.
+    pub fn other_models(self) -> &'static [OtherModel] {
+        match self {
+            AgentKind::ClaudeCode => &[
+                OtherModel {
+                    id: "claude-opus-4-8",
+                    label: "Opus 4.8",
+                },
+                OtherModel {
+                    id: "claude-opus-4-7",
+                    label: "Opus 4.7",
+                },
+                OtherModel {
+                    id: "claude-opus-4-6",
+                    label: "Opus 4.6",
+                },
+                OtherModel {
+                    id: "claude-sonnet-4-6",
+                    label: "Sonnet 4.6",
+                },
+            ],
+            AgentKind::Codex => &[OtherModel {
+                id: "gpt-5.3-codex",
+                label: "GPT-5.3-Codex",
+            }],
+            AgentKind::Gemini => &[
+                OtherModel {
+                    id: "gemini-3.7-flash",
+                    label: "Gemini 3.7 Flash",
+                },
+                OtherModel {
+                    id: "gemini-3.5-flash",
+                    label: "Gemini 3.5 Flash",
+                },
+                OtherModel {
+                    id: "gemini-3.5-flash-lite",
+                    label: "Gemini 3.5 Flash-Lite",
+                },
+            ],
         }
     }
 }

--- a/nori-rs/config.md
+++ b/nori-rs/config.md
@@ -37,7 +37,10 @@ recovery is manual (pick another model via `/model`).
 
 When you pick a custom model with `/model` and the agent rejects it, Nori writes
 the value here and restarts the session so the model is injected on the next
-spawn.
+spawn. The `/model` picker also surfaces a curated per-agent **Other** section of
+known-good models the adapter does not advertise, so you can select one instead
+of typing its id; choosing one follows the same reject → persist-here → restart
+path.
 
 ## Custom agents: `[[agents]]`
 

--- a/nori-rs/harness/docs.md
+++ b/nori-rs/harness/docs.md
@@ -94,7 +94,10 @@ this is best-effort — a failure is logged and never blocks startup. After spaw
 `currentValue`; when injection already made the model current, that RPC is skipped
 (no config response is emitted), and for agents with no injection channel the RPC
 remains the only mechanism. Injection is how an out-of-catalog model becomes the
-session's current model, because the post-spawn RPC would reject it.
+session's current model, because the post-spawn RPC would reject it. The harness
+re-exports `AgentKind::other_models()` / `OtherModel` so the TUI's `/model`
+picker can offer a curated list of these injectable, unadvertised models (see
+[`nori-acp-host`](../acp-host/docs.md) and [`nori-tui`](../tui/docs.md)).
 
 #### Typed control surface
 

--- a/nori-rs/harness/src/lib.rs
+++ b/nori-rs/harness/src/lib.rs
@@ -57,6 +57,7 @@ pub use registry::AcpAgentConfig;
 pub use registry::AcpAgentInfo;
 pub use registry::AcpProviderInfo;
 pub use registry::AgentKind;
+pub use registry::OtherModel;
 pub use registry::PackageManager;
 pub use registry::Provider;
 pub use registry::RegisteredAgent;

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -169,8 +169,37 @@ identifier: a `SettingsItem` enum for `/settings`, or the ACP option id for
   `/config` open), the multi-toggle Footer Segments sub-picker (which already
   stays open by replacing itself), and the bespoke Hotkeys view. Failed persists
   never reopen.
-- For Model-category config options, `acp_session_config_value_picker_params()`
-  appends a "Use custom model..." entry. Selecting it emits
+- Model-category value pickers (`acp_session_config_value_picker_params()`)
+  split into two labeled sections when both have content. **Recommended** lists
+  the values the agent advertises over ACP, exactly as reported. **Other** lists
+  a curated, per-agent set of real models the adapter does *not* advertise but
+  that generally run when forced via spawn-time injection; it comes from
+  `nori_harness::AgentKind::other_models()`, resolved in
+  `@/nori-rs/tui/src/chatwidget/pickers.rs` via `AgentKind::from_slug` on the
+  active agent (custom/unknown agents resolve to an empty list → no Other
+  section). The Other list is deduplicated at render time against the advertised
+  values so a model an account already sees under Recommended never appears
+  twice. When either side is empty — no advertised catalog, no curated
+  complement, or a non-model option — the picker renders one flat list exactly as
+  before and the labeled headers do not appear. The durable-complement design is
+  intentional: the advertised set is agent/version/account-dependent, so the
+  curated list plus runtime dedup avoids a second, drift-prone source of truth.
+- An Other row whose id already equals the session's injected `currentValue` is
+  marked `(current)` and carries no action; every other Other row emits
+  `AppEvent::SetAcpSessionConfigOption { is_custom_model: true }` — the same event
+  a free-text custom entry emits — so it follows the identical
+  reject → persist-to-`[default_models]` → restart-with-injection recovery path
+  (below). `initial_selected_idx` prefers the current row.
+- Section labels are a non-selectable header primitive shared by every
+  `ListSelectionView` (`is_header` on `SelectionItem` and `GenericDisplayRow`, in
+  `@/nori-rs/tui/src/bottom_pane/list_selection_view.rs` and
+  `@/nori-rs/tui/src/bottom_pane/selection_popup_common.rs`): headers render bold
+  with no number or `›` cursor, keyboard navigation and default selection skip
+  them, and the `1..N` numbering counts only selectable rows. Grouped non-model
+  config options reuse the same primitive for their group labels (previously
+  drawn as bracketed `[Group]` text).
+- `acp_session_config_value_picker_params()` also pins a "Use custom model..."
+  entry at the bottom of every Model-category picker. Selecting it emits
   `AppEvent::OpenCustomModelInput`, which opens a `CustomModelInputView`
   (`@/nori-rs/tui/src/nori/custom_model_input.rs`) — a `BottomPaneView` text
   input for free-form model IDs. On submit it emits

--- a/nori-rs/tui/src/bottom_pane/command_popup.rs
+++ b/nori-rs/tui/src/bottom_pane/command_popup.rs
@@ -296,6 +296,7 @@ impl CommandPopup {
                         item,
                         CommandItem::Builtin(cmd) if self.disabled_builtins.contains_key(&cmd)
                     ),
+                    is_header: false,
                 }
             })
             .collect()

--- a/nori-rs/tui/src/bottom_pane/file_search_popup.rs
+++ b/nori-rs/tui/src/bottom_pane/file_search_popup.rs
@@ -133,6 +133,7 @@ impl WidgetRef for &FileSearchPopup {
                     description: None,
                     styled_description: None,
                     disabled: false,
+                    is_header: false,
                 })
                 .collect()
         };

--- a/nori-rs/tui/src/bottom_pane/list_selection_view.rs
+++ b/nori-rs/tui/src/bottom_pane/list_selection_view.rs
@@ -43,6 +43,9 @@ pub(crate) struct SelectionItem {
     pub actions: Vec<SelectionAction>,
     pub dismiss_on_select: bool,
     pub search_value: Option<String>,
+    /// When true, this row is a non-selectable section header: navigation skips
+    /// it, it shows no number or cursor, and it renders as a bold section label.
+    pub is_header: bool,
 }
 
 pub(crate) struct SelectionViewParams {
@@ -221,6 +224,7 @@ impl ListSelectionView {
         }
 
         let len = self.filtered_indices.len();
+        let first_selectable = self.first_selectable_visible_idx();
         self.state.selected_idx = self
             .state
             .selected_idx
@@ -236,7 +240,14 @@ impl ListSelectionView {
                         .position(|idx| *idx == actual_idx)
                 })
             })
-            .or_else(|| (len > 0).then_some(0));
+            .or(first_selectable);
+
+        // Never rest the cursor on a non-selectable section header.
+        if let Some(sel) = self.state.selected_idx
+            && self.is_header_visible(sel)
+        {
+            self.state.selected_idx = first_selectable;
+        }
 
         let visible = Self::max_visible_rows(len);
         self.state.clamp_selection(len);
@@ -244,54 +255,108 @@ impl ListSelectionView {
     }
 
     fn build_rows(&self) -> Vec<GenericDisplayRow> {
+        let show_numbers = !self.is_searchable || (self.vim_mode && !self.search_active);
+        let mut rows = Vec::with_capacity(self.filtered_indices.len());
+        // Numbers count only selectable rows so section headers do not consume
+        // a position in the 1..N sequence.
+        let mut number = 0usize;
+        for (visible_idx, actual_idx) in self.filtered_indices.iter().enumerate() {
+            let Some(item) = self.items.get(*actual_idx) else {
+                continue;
+            };
+            if item.is_header {
+                rows.push(GenericDisplayRow {
+                    name: item.name.clone(),
+                    display_shortcut: None,
+                    match_indices: None,
+                    description: None,
+                    styled_description: None,
+                    disabled: false,
+                    is_header: true,
+                });
+                continue;
+            }
+            number += 1;
+            let is_selected = self.state.selected_idx == Some(visible_idx);
+            let prefix = if is_selected { '›' } else { ' ' };
+            let name = item.name.as_str();
+            let name_with_marker = if item.is_current {
+                format!("{name} (current)")
+            } else {
+                item.name.clone()
+            };
+            let display_name = if show_numbers {
+                format!("{prefix} {number}. {name_with_marker}")
+            } else {
+                format!("{prefix} {name_with_marker}")
+            };
+            let description = is_selected
+                .then(|| item.selected_description.clone())
+                .flatten()
+                .or_else(|| item.description.clone());
+            rows.push(GenericDisplayRow {
+                name: display_name,
+                display_shortcut: item.display_shortcut,
+                match_indices: None,
+                description,
+                styled_description: None,
+                disabled: false,
+                is_header: false,
+            });
+        }
+        rows
+    }
+
+    /// Whether the visible row at `visible_idx` is a non-selectable header.
+    fn is_header_visible(&self, visible_idx: usize) -> bool {
         self.filtered_indices
-            .iter()
-            .enumerate()
-            .filter_map(|(visible_idx, actual_idx)| {
-                self.items.get(*actual_idx).map(|item| {
-                    let is_selected = self.state.selected_idx == Some(visible_idx);
-                    let prefix = if is_selected { '›' } else { ' ' };
-                    let name = item.name.as_str();
-                    let name_with_marker = if item.is_current {
-                        format!("{name} (current)")
-                    } else {
-                        item.name.clone()
-                    };
-                    let n = visible_idx + 1;
-                    let show_numbers =
-                        !self.is_searchable || (self.vim_mode && !self.search_active);
-                    let display_name = if show_numbers {
-                        format!("{prefix} {n}. {name_with_marker}")
-                    } else {
-                        format!("{prefix} {name_with_marker}")
-                    };
-                    let description = is_selected
-                        .then(|| item.selected_description.clone())
-                        .flatten()
-                        .or_else(|| item.description.clone());
-                    GenericDisplayRow {
-                        name: display_name,
-                        display_shortcut: item.display_shortcut,
-                        match_indices: None,
-                        description,
-                        styled_description: None,
-                        disabled: false,
-                    }
-                })
-            })
-            .collect()
+            .get(visible_idx)
+            .and_then(|actual| self.items.get(*actual))
+            .is_some_and(|item| item.is_header)
+    }
+
+    /// The first visible row that is not a header, if any.
+    fn first_selectable_visible_idx(&self) -> Option<usize> {
+        (0..self.filtered_indices.len()).find(|&idx| !self.is_header_visible(idx))
+    }
+
+    /// Visible index of the `n`-th (1-based) selectable row, matching the numbers
+    /// shown in the list. Headers are unnumbered, so digit selection must count
+    /// only selectable rows.
+    fn nth_selectable_visible_idx(&self, n: usize) -> Option<usize> {
+        n.checked_sub(1).and_then(|skip| {
+            (0..self.filtered_indices.len())
+                .filter(|&idx| !self.is_header_visible(idx))
+                .nth(skip)
+        })
     }
 
     fn move_up(&mut self) {
         let len = self.visible_len();
-        self.state.move_up_wrap(len);
+        if len == 0 {
+            return;
+        }
+        for _ in 0..len {
+            self.state.move_up_wrap(len);
+            if !self.is_header_visible(self.state.selected_idx.unwrap_or(0)) {
+                break;
+            }
+        }
         let visible = Self::max_visible_rows(len);
         self.state.ensure_visible(len, visible);
     }
 
     fn move_down(&mut self) {
         let len = self.visible_len();
-        self.state.move_down_wrap(len);
+        if len == 0 {
+            return;
+        }
+        for _ in 0..len {
+            self.state.move_down_wrap(len);
+            if !self.is_header_visible(self.state.selected_idx.unwrap_or(0)) {
+                break;
+            }
+        }
         let visible = Self::max_visible_rows(len);
         self.state.ensure_visible(len, visible);
     }
@@ -457,8 +522,7 @@ impl BottomPaneView for ListSelectionView {
                         if let Some(idx) = c
                             .to_digit(10)
                             .map(|d| d as usize)
-                            .and_then(|d| d.checked_sub(1))
-                            && idx < self.items.len()
+                            .and_then(|n| self.nth_selectable_visible_idx(n))
                         {
                             self.state.selected_idx = Some(idx);
                             self.accept();
@@ -495,8 +559,7 @@ impl BottomPaneView for ListSelectionView {
                         if let Some(idx) = c
                             .to_digit(10)
                             .map(|d| d as usize)
-                            .and_then(|d| d.checked_sub(1))
-                            && idx < self.items.len()
+                            .and_then(|n| self.nth_selectable_visible_idx(n))
                         {
                             self.state.selected_idx = Some(idx);
                             self.accept();
@@ -1075,6 +1138,161 @@ mod tests {
         );
         assert_snapshot!(
             "list_selection_model_picker_width_80",
+            render_lines_with_width(&view, 80)
+        );
+    }
+
+    fn sectioned_items() -> Vec<SelectionItem> {
+        vec![
+            SelectionItem {
+                name: "Recommended".to_string(),
+                is_header: true,
+                ..Default::default()
+            },
+            SelectionItem {
+                name: "Alpha".to_string(),
+                dismiss_on_select: true,
+                ..Default::default()
+            },
+            SelectionItem {
+                name: "Other".to_string(),
+                is_header: true,
+                ..Default::default()
+            },
+            SelectionItem {
+                name: "Beta".to_string(),
+                dismiss_on_select: true,
+                ..Default::default()
+            },
+        ]
+    }
+
+    #[test]
+    fn digit_keys_select_numbered_selectable_row_skipping_headers() {
+        let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        // sectioned_items renders as: Recommended (header), 1. Alpha,
+        // Other (header), 2. Beta. Headers are unnumbered.
+        let mut view = ListSelectionView::new(
+            SelectionViewParams {
+                title: Some("Test".to_string()),
+                items: sectioned_items(),
+                is_searchable: false,
+                ..Default::default()
+            },
+            tx,
+        );
+
+        view.handle_key_event(KeyEvent::new(KeyCode::Char('2'), KeyModifiers::NONE));
+
+        assert_eq!(
+            view.take_last_selected_index(),
+            Some(3),
+            "pressing '2' should accept the row shown as 2 (Beta), not a header or Alpha"
+        );
+    }
+
+    #[test]
+    fn navigation_skips_header_rows() {
+        let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let mut view = ListSelectionView::new(
+            SelectionViewParams {
+                title: Some("Test".to_string()),
+                items: sectioned_items(),
+                is_searchable: false,
+                ..Default::default()
+            },
+            tx,
+        );
+
+        assert_eq!(
+            view.state.selected_idx,
+            Some(1),
+            "initial selection skips the leading header and lands on the first selectable"
+        );
+
+        view.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(
+            view.state.selected_idx,
+            Some(3),
+            "down should skip the 'Other' header and land on Beta"
+        );
+
+        view.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(
+            view.state.selected_idx,
+            Some(1),
+            "down from the last selectable should wrap to the first selectable"
+        );
+
+        view.handle_key_event(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(
+            view.state.selected_idx,
+            Some(3),
+            "up from the first selectable should wrap to the last, skipping both headers"
+        );
+    }
+
+    #[test]
+    fn snapshot_model_picker_sections_width_80() {
+        let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let items = vec![
+            SelectionItem {
+                name: "Recommended".to_string(),
+                is_header: true,
+                ..Default::default()
+            },
+            SelectionItem {
+                name: "Opus 5".to_string(),
+                description: Some("Most capable".to_string()),
+                is_current: true,
+                dismiss_on_select: true,
+                ..Default::default()
+            },
+            SelectionItem {
+                name: "Sonnet 5".to_string(),
+                description: Some("Fast and capable".to_string()),
+                dismiss_on_select: true,
+                ..Default::default()
+            },
+            SelectionItem {
+                name: "Other".to_string(),
+                is_header: true,
+                ..Default::default()
+            },
+            SelectionItem {
+                name: "Opus 4.6".to_string(),
+                description: Some("claude-opus-4-6".to_string()),
+                dismiss_on_select: true,
+                ..Default::default()
+            },
+            SelectionItem {
+                name: "Sonnet 4.6".to_string(),
+                description: Some("claude-sonnet-4-6".to_string()),
+                dismiss_on_select: true,
+                ..Default::default()
+            },
+            SelectionItem {
+                name: "Use custom model...".to_string(),
+                description: Some("Enter any model ID".to_string()),
+                dismiss_on_select: true,
+                ..Default::default()
+            },
+        ];
+        let view = ListSelectionView::new(
+            SelectionViewParams {
+                title: Some("Model".to_string()),
+                subtitle: Some("Select a value for this ACP session setting".to_string()),
+                items,
+                ..Default::default()
+            },
+            tx,
+        );
+
+        assert_snapshot!(
+            "list_selection_model_picker_sections_width_80",
             render_lines_with_width(&view, 80)
         );
     }

--- a/nori-rs/tui/src/bottom_pane/selection_popup_common.rs
+++ b/nori-rs/tui/src/bottom_pane/selection_popup_common.rs
@@ -33,6 +33,8 @@ pub(crate) struct GenericDisplayRow {
     pub description: Option<String>,       // optional grey text after the name
     pub styled_description: Option<Line<'static>>,
     pub disabled: bool,
+    /// Non-selectable section header: rendered bold with no selection cursor.
+    pub is_header: bool,
 }
 
 /// Compute a shared description-column start based on the widest filtered name
@@ -236,7 +238,13 @@ pub(crate) fn render_rows(
 
         let mut wrapped = wrap_row(row, desc_col, area.width as usize);
 
-        if row.disabled {
+        if row.is_header {
+            for line in &mut wrapped {
+                line.spans.iter_mut().for_each(|span| {
+                    span.style = span.style.bold();
+                });
+            }
+        } else if row.disabled {
             for line in &mut wrapped {
                 line.spans.iter_mut().for_each(|span| {
                     span.style = span.style.dim();
@@ -328,6 +336,7 @@ mod tests {
             description: Some("recording ● on".to_string()),
             styled_description: Some(Line::from(vec!["recording ".dim(), "●".red(), " on".dim()])),
             disabled: false,
+            is_header: false,
         }];
         let mut state = ScrollState::new();
         state.clamp_selection(rows.len());
@@ -371,6 +380,7 @@ mod tests {
                 description: Some("§ first".to_string()),
                 styled_description: None,
                 disabled: false,
+                is_header: false,
             },
             GenericDisplayRow {
                 name: "a".to_string(),
@@ -379,6 +389,7 @@ mod tests {
                 description: Some("§ second".to_string()),
                 styled_description: None,
                 disabled: false,
+                is_header: false,
             },
             GenericDisplayRow {
                 name: "b".to_string(),
@@ -387,6 +398,7 @@ mod tests {
                 description: Some("§ third".to_string()),
                 styled_description: None,
                 disabled: false,
+                is_header: false,
             },
         ];
         let area = Rect::new(0, 0, 50, 2);

--- a/nori-rs/tui/src/bottom_pane/skill_popup.rs
+++ b/nori-rs/tui/src/bottom_pane/skill_popup.rs
@@ -111,6 +111,7 @@ impl SkillPopup {
                 description: Some(item.description),
                 styled_description: None,
                 disabled: false,
+                is_header: false,
             })
             .collect()
     }

--- a/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__list_selection_view__tests__list_selection_model_picker_sections_width_80.snap
+++ b/nori-rs/tui/src/bottom_pane/snapshots/nori_tui__bottom_pane__list_selection_view__tests__list_selection_model_picker_sections_width_80.snap
@@ -1,0 +1,16 @@
+---
+source: tui/src/bottom_pane/list_selection_view.rs
+assertion_line: 1277
+expression: "render_lines_with_width(&view, 80)"
+---
+                                                                                
+  Model                                                                         
+  Select a value for this ACP session setting                                   
+                                                                                
+Recommended                                                                     
+› 1. Opus 5 (current)     Most capable                                          
+  2. Sonnet 5             Fast and capable                                      
+Other                                                                           
+  3. Opus 4.6             claude-opus-4-6                                       
+  4. Sonnet 4.6           claude-sonnet-4-6                                     
+  5. Use custom model...  Enter any model ID

--- a/nori-rs/tui/src/chatwidget/event_handlers.rs
+++ b/nori-rs/tui/src/chatwidget/event_handlers.rs
@@ -579,6 +579,7 @@ impl ChatWidget {
                     })],
                     dismiss_on_select: true,
                     search_value: None,
+                    is_header: false,
                 }
             })
             .collect();

--- a/nori-rs/tui/src/chatwidget/pickers.rs
+++ b/nori-rs/tui/src/chatwidget/pickers.rs
@@ -721,8 +721,13 @@ impl ChatWidget {
         &mut self,
         option: nori_protocol::acp::v1::SessionConfigOption,
     ) {
-        let params =
-            crate::nori::session_config_picker::acp_session_config_value_picker_params(&option);
+        let other_models = nori_harness::AgentKind::from_slug(&self.config.active_agent)
+            .map(nori_harness::AgentKind::other_models)
+            .unwrap_or(&[]);
+        let params = crate::nori::session_config_picker::acp_session_config_value_picker_params(
+            &option,
+            other_models,
+        );
         self.bottom_pane.show_selection_view(params);
     }
 

--- a/nori-rs/tui/src/nori/session_config_picker.rs
+++ b/nori-rs/tui/src/nori/session_config_picker.rs
@@ -1,5 +1,6 @@
 //! Generic picker helpers for ACP session config options.
 
+use nori_harness::OtherModel;
 use nori_protocol::acp::v1 as acp;
 use ratatui::text::Line;
 
@@ -78,6 +79,7 @@ pub(crate) fn acp_session_config_picker_params(
 
 pub(crate) fn acp_session_config_value_picker_params(
     option: &acp::SessionConfigOption,
+    other_models: &[OtherModel],
 ) -> SelectionViewParams {
     let acp::SessionConfigKind::Select(select) = &option.kind else {
         return SelectionViewParams {
@@ -94,17 +96,14 @@ pub(crate) fn acp_session_config_value_picker_params(
         };
     };
 
-    let mut items = Vec::new();
-    let mut initial_selected_idx = None;
+    let is_model = option.category == Some(acp::SessionConfigOptionCategory::Model);
 
+    // "Recommended": the values the agent advertises, exactly as reported.
+    let mut recommended: Vec<SelectionItem> = Vec::new();
     match &select.options {
         acp::SessionConfigSelectOptions::Ungrouped(options) => {
             for option_value in options {
-                let idx = items.len();
-                if option_value.value == select.current_value && initial_selected_idx.is_none() {
-                    initial_selected_idx = Some(idx);
-                }
-                items.push(value_item(
+                recommended.push(value_item(
                     option,
                     option_value,
                     None,
@@ -114,14 +113,9 @@ pub(crate) fn acp_session_config_value_picker_params(
         }
         acp::SessionConfigSelectOptions::Grouped(groups) => {
             for group in groups {
-                items.push(group_header_item(group));
+                recommended.push(group_header_item(group));
                 for option_value in &group.options {
-                    let idx = items.len();
-                    if option_value.value == select.current_value && initial_selected_idx.is_none()
-                    {
-                        initial_selected_idx = Some(idx);
-                    }
-                    items.push(value_item(
+                    recommended.push(value_item(
                         option,
                         option_value,
                         Some(&group.name),
@@ -133,7 +127,34 @@ pub(crate) fn acp_session_config_value_picker_params(
         _ => {}
     }
 
-    if option.category == Some(acp::SessionConfigOptionCategory::Model) {
+    // "Other": curated models the agent does not advertise, forced via spawn-time
+    // injection. Deduplicated against advertised values so nothing appears twice.
+    let mut other: Vec<SelectionItem> = Vec::new();
+    if is_model {
+        let advertised = advertised_value_strings(&select.options);
+        let current_value = select.current_value.to_string();
+        for model in other_models {
+            if advertised.contains(model.id) {
+                continue;
+            }
+            other.push(other_model_item(option, model, current_value == model.id));
+        }
+    }
+
+    // Only show labeled sections when both sides have content; otherwise render a
+    // flat list exactly as before.
+    let mut items = Vec::new();
+    if !recommended.is_empty() && !other.is_empty() {
+        items.push(section_header_item("Recommended"));
+        items.append(&mut recommended);
+        items.push(section_header_item("Other"));
+        items.append(&mut other);
+    } else {
+        items.append(&mut recommended);
+        items.append(&mut other);
+    }
+
+    if is_model {
         let config_id = option.id.to_string();
         let option_name = option.name.clone();
         items.push(SelectionItem {
@@ -151,9 +172,11 @@ pub(crate) fn acp_session_config_value_picker_params(
         });
     }
 
-    if initial_selected_idx.is_none() {
-        initial_selected_idx = items.iter().position(|item| !item.actions.is_empty());
-    }
+    let initial_selected_idx = items.iter().position(|item| item.is_current).or_else(|| {
+        items
+            .iter()
+            .position(|item| !item.is_header && !item.actions.is_empty())
+    });
 
     SelectionViewParams {
         title: Some(option.name.clone()),
@@ -191,11 +214,70 @@ fn current_value_label(option: &acp::SessionConfigOption) -> Option<String> {
     }
 }
 
+fn section_header_item(label: &str) -> SelectionItem {
+    SelectionItem {
+        name: label.to_string(),
+        is_header: true,
+        dismiss_on_select: false,
+        ..Default::default()
+    }
+}
+
+fn advertised_value_strings(
+    options: &acp::SessionConfigSelectOptions,
+) -> std::collections::HashSet<String> {
+    match options {
+        acp::SessionConfigSelectOptions::Ungrouped(values) => {
+            values.iter().map(|value| value.value.to_string()).collect()
+        }
+        acp::SessionConfigSelectOptions::Grouped(groups) => groups
+            .iter()
+            .flat_map(|group| group.options.iter())
+            .map(|value| value.value.to_string())
+            .collect(),
+        _ => std::collections::HashSet::new(),
+    }
+}
+
+fn other_model_item(
+    option: &acp::SessionConfigOption,
+    model: &OtherModel,
+    is_current: bool,
+) -> SelectionItem {
+    let actions: Vec<SelectionAction> = if is_current {
+        Vec::new()
+    } else {
+        let config_id = option.id.to_string();
+        let option_name = option.name.clone();
+        let value = model.id.to_string();
+        let value_name = model.label.to_string();
+        vec![Box::new(move |tx| {
+            tx.send(AppEvent::SetAcpSessionConfigOption {
+                config_id: config_id.clone(),
+                value: value.clone(),
+                option_name: option_name.clone(),
+                value_name: value_name.clone(),
+                is_custom_model: true,
+            });
+        })]
+    };
+
+    SelectionItem {
+        name: model.label.to_string(),
+        description: Some(model.id.to_string()),
+        is_current,
+        actions,
+        dismiss_on_select: true,
+        search_value: Some(format!("{} {}", model.label, model.id)),
+        ..Default::default()
+    }
+}
+
 fn group_header_item(group: &acp::SessionConfigSelectGroup) -> SelectionItem {
     SelectionItem {
-        name: format!("[{}]", group.name),
+        name: group.name.clone(),
+        is_header: true,
         dismiss_on_select: false,
-        search_value: Some(group.name.clone()),
         ..Default::default()
     }
 }
@@ -337,14 +419,15 @@ mod tests {
 
     #[test]
     fn value_picker_preserves_group_order_and_current_selection() {
-        let params = super::acp_session_config_value_picker_params(&grouped_mode_option());
+        let params = super::acp_session_config_value_picker_params(&grouped_mode_option(), &[]);
         let names = params
             .items
             .iter()
             .map(|item| item.name.as_str())
             .collect::<Vec<_>>();
 
-        assert_eq!(names, vec!["[Safe]", "Ask", "[Active]", "Plan", "Build"]);
+        assert_eq!(names, vec!["Safe", "Ask", "Active", "Plan", "Build"]);
+        assert!(params.items[0].is_header, "group labels render as headers");
         assert!(params.items[3].is_current);
         assert_eq!(params.initial_selected_idx, Some(3));
     }
@@ -354,7 +437,7 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let app_event_tx = crate::app_event_sender::AppEventSender::new(tx);
         let mut current_view = crate::bottom_pane::ListSelectionView::new(
-            super::acp_session_config_value_picker_params(&model_option()),
+            super::acp_session_config_value_picker_params(&model_option(), &[]),
             app_event_tx.clone(),
         );
 
@@ -371,7 +454,7 @@ mod tests {
         );
 
         let mut alternate_view = crate::bottom_pane::ListSelectionView::new(
-            super::acp_session_config_value_picker_params(&model_option()),
+            super::acp_session_config_value_picker_params(&model_option(), &[]),
             app_event_tx,
         );
         crate::bottom_pane::BottomPaneView::handle_key_event(
@@ -418,7 +501,7 @@ mod tests {
 
     #[test]
     fn model_picker_includes_custom_model_entry() {
-        let params = super::acp_session_config_value_picker_params(&model_option());
+        let params = super::acp_session_config_value_picker_params(&model_option(), &[]);
         let names: Vec<&str> = params.items.iter().map(|i| i.name.as_str()).collect();
 
         assert_eq!(
@@ -439,8 +522,158 @@ mod tests {
 
     #[test]
     fn non_model_picker_does_not_include_custom_entry() {
-        let params = super::acp_session_config_value_picker_params(&grouped_mode_option());
+        let params = super::acp_session_config_value_picker_params(&grouped_mode_option(), &[]);
 
         assert!(!params.items.iter().any(|i| i.name == "Use custom model..."));
+    }
+
+    fn model_option_with_current(current: &'static str) -> acp::SessionConfigOption {
+        acp::SessionConfigOption::select(
+            "model",
+            "Model",
+            current,
+            vec![
+                acp::SessionConfigSelectOption::new("mock-model-default", "Mock Default Model"),
+                acp::SessionConfigSelectOption::new("mock-model-fast", "Mock Fast Model"),
+            ],
+        )
+        .category(acp::SessionConfigOptionCategory::Model)
+    }
+
+    const OTHER_MODELS: &[OtherModel] = &[
+        OtherModel {
+            id: "legacy-a",
+            label: "Legacy A",
+        },
+        OtherModel {
+            id: "legacy-b",
+            label: "Legacy B",
+        },
+    ];
+
+    fn item_names(params: &SelectionViewParams) -> Vec<&str> {
+        params.items.iter().map(|item| item.name.as_str()).collect()
+    }
+
+    #[test]
+    fn model_picker_splits_recommended_and_other_sections() {
+        let params = super::acp_session_config_value_picker_params(&model_option(), OTHER_MODELS);
+
+        assert_eq!(
+            item_names(&params),
+            vec![
+                "Recommended",
+                "Mock Default Model",
+                "Mock Fast Model",
+                "Other",
+                "Legacy A",
+                "Legacy B",
+                "Use custom model...",
+            ]
+        );
+
+        let row = |name: &str| {
+            params
+                .items
+                .iter()
+                .find(|item| item.name == name)
+                .unwrap_or_else(|| panic!("row {name} present"))
+        };
+        assert!(row("Recommended").is_header, "section labels are headers");
+        assert!(row("Other").is_header, "section labels are headers");
+        assert!(
+            !row("Mock Default Model").is_header,
+            "advertised models are selectable rows"
+        );
+        assert!(
+            !row("Legacy A").is_header,
+            "other models are selectable rows"
+        );
+    }
+
+    #[test]
+    fn model_picker_dedupes_other_against_advertised() {
+        let others: &[OtherModel] = &[
+            OtherModel {
+                id: "mock-model-fast",
+                label: "Should Not Appear",
+            },
+            OtherModel {
+                id: "legacy-b",
+                label: "Legacy B",
+            },
+        ];
+
+        let params = super::acp_session_config_value_picker_params(&model_option(), others);
+
+        assert_eq!(
+            item_names(&params),
+            vec![
+                "Recommended",
+                "Mock Default Model",
+                "Mock Fast Model",
+                "Other",
+                "Legacy B",
+                "Use custom model...",
+            ],
+            "an already-advertised id must not be duplicated in the Other section"
+        );
+    }
+
+    #[test]
+    fn selecting_other_model_requests_injected_config_change() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let app_event_tx = crate::app_event_sender::AppEventSender::new(tx);
+        let params = super::acp_session_config_value_picker_params(&model_option(), OTHER_MODELS);
+
+        let other = params
+            .items
+            .iter()
+            .find(|item| item.name == "Legacy A")
+            .expect("other model row present");
+        for action in &other.actions {
+            action(&app_event_tx);
+        }
+
+        let event = rx
+            .try_recv()
+            .expect("selecting an other model emits a config change");
+        assert!(matches!(
+            event,
+            AppEvent::SetAcpSessionConfigOption {
+                config_id,
+                value,
+                option_name,
+                value_name,
+                is_custom_model,
+            } if config_id == "model"
+                && value == "legacy-a"
+                && option_name == "Model"
+                && value_name == "Legacy A"
+                && is_custom_model
+        ));
+        assert!(rx.try_recv().is_err(), "expected a single config event");
+    }
+
+    #[test]
+    fn current_injected_other_model_is_marked_and_not_resettable() {
+        let params = super::acp_session_config_value_picker_params(
+            &model_option_with_current("legacy-a"),
+            OTHER_MODELS,
+        );
+
+        let other = params
+            .items
+            .iter()
+            .find(|item| item.name == "Legacy A")
+            .expect("other model row present");
+        assert!(
+            other.is_current,
+            "the active injected model should be current"
+        );
+        assert!(
+            other.actions.is_empty(),
+            "the already-current model should not be re-settable"
+        );
     }
 }


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- The `/model` picker now splits into a **Recommended** section (models the ACP agent advertises) and an **Other** section (a curated, per-agent list of real models the agent does not advertise but that work via the existing spawn-time model injection). Selecting an Other model routes through the existing reject → persist-to-`[default_models]` → restart-with-injection path (`is_custom_model: true`); the Other list is deduped against advertised values, and sections only appear when both sides are non-empty (otherwise flat, as before).
- Adds a non-selectable section-header primitive (`is_header`) to the shared `ListSelectionView` — headers render bold with no number/cursor, and navigation, default selection, and digit selection all skip them. Grouped config options reuse this primitive instead of the old `[Group]` bracket text.
- Curated Other lists were deprecation-verified against each provider's authoritative model/deprecation pages and are the durable complement to each adapter's (version/account-dependent) advertised catalog: **Claude Code** — Opus 4.8/4.7/4.6, Sonnet 4.6; **Codex** — GPT-5.3-Codex; **Gemini** — 3.7 Flash, 3.5 Flash, 3.5 Flash-Lite.

## Test Plan
- [x] `cargo test -p nori-tui` (1297 passed) — composition/dedup/injection-routing/current-marking unit tests, header-navigation + digit-selection tests, and a two-section render snapshot
- [x] `cargo test -p nori-acp-host` (79 passed)
- [x] `cargo build --bin nori && cargo test -p tui-pty-e2e` (6 passed)
- [x] End-to-end: drove the real TUI (mock agent under `codex` slug) and confirmed the `/model` picker renders Recommended/Other sections, headers are non-selectable, numbering + arrow nav skip headers, and `gpt-5.3-codex` appears under Other
- [x] `just fmt` + `just fix` clean

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets