### PR TITLE
feat(tui-components): color agent picker surfaces

### DIFF
--- a/nori-rs/tui-components/DESIGN.md
+++ b/nori-rs/tui-components/DESIGN.md
@@ -45,8 +45,16 @@ as they move into this crate.
     terminal setup, event loops, commands, or application actions.
 20. Mark search with a text magnifying-glass character, not an emoji. Shade
     only the editable input region after the marker.
-21. Keep inactive search affordances concise: show `/ search` as the canonical
-    hint even when a consumer supports additional activation aliases.
+
+Keep the inactive search affordance concise: display `/ search`, even when a
+consumer accepts additional activation aliases such as `f` and Ctrl-F. The
+visible hint communicates the conventional binding without becoming an
+exhaustive keymap; once search is active, printable keys belong to the query.
+
+Provider identity is explicit metadata, never inferred from display labels.
+Provider-toned category tabs retain their identity color when active and add
+bold emphasis. Provider-toned cells use the same identity mapping, while
+selection and disabled styles remain the stronger interaction signals.
 
 ## Overlay menus
 
@@ -109,11 +117,15 @@ Overlay menu layout responds to the caller's rectangle:
 
 The overlay may shade only the caller-provided area. `backdrop` and
 `menu_surface` are terminal-relative neutral theme tokens: derive them from a
-reported RGB terminal background only when true-color support is known. Leave
-their backgrounds unset otherwise. Never replace them with indexed grays. A
-selected item fills its complete rendered height and padding with the selected
-neutral surface, then receives matching one-cell thin accent rails on both
-edges. Ordinary rows use the menu surface; they are not zebra striped.
+reported RGB terminal background only when true-color support is known. The
+`menu_item_surface` token starts from that derived menu surface and lowers each
+RGB channel by a small fixed amount, keeping enabled items slightly darker on
+both dark and light terminals. Leave all of these backgrounds unset otherwise,
+and never replace them with indexed grays. A selected item fills its complete
+rendered height and padding with the selected neutral surface, then receives
+matching one-cell thin accent rails on both edges. Unselected enabled rows use
+`menu_item_surface`; disabled rows remain faded on `menu_surface`. Menu rows are
+not zebra striped.
 
 There is intentionally no public `SelectableListState` abstraction. The menu
 and picker both expose caller-held state and typed outcomes, but their
@@ -165,4 +177,6 @@ are the visual acceptance target for this crate. Detail pane is page `5`; page
 activate, `Tab`/`Shift-Tab` to change the menu case, and the displayed number or
 character shortcuts to invoke actions. The example owns its terminal and event
 loop, adapts raw keys to domain-free actions, and uses production components
-only.
+only. While Picker search is active, printable keys belong exclusively to the
+query: global page, quit, density, mode, and state shortcuts resume only after
+search deactivates, and Escape deactivates search before leaving the example.

--- a/nori-rs/tui-components/README.md
+++ b/nori-rs/tui-components/README.md
@@ -29,14 +29,14 @@ cargo run -p nori-tui-components --example nori_storybook
 
 The canonical storybook contains Picker, Markdown, Primitives, States, Detail
 pane, and the production Overlay menu. Use `1-6` to change page, `d` to switch
-picker density, and `Tab`/`Shift-Tab` to compare overlay-menu states. While the
-Picker page search is inactive, `/`, `f`, or Ctrl-F activates search; its
-concise footer mentions only `/`. While search is active, every printable key
-belongs to the query instead of the surrounding page shortcuts. While the
-overlay page is active, use arrows or `j`/`k` to move, `Enter` to activate, and
-`1-5` or `r`/`s`/`i`/`a` to invoke displayed shortcuts. Overlay shortcuts take
-precedence over numbered page navigation; the left arrow returns to Detail pane
-and the right arrow wraps to Picker.
+picker density, and `Tab`/`Shift-Tab` to compare overlay-menu states. Picker
+search owns every printable key while active, so page, quit, density, mode, and
+state shortcuts resume after search deactivates. `/`, `f`, and Ctrl-F all
+activate picker search; the visible subtitle and footer mention only `/` to
+keep the hint concise. While the overlay page is active, use arrows or `j`/`k`
+to move, `Enter` to activate, and `1-5` or `r`/`s`/`i`/`a` to invoke displayed
+shortcuts. Overlay shortcuts take precedence over numbered page navigation;
+the left arrow returns to Detail pane and the right arrow wraps to Picker.
 The focused examples remain useful while developing one component:
 
 ```console
@@ -45,4 +45,5 @@ cargo run -p nori-tui-components --example markdown_storybook
 cargo run -p nori-tui-components --example component_storybook
 ```
 
-Press `q` or `Esc` to leave an example while picker search is inactive.
+Press `q` or `Esc` to leave an example. In picker examples, active search owns
+printable keys and the first Escape, so deactivate search before quitting.

--- a/nori-rs/tui-components/docs.md
+++ b/nori-rs/tui-components/docs.md
@@ -44,10 +44,11 @@ consumer application
 - [`DetailPane`](src/detail.rs) is a stateless definition-list renderer for
   caller-positioned side or bottom regions. Its caller retains placement,
   scrolling, focus, loading, key handling, and application routing.
-- [`theme`](src/theme/) supplies semantic styles shared across components.
-  Neutral backgrounds are derived from a reported terminal RGB background
-  only when the consumer knows true color is supported; otherwise those
-  backgrounds remain unset.
+- [`theme`](src/theme/) supplies semantic styles shared across components,
+  including agent identity tones selected through [`ProviderKind`](src/detail.rs).
+  Neutral backgrounds, including the distinct overlay item layer, are derived
+  from a reported terminal RGB background only when the consumer knows true
+  color is supported; otherwise those backgrounds remain unset.
 - Ratatui provides the rendering types and caller rectangles. Crossterm is an
   example-only development dependency, so the public library does not bind a
   consumer to one raw event source.
@@ -76,11 +77,26 @@ consumer application
   clears the query and selects the first available visible item, and selecting
   `SearchMode::None` also clears both search state and query.
 - The [`picker` renderer](src/picker/render.rs) shows its input row only during
-  active search and derives footer hints from the same state. Inactive pickers
-  intentionally show the concise conventional `/ search` affordance instead
-  of an exhaustive consumer keymap. This keeps the state machine and
+  active search and derives footer hints from the same state. Its inactive
+  footer deliberately advertises only the concise `/ search` convention, not
+  every raw-key alias a consumer may map. This keeps the state machine and
   presentation synchronized while leaving the consumer free to choose which
-  raw keys activate search; Nori also accepts `f` and Ctrl-F.
+  raw keys activate search.
+- Picker consumers may attach explicit [`ProviderKind`](src/detail.rs) values
+  to category names and individual cells. Category tabs retain their provider
+  foreground when active and add bold emphasis; toned cells are used only for
+  enabled, unselected rows so disabled and selected state styles remain the
+  stronger interaction signal. The shared theme supplies this default identity
+  mapping:
+
+  | Agent identity | Terminal tone |
+  | --- | --- |
+  | Claude | Warm yellow/orange |
+  | Codex | White |
+  | Gemini and Antigravity | Blue |
+  | Nori | Green |
+
+  Pi retains the warning tone and unknown providers use normal text.
 - `OverlayMenu` centers a content-derived, maximum-width surface inside the
   supplied rectangle. Rendering reconciles only menu-local viewport offset and
   capacity so the selection stays visible when content exceeds the available
@@ -94,9 +110,15 @@ consumer application
   display width, and emits overflow markers when not all items fit. Key hints
   occupy the bottom of the remaining surface and clamp below the title so tiny
   or non-zero-origin caller rectangles remain bounded.
-- Selected items retain the normal primary accent across semantic tones, fill
-  the complete row surface, and use symmetric thin edge rails. Warning and
-  destructive colors identify consequences only while an item is not selected.
+- Enabled, unselected menu items fill their complete item rectangles with the
+  darker [`Theme::menu_item_surface`](src/theme/mod.rs) layer. Its terminal-aware
+  default starts from `menu_surface` and lowers each RGB channel by a small
+  fixed amount, so enabled items keep the same depth direction on dark and
+  light terminal backgrounds. Selected items retain the normal primary accent
+  across semantic tones and use symmetric thin edge rails; disabled items
+  remain faded on `menu_surface` and stay unavailable to navigation or
+  activation. Warning and destructive colors identify consequences only while
+  an item is not selected.
 
 ### Things to Know
 
@@ -106,8 +128,15 @@ consumer application
 - Search state is independent of a consumer's editing mode. A consumer must
   explicitly map activation and deactivation keys to picker actions; printable
   query input has no effect until activation, so navigation shortcuts remain
-  available while search is inactive. Once active, all printable input belongs
-  to the query, including characters used by surrounding storybook shortcuts.
+  available while search is inactive. Nori's picker adapters support `/`, `f`,
+  and Ctrl-F even though the visible inactive hint names only `/`.
+- The storybook event adapters demonstrate the inverse routing invariant:
+  while picker search is active, every printable character belongs to the
+  query, so page navigation, quit, density, mode, and state shortcuts remain
+  suspended until search deactivates.
+- Provider tones are opt-in metadata rather than label inference. Untoned
+  categories keep the existing accent-or-muted active treatment, and untoned
+  cells keep the row's normal state style.
 - A shortcut invokes its matching enabled item immediately. When an item has
   both shortcut families, either maps to the same stable key; precedence among
   raw input meanings belongs to the consumer adapter.
@@ -117,8 +146,8 @@ consumer application
   most two rows, blank spacing separates items, and selected content remains
   visible as the viewport changes.
 - `backdrop` styles only the caller-provided rectangle. Without a derived RGB
-  theme, neither the backdrop nor menu surface substitutes an absolute neutral
-  color.
+  theme, the backdrop, menu surface, and menu-item surface remain unset instead
+  of substituting an absolute neutral color.
 - No public selectable-list core is extracted: menu and picker semantics do
   not yet have another proven shared consumer beyond their existing
   state-in/typed-outcome-out convention.

--- a/nori-rs/tui-components/examples/nori_storybook.rs
+++ b/nori-rs/tui-components/examples/nori_storybook.rs
@@ -547,30 +547,35 @@ fn picker_state() -> PickerState<String> {
             max: 40,
             weight: 3,
         }),
+        PickerColumn::fixed("type", "Type", 12),
         PickerColumn::flexible("project", "Project").hide_below(58),
         PickerColumn::fixed("updated", "Updated", 10),
         PickerColumn::fixed("status", "Turn status", 13).hide_below(82),
     ];
     let items = [
         PickerItem::new("new".to_string(), "title", "Start a new session")
+            .cell("type", "Nori")
+            .cell_tone("type", ProviderKind::Nori)
             .cell("project", "Not reported")
             .cell("updated", "now")
             .cell("status", "ready")
             .search_text("start create new")
             .pinned(true)
-            .category("Local")
+            .category("Nori")
             .description("Create a fresh ACP session")
             .details([
                 PickerDetail::new("Action", "Create a fresh ACP session"),
                 PickerDetail::new("Transcript", "No transcript will be loaded"),
             ]),
         PickerItem::new("parser".to_string(), "title", "Fix parser recovery")
+            .cell("type", "Codex")
+            .cell_tone("type", ProviderKind::Codex)
             .cell("project", "nori-cli")
             .cell("updated", "2m ago")
             .cell("status", "working")
             .search_text("fix parser recovery nori cli session 019f")
             .current(true)
-            .category("Local")
+            .category("Codex")
             .description("Codex is implementing parser recovery")
             .details([
                 PickerDetail::new("Agent", "Codex"),
@@ -578,41 +583,52 @@ fn picker_state() -> PickerState<String> {
                 PickerDetail::new("Current turn", "Implementing parser recovery"),
             ]),
         PickerItem::new("markdown".to_string(), "title", "Improve Markdown tables")
+            .cell("type", "Gemini")
+            .cell_tone("type", ProviderKind::Gemini)
             .cell("project", "external-codex")
             .cell("updated", "18m ago")
             .cell("status", "waiting")
             .search_text("markdown tables codex waiting")
-            .category("Local")
+            .category("Gemini")
             .description("Waiting for user input")
             .details([
                 PickerDetail::new("Agent", "Codex"),
                 PickerDetail::new("Current turn", "Waiting for user input"),
             ]),
         PickerItem::new("cloud".to_string(), "title", "Slack · Claude")
+            .cell("type", "Claude")
+            .cell_tone("type", ProviderKind::Claude)
             .cell("project", "Nori Sessions")
             .cell("updated", "1h ago")
             .cell("status", "ready")
             .search_text("slack claude cloud sessions")
-            .category("Cloud")
+            .category("Claude")
             .description("The broker owns this remote session")
             .details([
                 PickerDetail::new("Origin", "Nori cloud"),
                 PickerDetail::new("Ownership", "Broker-managed remote session"),
             ]),
         PickerItem::new("offline".to_string(), "title", "Unavailable legacy session")
+            .cell("type", "Antigravity")
+            .cell_tone("type", ProviderKind::Antigravity)
             .cell("project", "handroll")
             .cell("updated", "3d ago")
             .cell("status", "offline")
             .search_text("legacy handroll offline")
             .disabled(true)
-            .category("Cloud")
+            .category("Antigravity")
             .description("This legacy session cannot be resumed"),
     ];
     PickerState::new("Nori component storybook", columns, items)
         .subtitle("Search ACP sessions or start fresh")
         .mode(PickerMode::Single)
         .search_mode(SearchMode::Fuzzy)
-        .categories(["Local", "Cloud"])
+        .categories(["Claude", "Codex", "Gemini", "Antigravity", "Nori"])
+        .category_tone("Claude", ProviderKind::Claude)
+        .category_tone("Codex", ProviderKind::Codex)
+        .category_tone("Gemini", ProviderKind::Gemini)
+        .category_tone("Antigravity", ProviderKind::Antigravity)
+        .category_tone("Nori", ProviderKind::Nori)
         .search_placeholder("Title, project, or session id")
 }
 

--- a/nori-rs/tui-components/examples/picker_storybook.rs
+++ b/nori-rs/tui-components/examples/picker_storybook.rs
@@ -14,6 +14,7 @@ use nori_tui_components::PickerItem;
 use nori_tui_components::PickerMode;
 use nori_tui_components::PickerOutcome;
 use nori_tui_components::PickerState;
+use nori_tui_components::ProviderKind;
 use nori_tui_components::SearchMode;
 use ratatui::layout::Alignment;
 use ratatui::text::Line;
@@ -144,30 +145,35 @@ fn story_state() -> PickerState<String> {
             max: 40,
             weight: 3,
         }),
+        PickerColumn::fixed("type", "Type", 12),
         PickerColumn::flexible("project", "Project").hide_below(58),
         PickerColumn::fixed("updated", "Updated", 10),
         PickerColumn::fixed("status", "Turn status", 13).hide_below(82),
     ];
     let items = [
         PickerItem::new("new".to_string(), "title", "Start a new session")
+            .cell("type", "Nori")
+            .cell_tone("type", ProviderKind::Nori)
             .cell("project", "Not reported")
             .cell("updated", "now")
             .cell("status", "ready")
             .search_text("start create new")
             .pinned(true)
-            .category("Local")
+            .category("Nori")
             .description("Create a fresh ACP session")
             .details([
                 PickerDetail::new("Action", "Create a fresh ACP session"),
                 PickerDetail::new("Transcript", "No transcript will be loaded"),
             ]),
         PickerItem::new("parser".to_string(), "title", "Fix parser recovery")
+            .cell("type", "Codex")
+            .cell_tone("type", ProviderKind::Codex)
             .cell("project", "nori-cli")
             .cell("updated", "2m ago")
             .cell("status", "working")
             .search_text("fix parser recovery nori cli session 019f")
             .current(true)
-            .category("Local")
+            .category("Codex")
             .description("Codex is implementing parser recovery")
             .details([
                 PickerDetail::new("Agent", "Codex"),
@@ -175,39 +181,50 @@ fn story_state() -> PickerState<String> {
                 PickerDetail::new("Current turn", "Implementing parser recovery"),
             ]),
         PickerItem::new("markdown".to_string(), "title", "Improve Markdown tables")
+            .cell("type", "Gemini")
+            .cell_tone("type", ProviderKind::Gemini)
             .cell("project", "external-codex")
             .cell("updated", "18m ago")
             .cell("status", "waiting")
             .search_text("markdown tables codex waiting")
-            .category("Local")
+            .category("Gemini")
             .description("Waiting for user input")
             .details([
                 PickerDetail::new("Agent", "Codex"),
                 PickerDetail::new("Turn", "Waiting for user input"),
             ]),
         PickerItem::new("cloud".to_string(), "title", "Slack · Claude")
+            .cell("type", "Claude")
+            .cell_tone("type", ProviderKind::Claude)
             .cell("project", "Nori Sessions")
             .cell("updated", "1h ago")
             .cell("status", "ready")
             .search_text("slack claude cloud sessions")
-            .category("Cloud")
+            .category("Claude")
             .description("The broker owns this remote session")
             .details([
                 PickerDetail::new("Origin", "Nori cloud"),
                 PickerDetail::new("Ownership", "The broker owns the remote session"),
             ]),
         PickerItem::new("offline".to_string(), "title", "Unavailable legacy session")
+            .cell("type", "Antigravity")
+            .cell_tone("type", ProviderKind::Antigravity)
             .cell("project", "handroll")
             .cell("updated", "3d ago")
             .cell("status", "offline")
             .search_text("legacy handroll offline")
             .disabled(true)
-            .category("Cloud"),
+            .category("Antigravity"),
     ];
     PickerState::new("Picker storybook", columns, items)
         .subtitle("/ searches · tab changes category · enter selects · q exits")
         .mode(PickerMode::Single)
         .search_mode(SearchMode::Fuzzy)
-        .categories(["Local", "Cloud"])
+        .categories(["Claude", "Codex", "Gemini", "Antigravity", "Nori"])
+        .category_tone("Claude", ProviderKind::Claude)
+        .category_tone("Codex", ProviderKind::Codex)
+        .category_tone("Gemini", ProviderKind::Gemini)
+        .category_tone("Antigravity", ProviderKind::Antigravity)
+        .category_tone("Nori", ProviderKind::Nori)
         .search_placeholder("Title, project, or session id")
 }

--- a/nori-rs/tui-components/src/detail.rs
+++ b/nori-rs/tui-components/src/detail.rs
@@ -32,6 +32,8 @@ pub enum DetailTone {
 pub enum ProviderKind {
     Claude,
     Codex,
+    Gemini,
+    Antigravity,
     Pi,
     Nori,
     #[default]
@@ -226,13 +228,24 @@ fn tone_style(tone: DetailTone, theme: Theme) -> Style {
     match tone {
         DetailTone::Default => theme.text,
         DetailTone::Muted => theme.muted,
-        DetailTone::Info
-        | DetailTone::Provider(ProviderKind::Codex)
-        | DetailTone::Provider(ProviderKind::Nori) => theme.info,
-        DetailTone::Success | DetailTone::Provider(ProviderKind::Claude) => theme.success,
+        DetailTone::Info => theme.info,
+        DetailTone::Success => theme.success,
         DetailTone::Warning | DetailTone::Provider(ProviderKind::Pi) => theme.warning,
         DetailTone::Error => theme.error,
         DetailTone::Provider(ProviderKind::Other) => theme.text,
+        DetailTone::Provider(provider) => provider_tone_style(provider, theme),
+    }
+}
+
+pub(crate) fn provider_tone_style(provider: ProviderKind, theme: Theme) -> Style {
+    match provider {
+        ProviderKind::Claude => theme.provider_claude,
+        ProviderKind::Codex => theme.provider_codex,
+        ProviderKind::Gemini => theme.provider_gemini,
+        ProviderKind::Antigravity => theme.provider_antigravity,
+        ProviderKind::Nori => theme.provider_nori,
+        ProviderKind::Pi => theme.warning,
+        ProviderKind::Other => theme.text,
     }
 }
 

--- a/nori-rs/tui-components/src/detail/tests.rs
+++ b/nori-rs/tui-components/src/detail/tests.rs
@@ -62,7 +62,7 @@ fn detail_pane_respects_fixed_gutter_and_provider_tone() {
         .expect("draw pane");
     let buffer = terminal.backend().buffer();
     assert_eq!(buffer[(11, 0)].symbol(), "│");
-    assert_eq!(buffer[(13, 0)].fg, Color::Cyan);
+    assert_eq!(buffer[(13, 0)].fg, Color::White);
 }
 
 #[test]

--- a/nori-rs/tui-components/src/menu/render.rs
+++ b/nori-rs/tui-components/src/menu/render.rs
@@ -297,6 +297,9 @@ fn render_item<K>(
         return;
     }
     let selected_style = theme.selected.remove_modifier(Modifier::BOLD);
+    if !item.disabled {
+        buf.set_style(area, theme.menu_item_surface);
+    }
     if selected {
         buf.set_style(area, selected_style);
         for y in area.y..area.bottom() {

--- a/nori-rs/tui-components/src/menu/tests.rs
+++ b/nori-rs/tui-components/src/menu/tests.rs
@@ -371,6 +371,66 @@ fn derived_surfaces_style_the_backdrop_menu_and_title() {
 
 #[test]
 #[allow(clippy::disallowed_methods)]
+fn unselected_enabled_items_use_a_deeper_surface_than_disabled_items() {
+    let theme = Theme::for_terminal_background(Some((20, 20, 20)));
+    let mut state = MenuState::try_new([
+        basic_item("selected", "Selected action"),
+        basic_item("enabled", "Enabled action"),
+        basic_item("disabled", "Disabled action").disabled(true),
+    ])
+    .expect("valid surface menu");
+    let buffer = rendered_buffer(
+        &mut state,
+        80,
+        24,
+        "Surface depth",
+        None,
+        theme,
+        Color::Blue,
+    );
+
+    let selected = find_ascii_text(&buffer, "Selected action").expect("selected item");
+    let enabled = find_ascii_text(&buffer, "Enabled action").expect("enabled item");
+    let disabled = find_ascii_text(&buffer, "Disabled action").expect("disabled item");
+
+    assert_eq!(buffer[selected].bg, Color::Rgb(43, 43, 43));
+    assert_eq!(buffer[enabled].bg, Color::Rgb(35, 35, 35));
+    assert_eq!(buffer[disabled].bg, Color::Rgb(38, 38, 38));
+    assert_eq!(buffer[disabled].fg, Color::DarkGray);
+}
+
+#[test]
+#[allow(clippy::disallowed_methods)]
+fn enabled_items_stay_darker_than_disabled_items_on_light_backgrounds() {
+    let theme = Theme::for_terminal_background(Some((240, 240, 240)));
+    let mut state = MenuState::try_new([
+        basic_item("selected", "Selected action"),
+        basic_item("enabled", "Enabled action"),
+        basic_item("disabled", "Disabled action").disabled(true),
+    ])
+    .expect("valid light surface menu");
+    let buffer = rendered_buffer(
+        &mut state,
+        80,
+        24,
+        "Surface depth",
+        None,
+        theme,
+        Color::Blue,
+    );
+
+    let selected = find_ascii_text(&buffer, "Selected action").expect("selected item");
+    let enabled = find_ascii_text(&buffer, "Enabled action").expect("enabled item");
+    let disabled = find_ascii_text(&buffer, "Disabled action").expect("disabled item");
+
+    assert_eq!(buffer[selected].bg, Color::Rgb(216, 216, 216));
+    assert_eq!(buffer[enabled].bg, Color::Rgb(217, 217, 217));
+    assert_eq!(buffer[disabled].bg, Color::Rgb(220, 220, 220));
+    assert_eq!(buffer[disabled].fg, Color::DarkGray);
+}
+
+#[test]
+#[allow(clippy::disallowed_methods)]
 fn selection_fills_every_item_row_and_uses_symmetric_accent_rails() {
     let theme = Theme::for_terminal_background(Some((20, 20, 20)));
     let mut state = consequence_state();

--- a/nori-rs/tui-components/src/picker/mod.rs
+++ b/nori-rs/tui-components/src/picker/mod.rs
@@ -9,6 +9,8 @@ use nucleo_matcher::pattern::Normalization;
 use nucleo_matcher::pattern::Pattern;
 use ratatui::text::Line;
 
+use crate::ProviderKind;
+
 mod render;
 
 pub use render::Picker;
@@ -69,6 +71,7 @@ impl PickerColumn {
 pub struct PickerItem<K> {
     pub key: K,
     pub cells: BTreeMap<String, String>,
+    pub cell_tones: BTreeMap<String, ProviderKind>,
     pub search_text: String,
     pub category: Option<String>,
     pub detail: Vec<Line<'static>>,
@@ -87,6 +90,7 @@ impl<K> PickerItem<K> {
         Self {
             key,
             cells: BTreeMap::from([(primary_column.into(), label.clone())]),
+            cell_tones: BTreeMap::new(),
             search_text: label,
             category: None,
             detail: Vec::new(),
@@ -102,6 +106,12 @@ impl<K> PickerItem<K> {
 
     pub fn cell(mut self, column: impl Into<String>, value: impl Into<String>) -> Self {
         self.cells.insert(column.into(), value.into());
+        self
+    }
+
+    /// Apply an agent/provider tone to one rendered cell.
+    pub fn cell_tone(mut self, column: impl Into<String>, provider: ProviderKind) -> Self {
+        self.cell_tones.insert(column.into(), provider);
         self
     }
 
@@ -276,6 +286,7 @@ pub struct PickerState<K> {
     pub search_active: bool,
     pub query: String,
     pub categories: Vec<String>,
+    pub category_tones: BTreeMap<String, ProviderKind>,
     pub active_category: Option<String>,
     pub selected_index: Option<usize>,
     pub selected_keys: Vec<K>,
@@ -300,6 +311,7 @@ impl<K: Clone + Eq> PickerState<K> {
             search_active: false,
             query: String::new(),
             categories: Vec::new(),
+            category_tones: BTreeMap::new(),
             active_category: None,
             selected_index: None,
             selected_keys: Vec::new(),
@@ -332,6 +344,12 @@ impl<K: Clone + Eq> PickerState<K> {
 
     pub fn categories(mut self, categories: impl IntoIterator<Item = impl Into<String>>) -> Self {
         self.categories = categories.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Apply an agent/provider tone to one category tab.
+    pub fn category_tone(mut self, category: impl Into<String>, provider: ProviderKind) -> Self {
+        self.category_tones.insert(category.into(), provider);
         self
     }
 

--- a/nori-rs/tui-components/src/picker/render.rs
+++ b/nori-rs/tui-components/src/picker/render.rs
@@ -4,6 +4,8 @@ use ratatui::layout::Direction;
 use ratatui::layout::Layout;
 use ratatui::layout::Margin;
 use ratatui::layout::Rect;
+use ratatui::style::Modifier;
+use ratatui::style::Style;
 use ratatui::text::Line;
 use ratatui::text::Span;
 use ratatui::widgets::Block;
@@ -27,6 +29,7 @@ use crate::KeyHints;
 use crate::MessageLevel;
 use crate::SemanticMessage;
 use crate::Theme;
+use crate::detail::provider_tone_style;
 
 /// Stateless renderer for a caller-owned [`PickerState`].
 pub struct Picker<'a, K> {
@@ -141,23 +144,36 @@ impl<K: Clone + Eq> Picker<'_, K> {
         if area.height == 0 {
             return;
         }
-        let options = std::iter::once(("All", self.state.active_category.is_none())).chain(
+        let options = std::iter::once(("All", None, self.state.active_category.is_none())).chain(
             self.state.categories.iter().map(|category| {
                 (
                     category.as_str(),
+                    Some(category.as_str()),
                     self.state.active_category.as_ref() == Some(category),
                 )
             }),
         );
         let spans = options
             .enumerate()
-            .flat_map(|(index, (label, active))| {
+            .flat_map(|(index, (label, category, active))| {
                 let gap = (index > 0).then(|| Span::raw("  "));
-                let style = if active {
-                    self.theme.accent
-                } else {
-                    self.theme.muted
-                };
+                let style = category
+                    .and_then(|category| self.state.category_tones.get(category))
+                    .map(|provider| provider_tone_style(*provider, self.theme))
+                    .map(|style| {
+                        if active {
+                            style.add_modifier(Modifier::BOLD)
+                        } else {
+                            style
+                        }
+                    })
+                    .unwrap_or_else(|| {
+                        if active {
+                            self.theme.accent
+                        } else {
+                            self.theme.muted
+                        }
+                    });
                 gap.into_iter()
                     .chain([Span::styled(label.to_string(), style)])
             })
@@ -245,7 +261,9 @@ impl<K: Clone + Eq> Picker<'_, K> {
                 buf,
                 &columns,
                 &widths,
-                columns.iter().map(|column| column.header.as_str()),
+                columns
+                    .iter()
+                    .map(|column| (column.header.as_str(), self.theme.table_header)),
                 self.theme.table_header,
                 " ",
             );
@@ -331,7 +349,16 @@ impl<K: Clone + Eq> Picker<'_, K> {
                 buf,
                 &columns,
                 &widths,
-                values.iter().map(String::as_str),
+                columns.iter().zip(&values).map(|(column, value)| {
+                    let cell_style = if selected || item.disabled {
+                        style
+                    } else {
+                        item.cell_tones.get(&column.key).map_or(style, |provider| {
+                            surface.patch(provider_tone_style(*provider, self.theme))
+                        })
+                    };
+                    (value.as_str(), cell_style)
+                }),
                 style,
                 marker,
             );
@@ -363,16 +390,16 @@ impl<K: Clone + Eq> Picker<'_, K> {
         buf: &mut Buffer,
         columns: &[&PickerColumn],
         widths: &[u16],
-        values: impl IntoIterator<Item = &'a str>,
-        style: ratatui::style::Style,
+        values: impl IntoIterator<Item = (&'a str, Style)>,
+        style: Style,
         marker: &str,
     ) {
         let mut x = area.x;
         buf.set_string(x, area.y, marker, style);
         x = x.saturating_add(2);
-        for ((column, width), value) in columns.iter().zip(widths).zip(values) {
+        for ((column, width), (value, value_style)) in columns.iter().zip(widths).zip(values) {
             let value = truncate(value, *width as usize);
-            buf.set_string(x, area.y, value, style);
+            buf.set_string(x, area.y, value, value_style);
             x = x.saturating_add(*width);
             if column.key
                 != columns

--- a/nori-rs/tui-components/src/picker/tests.rs
+++ b/nori-rs/tui-components/src/picker/tests.rs
@@ -1,10 +1,13 @@
 use super::*;
+use crate::ProviderKind;
 use crate::Theme;
 use insta::assert_snapshot;
 use pretty_assertions::assert_eq;
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
 use ratatui::style::Color;
+use ratatui::style::Modifier;
 
 fn session_picker() -> PickerState<String> {
     let columns = [
@@ -153,6 +156,96 @@ fn picker_applies_density_surfaces_search_input_and_selection() {
 }
 
 #[test]
+fn picker_maps_agent_tones_to_category_tabs_and_type_cells() {
+    let columns = [
+        PickerColumn::fixed("title", "Agent", 16),
+        PickerColumn::fixed("type", "Type", 16),
+    ];
+    let items = [
+        PickerItem::new("selected", "title", "Selected row").cell("type", "Neutral"),
+        PickerItem::new("claude", "title", "Agent one")
+            .cell("type", "Claude")
+            .cell_tone("type", ProviderKind::Claude),
+        PickerItem::new("codex", "title", "Agent two")
+            .cell("type", "Codex")
+            .cell_tone("type", ProviderKind::Codex),
+        PickerItem::new("gemini", "title", "Agent three")
+            .cell("type", "Gemini")
+            .cell_tone("type", ProviderKind::Gemini),
+        PickerItem::new("antigravity", "title", "Agent four")
+            .cell("type", "Antigravity")
+            .cell_tone("type", ProviderKind::Antigravity),
+        PickerItem::new("nori", "title", "Agent five")
+            .cell("type", "Nori")
+            .cell_tone("type", ProviderKind::Nori),
+    ];
+    let state = PickerState::new("Agent picker", columns, items)
+        .categories(["Claude", "Codex", "Gemini", "Antigravity", "Nori"])
+        .category_tone("Claude", ProviderKind::Claude)
+        .category_tone("Codex", ProviderKind::Codex)
+        .category_tone("Gemini", ProviderKind::Gemini)
+        .category_tone("Antigravity", ProviderKind::Antigravity)
+        .category_tone("Nori", ProviderKind::Nori);
+
+    let buffer = rendered_picker_buffer(&state, 110, 22);
+    let expected = [
+        ("Claude", Color::Yellow),
+        ("Codex", Color::White),
+        ("Gemini", Color::Blue),
+        ("Antigravity", Color::Blue),
+        ("Nori", Color::Green),
+    ];
+    for (label, color) in expected {
+        let category = find_ascii_text_at_or_below(&buffer, label, 2).expect("category tab");
+        assert_eq!(buffer[category].fg, color, "{label} category tone");
+        assert!(!buffer[category].modifier.contains(Modifier::BOLD));
+
+        let cell = find_ascii_text_at_or_below(&buffer, label, 4).expect("type cell");
+        assert_eq!(buffer[cell].fg, color, "{label} type tone");
+    }
+    let mut active_state = state;
+    assert_eq!(
+        active_state.handle(PickerAction::NextCategory),
+        PickerOutcome::CategoryChanged(Some("Claude".to_string()))
+    );
+    let active_buffer = rendered_picker_buffer(&active_state, 110, 22);
+    let active_claude =
+        find_ascii_text_at_or_below(&active_buffer, "Claude", 2).expect("active Claude tab");
+    assert_eq!(active_buffer[active_claude].fg, Color::Yellow);
+    assert!(
+        active_buffer[active_claude]
+            .modifier
+            .contains(Modifier::BOLD)
+    );
+}
+
+#[test]
+fn selection_and_disabled_styles_override_provider_cell_tones() {
+    let columns = [
+        PickerColumn::fixed("title", "Agent", 16),
+        PickerColumn::fixed("type", "Type", 16),
+    ];
+    let items = [
+        PickerItem::new("selected", "title", "Selected row")
+            .cell("type", "Selected tone")
+            .cell_tone("type", ProviderKind::Claude),
+        PickerItem::new("disabled", "title", "Disabled row")
+            .cell("type", "Disabled tone")
+            .cell_tone("type", ProviderKind::Nori)
+            .disabled(true),
+    ];
+    let state = PickerState::new("Agent picker", columns, items);
+
+    let buffer = rendered_picker_buffer(&state, 64, 12);
+    let selected_tone =
+        find_ascii_text_at_or_below(&buffer, "Selected tone", 2).expect("selected type cell");
+    assert_eq!(buffer[selected_tone].fg, Color::Cyan);
+    let disabled_tone =
+        find_ascii_text_at_or_below(&buffer, "Disabled tone", 2).expect("disabled type cell");
+    assert_eq!(buffer[disabled_tone].fg, Color::DarkGray);
+}
+
+#[test]
 fn picker_fuzzy_filter_snapshot() {
     let mut state = session_picker();
     state.handle(PickerAction::ActivateSearch);
@@ -228,4 +321,35 @@ fn caller_can_supply_a_custom_matcher() {
             .collect::<Vec<_>>(),
         vec!["tables"]
     );
+}
+
+fn rendered_picker_buffer<K: Clone + Eq>(
+    state: &PickerState<K>,
+    width: u16,
+    height: u16,
+) -> Buffer {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal
+        .draw(|frame| frame.render_widget(Picker::new(state), frame.area()))
+        .expect("draw picker");
+    terminal.backend().buffer().clone()
+}
+
+fn find_ascii_text_at_or_below(buffer: &Buffer, text: &str, minimum_y: u16) -> Option<(u16, u16)> {
+    assert!(text.is_ascii());
+    let characters = text.chars().collect::<Vec<_>>();
+    for y in minimum_y.max(buffer.area.y)..buffer.area.bottom() {
+        for x in buffer.area.x..buffer.area.right() {
+            if x.saturating_add(characters.len() as u16) > buffer.area.right() {
+                break;
+            }
+            if characters.iter().enumerate().all(|(offset, character)| {
+                buffer[(x + offset as u16, y)].symbol() == character.to_string()
+            }) {
+                return Some((x, y));
+            }
+        }
+    }
+    None
 }

--- a/nori-rs/tui-components/src/theme/mod.rs
+++ b/nori-rs/tui-components/src/theme/mod.rs
@@ -13,6 +13,7 @@ pub struct Theme {
     pub accent: Style,
     pub backdrop: Style,
     pub menu_surface: Style,
+    pub menu_item_surface: Style,
     pub surface: Style,
     pub input: Style,
     pub row: Style,
@@ -31,6 +32,11 @@ pub struct Theme {
     pub link: Style,
     pub table_header: Style,
     pub table_rule: Style,
+    pub provider_claude: Style,
+    pub provider_codex: Style,
+    pub provider_gemini: Style,
+    pub provider_antigravity: Style,
+    pub provider_nori: Style,
 }
 
 impl Default for Theme {
@@ -41,6 +47,7 @@ impl Default for Theme {
             accent: Style::new().fg(Color::Cyan),
             backdrop: Style::new(),
             menu_surface: Style::new(),
+            menu_item_surface: Style::new(),
             surface: Style::new(),
             input: Style::new(),
             row: Style::new(),
@@ -61,6 +68,11 @@ impl Default for Theme {
                 .add_modifier(Modifier::UNDERLINED),
             table_header: Style::new().add_modifier(Modifier::BOLD),
             table_rule: Style::new().fg(Color::DarkGray),
+            provider_claude: Style::new().fg(Color::Yellow),
+            provider_codex: Style::new().fg(Color::White),
+            provider_gemini: Style::new().fg(Color::Blue),
+            provider_antigravity: Style::new().fg(Color::Blue),
+            provider_nori: Style::new().fg(Color::Green),
         }
     }
 }
@@ -79,13 +91,27 @@ impl Theme {
         };
 
         theme.backdrop = theme.backdrop.bg(relative_surface(background, 4));
-        theme.menu_surface = theme.menu_surface.bg(relative_surface(background, 8));
+        let menu_surface = relative_surface(background, 8);
+        theme.menu_surface = theme.menu_surface.bg(menu_surface);
+        theme.menu_item_surface = theme.menu_item_surface.bg(darken_surface(menu_surface, 3));
         theme.row = theme.row.bg(relative_surface(background, 4));
         theme.row_alt = theme.row_alt.bg(relative_surface(background, 7));
         theme.input = theme.input.bg(relative_surface(background, 8));
         theme.detail_surface = theme.detail_surface.bg(relative_surface(background, 8));
         theme.selected = theme.selected.bg(relative_surface(background, 10));
         theme
+    }
+}
+
+#[allow(clippy::disallowed_methods)]
+fn darken_surface(surface: Color, amount: u8) -> Color {
+    match surface {
+        Color::Rgb(red, green, blue) => Color::Rgb(
+            red.saturating_sub(amount),
+            green.saturating_sub(amount),
+            blue.saturating_sub(amount),
+        ),
+        other => other,
     }
 }
 

--- a/nori-rs/tui-components/src/theme/tests.rs
+++ b/nori-rs/tui-components/src/theme/tests.rs
@@ -10,6 +10,7 @@ fn default_theme_falls_back_to_unshaded_semantic_surfaces() {
     assert_eq!(theme.accent.fg, Some(Color::Cyan));
     assert_eq!(theme.backdrop.bg, None);
     assert_eq!(theme.menu_surface.bg, None);
+    assert_eq!(theme.menu_item_surface.bg, None);
     assert_eq!(theme.surface.bg, None);
     assert_eq!(theme.input.bg, None);
     assert_eq!(theme.row.bg, None);
@@ -28,6 +29,7 @@ fn terminal_theme_derives_close_surfaces_from_dark_background() {
     assert_eq!(theme.row.bg, Some(Color::Rgb(29, 29, 29)));
     assert_eq!(theme.backdrop.bg, Some(Color::Rgb(29, 29, 29)));
     assert_eq!(theme.menu_surface.bg, Some(Color::Rgb(38, 38, 38)));
+    assert_eq!(theme.menu_item_surface.bg, Some(Color::Rgb(35, 35, 35)));
     assert_eq!(theme.row_alt.bg, Some(Color::Rgb(36, 36, 36)));
     assert_eq!(theme.input.bg, Some(Color::Rgb(38, 38, 38)));
     assert_eq!(theme.detail_surface.bg, Some(Color::Rgb(38, 38, 38)));
@@ -42,6 +44,7 @@ fn terminal_theme_derives_close_surfaces_from_light_background() {
     assert_eq!(theme.row.bg, Some(Color::Rgb(230, 230, 230)));
     assert_eq!(theme.backdrop.bg, Some(Color::Rgb(230, 230, 230)));
     assert_eq!(theme.menu_surface.bg, Some(Color::Rgb(220, 220, 220)));
+    assert_eq!(theme.menu_item_surface.bg, Some(Color::Rgb(217, 217, 217)));
     assert_eq!(theme.row_alt.bg, Some(Color::Rgb(223, 223, 223)));
     assert_eq!(theme.input.bg, Some(Color::Rgb(220, 220, 220)));
     assert_eq!(theme.selected.bg, Some(Color::Rgb(216, 216, 216)));


### PR DESCRIPTION
## Summary

- color picker category tabs and Type cells by agent identity
- Claude uses warm yellow/orange, Codex white, Gemini/Antigravity blue, and Nori green
- render enabled overlay actions on a slightly darker surface than disabled actions
- preserve selected and disabled style precedence
- keep surface depth correct on dark and light terminal backgrounds

## Stack

- base: fix/keyboard-driven-picker-search
- this PR contains the color customization only

## Validation

- component tests, dark/light surface tests, snapshots, strict Clippy, and live storybook checks passed before the stack split
- CI will be handled independently for this PR