### PR TITLE
fix(acp): complete remote observer turns

### DIFF
--- a/docs/plans/remote-local-turn-lifecycle-implementation.md
+++ b/docs/plans/remote-local-turn-lifecycle-implementation.md
@@ -1,0 +1,126 @@
+# Remote Local-Turn Lifecycle Bugfix Implementation Plan
+
+**Goal:** Make a remote Nori frontend observe a locally initiated turn once, render all agent output, return to idle, and fail remote prompt attempts while that local turn owns the session.
+
+**Architecture:** The harness emits ACP-visible `working`/`idle` lifecycle hints through the existing shared session fan-out. Prompt admission stays serialized in the harness reducer. The remote host only enforces controller ownership, rewrites the session ID, and forwards ACP events.
+
+**Tech Stack:** Rust, Tokio, ACP v1 `session/update`, existing Nori `_meta`, mock ACP agent, Cargo tests
+
+---
+
+## Testing Plan
+
+Add failing reducer tests in `nori-rs/harness/src/backend/session_reducer/tests.rs`:
+
+- A reject-if-busy prompt is not queued and does not disturb the active local turn.
+- Ordinary local prompts retain the existing queue behavior.
+- A Nori `working`/`idle` envelope bounds observer activity without creating a local request; bounded chunks do not produce the orphan-update warning, while truly unowned chunks still do.
+
+Replace the queued-remote-prompt expectation and add lifecycle coverage in `nori-rs/harness/tests/remote_host.rs`:
+
+- A local prompt produces outward events in this order: `working`, canonical user chunks, agent chunks, `idle`.
+- The observer receives no prompt response for a request it did not initiate.
+- A remote prompt attempted during that turn fails immediately and never enters the local queue.
+- Remote cancel cannot cancel a local-owned turn.
+- Remote-owned prompts still stream updates and receive their correlated response.
+- Every forwarded notification has only its session ID rewritten.
+
+Strengthen `nori-rs/tui/src/chatwidget/tests/part10.rs` so non-newline agent chunks become visible on `idle`, the proactive Working state clears, and the submitter still renders its prompt once.
+
+<!-- prettier-ignore -->
+NOTE: I will write *all* tests before I add any implementation behavior.
+
+## Observed Failure
+
+The agent response was present in the trace. The remote TUI buffered its non-newline chunks, then stayed in proactive Working because no observer-visible completion arrived. The remote host also queued remote prompts behind local activity and allowed remote cancel to target whichever turn was active.
+
+## Implementation Tasks
+
+### 1. Add serialized prompt admission
+
+**Files:**
+
+- `nori-rs/harness/src/runtime.rs`
+- `nori-rs/harness/src/backend/submit_and_ops.rs`
+- `nori-rs/harness/src/backend/session_reducer.rs`
+- `nori-rs/harness/src/backend/session_runtime_driver.rs`
+
+Add an explicit prompt admission policy: normal callers queue; the remote controller uses reject-if-busy. Make the reducer decide admission so simultaneous submissions cannot pass a stale phase check. A rejection resolves the pending prompt request immediately with a typed busy error and leaves phase, active request, and queue unchanged.
+
+Keep `HarnessHandle::prompt()` and local TUI behavior unchanged. Add a crate-private remote submission method that selects reject-if-busy.
+
+### 2. Publish observer lifecycle through the shared fan-out
+
+**Files:**
+
+- `nori-rs/harness/src/backend/session_runtime_driver.rs`
+- `nori-rs/harness/src/normalized/session_runtime.rs`
+- `nori-rs/harness/src/backend/session_reducer.rs`
+
+Publish `SessionInfoUpdate` notifications with `_meta.nori.status`:
+
+- `working` after the downstream prompt receives its wire request ID and before canonical user chunks;
+- `idle` after success, cancellation, or failure, after all agent chunks.
+
+Send these as ordinary public ACP notifications. Do not synthesize assistant text: the original agent chunks are already present, and `idle` flushes the observer's stream buffer.
+
+Track the Nori status as observer activity separate from local `SessionPhase`. It may suppress the orphan warning only between `working` and `idle`; it must not create an owned request, affect queueing, or suppress statusless unowned/load/replay content.
+
+### 3. Enforce remote-controller ownership
+
+**File:** `nori-rs/harness/src/remote_agent.rs`
+
+Use reject-if-busy for remote `session/prompt` and map the typed busy result to a stable ACP server error. Forward `session/cancel` only when the active harness request is in `remote_turns`; otherwise leave the local turn untouched.
+
+Keep local-turn prompt outcomes private because no remote JSON-RPC request exists to answer. Forward their lifecycle and content notifications normally. Do not add response synthesis or content buffering to the remote host.
+
+### 4. Document the now-defined coexistence policy
+
+**File:** `docs/specs/remote-acp-transport.md`
+
+Replace the deferred simultaneous-input language with:
+
+- the first admitted prompt owns the active turn;
+- local prompts keep normal queue semantics;
+- remote prompts fail while another turn is active;
+- remote cancel affects only a remote-owned turn;
+- observers receive `working`, content, and `idle`, but no foreign prompt response.
+
+State that `_meta.nori.status` is an optional Nori lifecycle hint carried by standard ACP `session/update`; non-Nori clients may ignore it.
+
+## Compatibility and Edge Cases
+
+- No Handroll, WebSocket, HTTPS/SSE, or downstream-agent changes.
+- ACP clients that ignore `_meta` continue receiving the same content stream.
+- Duplicate lifecycle hints from a nested Nori agent are idempotent and must not duplicate content.
+- `idle` must be emitted for cancellation and transport failure so observers cannot remain Working.
+- Reconnect/load replay remains content-complete; lifecycle hints do not claim request ownership.
+- A rejected remote prompt must not later start after the local turn ends.
+
+## Verification
+
+From `nori-rs/`:
+
+```bash
+cargo build -p mock-acp-agent
+MOCK_ACP_AGENT_BIN="$PWD/target/debug/mock_acp_agent" cargo test -p nori-harness --test remote_host
+cargo test -p nori-harness backend::session_reducer::tests
+cargo test -p nori-tui proactive_turn
+cargo build --bin nori
+```
+
+Then repeat the two-terminal LAN test: start a local turn on the agent TUI, confirm the remote TUI renders its prompt and full response, returns to idle, and receives an immediate busy error if it submits during that turn.
+
+**Testing Details**
+
+Tests assert public event order and user-visible TUI state, not private field choreography. The current baseline passes the focused remote-host and proactive-turn suites when `MOCK_ACP_AGENT_BIN` points to the built underscore-named binary.
+
+**Implementation Details**
+
+The key invariant is one shared ACP notification sequence for all frontends. The remote host remains a thin ownership/correlation boundary; admission and lifecycle truth remain in the serialized harness.
+
+**Question**
+
+Use the existing non-retryable Nori code `-32015` for “session already active,” or reserve a new server-defined code specifically for “turn busy”? This plan assumes `-32015` unless review finds client behavior that makes it unsafe.
+
+---

--- a/docs/specs/remote-acp-transport.md
+++ b/docs/specs/remote-acp-transport.md
@@ -162,11 +162,18 @@ frontend: once it becomes active, both render the harness's canonical
 
 Opening the microVM terminal therefore reveals the already-running Nori TUI;
 it does not reconstruct a second frontend or replace the WebSocket
-controller. While a remote controller is connected, the TUI acts as an
-observer. An observer sees a turn's `session/update` notifications but not
-its stop reason, which travels in the prompt response to the initiator.
-Harness commands serialize mutations. Detailed policy for simultaneous local
-and remote input is deferred.
+controller. The first accepted prompt owns the turn. Local prompts retain the
+existing harness queue; a remote prompt received while any turn is active is
+rejected as busy and is never queued. A remote cancel affects only a
+remote-owned turn, never activity started by the local TUI.
+
+Observers receive the complete shared update stream, including final assistant
+content. The harness brackets each active turn with `session/update`
+`SessionInfoUpdate` notifications carrying `_meta.nori.status` values
+`working` and `idle`. This optional Nori extension lets an observing frontend
+enter and leave its working state without receiving the initiator's prompt
+response or stop reason. The remote host only rewrites the session id and
+forwards these notifications.
 
 An agent switch uses the TUI's transactional session boundary. The remote host
 continues following the current `HarnessHandle` while a candidate initializes,

--- a/nori-rs/acp-host/docs.md
+++ b/nori-rs/acp-host/docs.md
@@ -92,10 +92,16 @@ The dependency direction stays `nori-harness -> nori-acp-host`.
   an already-running session.
 - A remote `PromptRequest` passes its top-level `_meta` through the
   `HostedAgent` interface with its content and session id. The harness
-  implementation retains that metadata while the prompt waits in its queue and
-  forwards it to the downstream ACP agent. This preserves the shared
+  implementation retains that metadata through prompt admission and forwards
+  it to the downstream ACP agent. This preserves the shared
   `nori_protocol::PROMPT_ECHO_ID_META_KEY` correlation marker across composed
   Nori hosts without making the transport interpret it.
+- Prompt registration and a following `session/cancel` preserve WebSocket wire
+  order through the same correlation lock. The prompt handler acquires the lock
+  before spawning its hosted call and holds it until the harness request id is
+  registered with the remote responder; cancel waits for that boundary before
+  calling `HostedAgent::cancel`. This prevents an immediately following cancel
+  from overtaking the prompt state it is meant to target.
 - Responses are correlated at the boundary: `HostedAgent::prompt` returns the
   harness-issued request id, and the turn's final response arrives in stream
   order through the hosted event subscription, so a turn's `session/update`
@@ -163,6 +169,11 @@ The dependency direction stays `nori-harness -> nori-acp-host`.
   session. Per the RFD's v1 reliability model there are no sequence numbers and
   no replay of missed messages; `session/load` from the transcript is the
   recovery path after reconnect, so the server must advertise `loadSession`.
+- `session/cancel` has no response envelope, so the connection must not treat
+  successful notification dispatch as proof that prompt ownership was already
+  registered. Its ordering lock covers only the correlation boundary; the
+  hosted harness remains responsible for deciding whether the controller owns
+  the target turn.
 - `nori exec --acp` remains a separate, bounded stdio facade (see
   `@/nori-rs/exec/docs.md`); the remote module instead exposes the long-lived
   interactive harness session.

--- a/nori-rs/acp-host/src/remote/connection.rs
+++ b/nori-rs/acp-host/src/remote/connection.rs
@@ -217,13 +217,11 @@ async fn serve_gated_connection<H: HostedAgent>(
                 async move |request: acp::PromptRequest,
                             responder: Responder<acp::PromptResponse>,
                             cx: ConnectionTo<Client>| {
-                    // Spawned: a prompt queued behind an active turn resolves
-                    // only when it is issued, and other incoming messages
-                    // (notably session/cancel) must keep dispatching.
+                    // Acquire the correlation lock before spawning so a later
+                    // session/cancel cannot overtake prompt registration.
                     let hosted = hosted.clone();
-                    let pending_prompts = pending_prompts.clone();
+                    let mut pending = pending_prompts.clone().lock_owned().await;
                     cx.spawn(async move {
-                        let mut pending = pending_prompts.lock().await;
                         match hosted
                             .prompt(&request.session_id, request.prompt, request.meta)
                             .await
@@ -257,7 +255,12 @@ async fn serve_gated_connection<H: HostedAgent>(
         .on_receive_notification(
             {
                 let hosted = hosted.clone();
+                let pending_prompts = pending_prompts.clone();
                 async move |notification: acp::CancelNotification, _cx: ConnectionTo<Client>| {
+                    // A prompt handler holds this lock until the hosted
+                    // request id is registered. Preserve wire order so cancel
+                    // cannot be acknowledged in the ownership gap.
+                    let _pending = pending_prompts.lock().await;
                     hosted.cancel(&notification.session_id).await?;
                     Ok(())
                 }

--- a/nori-rs/acp-host/tests/remote_ws.rs
+++ b/nori-rs/acp-host/tests/remote_ws.rs
@@ -25,6 +25,7 @@ use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
 use tokio::sync::Mutex;
+use tokio::sync::Notify;
 use tokio::sync::mpsc;
 use tokio_tungstenite::MaybeTlsStream;
 use tokio_tungstenite::WebSocketStream;
@@ -42,6 +43,7 @@ struct FakeState {
     sink: Option<mpsc::Sender<SessionEvent>>,
     prompts: Vec<(acp::SessionId, Vec<acp::ContentBlock>, Option<acp::Meta>)>,
     responds: Vec<(acp::RequestId, Result<acp::ClientResponse, acp::Error>)>,
+    cancels: Vec<acp::SessionId>,
     detaches: Vec<i64>,
     replay: Vec<acp::SessionNotification>,
 }
@@ -49,6 +51,7 @@ struct FakeState {
 #[derive(Default)]
 struct FakeHosted {
     list_sessions_delay: Duration,
+    prompt_release: Option<Arc<Notify>>,
     state: Mutex<FakeState>,
 }
 
@@ -127,6 +130,10 @@ impl HostedAgent for FakeHosted {
             state.prompts.push((session_id.clone(), prompt, meta));
             state.sink.clone()
         };
+        if let Some(prompt_release) = &self.prompt_release {
+            prompt_release.notified().await;
+            return Ok(request_id);
+        }
         if let Some(sink) = sink {
             for text in ["Hello ", "world"] {
                 let event = SessionEvent::Acp(AcpEvent::Notification(
@@ -146,7 +153,9 @@ impl HostedAgent for FakeHosted {
     }
 
     async fn cancel(&self, session_id: &acp::SessionId) -> Result<(), acp::Error> {
-        Self::check(session_id)
+        Self::check(session_id)?;
+        self.state.lock().await.cancels.push(session_id.clone());
+        Ok(())
     }
 
     async fn close_session(&self, session_id: &acp::SessionId) -> Result<(), acp::Error> {
@@ -205,6 +214,7 @@ async fn start_server_with_options(
 ) -> TestServer {
     let hosted = Arc::new(FakeHosted {
         list_sessions_delay,
+        prompt_release: None,
         state: Mutex::new(FakeState {
             has_active_session,
             ..FakeState::default()
@@ -217,6 +227,73 @@ async fn start_server_with_options(
     .await
     .expect("bind remote server");
     TestServer { server, hosted }
+}
+
+#[tokio::test]
+async fn cancel_waits_until_the_preceding_prompt_is_registered() {
+    let prompt_release = Arc::new(Notify::new());
+    let hosted = Arc::new(FakeHosted {
+        list_sessions_delay: Duration::ZERO,
+        prompt_release: Some(prompt_release.clone()),
+        state: Mutex::new(FakeState {
+            has_active_session: true,
+            ..FakeState::default()
+        }),
+    });
+    let server = RemoteAcpServer::bind(
+        "127.0.0.1:0".parse::<SocketAddr>().expect("addr"),
+        hosted.clone(),
+    )
+    .await
+    .expect("bind remote server");
+    let (mut client, _) = WsClient::connect(server.local_addr()).await;
+    client.initialize().await;
+
+    client
+        .send_json(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": SESSION_ID,
+                "prompt": [{ "type": "text", "text": "cancel immediately" }],
+            },
+        }))
+        .await;
+    tokio::time::timeout(RECV_TIMEOUT, async {
+        loop {
+            if !hosted.state.lock().await.prompts.is_empty() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("prompt should reach the hosted agent");
+    client
+        .send_json(json!({
+            "jsonrpc": "2.0",
+            "method": "session/cancel",
+            "params": { "sessionId": SESSION_ID },
+        }))
+        .await;
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        hosted.state.lock().await.cancels.is_empty(),
+        "cancel must wait until the prompt request id is registered"
+    );
+    prompt_release.notify_one();
+    tokio::time::timeout(RECV_TIMEOUT, async {
+        loop {
+            if hosted.state.lock().await.cancels == vec![FakeHosted::session_id()] {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("cancel should reach the hosted agent after prompt registration");
 }
 
 struct WsClient {

--- a/nori-rs/harness/docs.md
+++ b/nori-rs/harness/docs.md
@@ -144,6 +144,15 @@ active wire prompt. Load/replay chunks, unowned activity, and unmarked user
 messages continue through unchanged; content alone is never used to guess
 ownership.
 
+Every admitted prompt is also bracketed in the shared fan-out by
+`SessionInfoUpdate` notifications carrying `_meta.nori.status`. `working` is
+published after the downstream transport assigns the prompt request id and
+before canonical user chunks or agent output; `idle` follows all completion,
+cancellation, or failure output. These are observer lifecycle hints, not prompt
+responses: a frontend that did not submit the turn can render and flush the
+complete stream without claiming the initiating request or receiving its stop
+reason.
+
 The public event stream has two source-owned branches:
 
 ```rust
@@ -287,18 +296,37 @@ types so frontends reach the whole remote surface through
   `TranscriptLoader`, and projects it with
   `transcript_to_replay_session_events`, keeping only session notifications
   and restamping them with the outward id.
-- Live `session/update` notifications—including canonical user prompt chunks—
-  are forwarded from the shared harness fan-out without content translation;
-  only their outward session id is rewritten, so the correlation marker is
-  preserved end to end. The transport still has one controller, while the
-  fan-out remains the common source for the TUI and future bounded observers.
-- Turn ownership is tracked by harness request id: `prompt` submits without
-  holding the state lock (a queued prompt resolves only when issued), then
-  registers the returned id as remote-owned; an outcome that raced ahead of
-  the registration is claimed from a small unclaimed-outcome buffer instead.
-  Only remote-owned turns forward their final response, `RequestFailed`, and
-  delegated permission requests to the remote controller. A locally initiated
-  turn's permission requests stay with the TUI.
+- Live `session/update` notifications—including canonical user prompt chunks
+  and `working`/`idle` lifecycle hints—are forwarded from the shared harness
+  fan-out without content translation; only their outward session id is
+  rewritten, so correlation and observer lifecycle survive the boundary. The
+  transport still has one controller, while the fan-out remains the common
+  source for the TUI and future bounded observers.
+- Remote prompt admission is serialized with the session runtime and rejects
+  with ACP error `-32015` while a turn is active or a local prompt is already
+  queued. Local submissions keep the ordinary harness queue. The admission
+  barrier provides a fast rejection before prompt hooks and snapshots, while
+  the reducer repeats the same decision at the state transition boundary.
+- Turn ownership is tracked by harness request id after a remote prompt is
+  admitted. An outcome that races ahead of registration is claimed from a
+  small bounded buffer. Only remote-owned turns forward their final response,
+  `RequestFailed`, and delegated permission requests to the controller; local
+  turns expose their content and lifecycle notifications but keep responses
+  and permission decisions with the local frontend.
+- Prompt registration runs in a detached host task, so dropping the calling
+  WebSocket task during disconnect does not abandon the admission operation or
+  leave the host permanently busy. Each registration carries a monotonic
+  submission token; completion may clear pending prompt and cancel state only
+  while that token still matches. Session replacement invalidates the token,
+  while controller reconnection leaves the host-owned registration running to
+  completion.
+- Remote `session/cancel` targets a harness request id rather than whichever
+  turn happens to be active. If cancel arrives while an admitted remote prompt
+  is still awaiting request-id registration, the host remembers it and sends
+  the request-scoped cancel immediately after registration. The reducer applies
+  that cancel only when the same request still owns the active turn, so a late
+  cancel cannot affect a later local turn. With no pending or registered remote
+  prompt, remote cancel is a no-op.
 - When the remote controller detaches or is replaced, its unanswered delegated
   requests are answered with a cancelled permission outcome so they cannot
   wedge the agent.
@@ -346,23 +374,27 @@ is terminal for that one prompt.
 
 An active local prompt or load owns request-scoped updates until its response.
 Without one, the reducer accepts, preserves, and projects each update as
-unowned activity. The first non-metadata update in an unowned burst emits
-`Received update with no active local request`; later updates do not repeat the
-warning until a local prompt or load starts. The warning does not create a
-synthetic request or `Prompting` phase, invent attribution, or prevent
-projection. User, agent, thought, plan, and tool updates all follow that rule;
-unowned tool snapshots retain `owner_request_id = None`, and an unknown tool
-update is normalized from a default tool call rather than discarded. This
-logic lives in
+unowned activity. The first non-metadata update in an unbounded unowned burst
+emits `Received update with no active local request`; later updates do not
+repeat the warning until a local prompt or load starts. A Nori
+`SessionInfoUpdate` with status `working` begins bounded observer activity, and
+status `idle` ends it and resets warning eligibility. Content inside that
+envelope is still unowned but does not emit the warning. The warning and
+observer state never create a synthetic request or `Prompting` phase, invent
+attribution, drain the queue, or prevent projection. User, agent, thought,
+plan, and tool updates all follow that rule; unowned tool snapshots retain
+`owner_request_id = None`, and an unknown tool update is normalized from a
+default tool call rather than discarded. This logic lives in
 [`session_reducer.rs`](src/backend/session_reducer.rs) and
 [`session_runtime_driver.rs`](src/backend/session_runtime_driver.rs).
 
-The public stream forwards raw ACP session metadata unchanged. The harness does
-not interpret metadata as prompt completion or publish an agent-turn completion
-event, so presentation of unowned updates or an agent-owned turn cannot drain
-the queue, end cancellation, or change request state. Optional presentation
-hints are interpreted only by the TUI, as described in
-[`nori-tui`](../tui/docs.md).
+Raw ACP session metadata remains public. The harness recognizes only the
+optional `_meta.nori.status` values needed to bound observer activity when no
+local request is active, and also publishes those hints around turns it
+admits. Status metadata does not complete a prompt, return a stop reason, end
+cancellation, or change local request state; the ACP prompt response remains
+the sole completion authority for the initiator. Presentation behavior is
+described in [`nori-tui`](../tui/docs.md).
 
 Session end reasons are:
 
@@ -539,5 +571,11 @@ temp dir is removed.
   (last connect wins), and a consumer whose bounded queue overflows is dropped,
   which closes its connection. Remote-host behavior is exercised in
   `@/nori-rs/harness/tests/remote_host.rs` against the mock ACP agent.
+- Remote and local frontends share notifications but not request ownership.
+  Local prompts may queue; remote prompts reject while busy, remote cancel is
+  scoped to the registered harness request id, and only the remote submitter
+  receives a correlated prompt outcome. Prompt registration belongs to
+  `HarnessRemoteHost`, so controller replacement cannot strand admission state,
+  while hosted-session replacement invalidates the old registration token.
 
 Created and maintained by Nori.

--- a/nori-rs/harness/src/backend/mod.rs
+++ b/nori-rs/harness/src/backend/mod.rs
@@ -33,6 +33,16 @@ use crate::undo::GhostSnapshotStack;
 
 mod remote_control_ext;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PromptAdmission {
+    Queue,
+    RejectIfBusy,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("session already has an active turn")]
+pub(crate) struct PromptBusy;
+
 // =============================================================================
 // Error Categorization
 // =============================================================================

--- a/nori-rs/harness/src/backend/session.rs
+++ b/nori-rs/harness/src/backend/session.rs
@@ -679,6 +679,9 @@ impl AcpBackend {
                     session_runtime_driver::SessionRuntimeInput::Reducer(event) => {
                         runtime_backend.apply_session_event(event).await;
                     }
+                    session_runtime_driver::SessionRuntimeInput::Barrier { response_tx } => {
+                        let _ = response_tx.send(());
+                    }
                     session_runtime_driver::SessionRuntimeInput::PermissionRequest {
                         pending_request,
                         current_policy,

--- a/nori-rs/harness/src/backend/session_reducer.rs
+++ b/nori-rs/harness/src/backend/session_reducer.rs
@@ -40,8 +40,12 @@ pub enum InboundEvent {
     PermissionRequest { request_id: String, call_id: String },
     /// The user submitted a prompt (may be queued if a request is in flight).
     PromptSubmit(QueuedPrompt),
+    /// A remote controller submitted a prompt that must not queue.
+    PromptSubmitIfIdle(QueuedPrompt),
     /// The user requested cancellation of the active prompt.
     CancelSubmit,
+    /// A controller requested cancellation only if it owns this prompt.
+    CancelSubmitFor { request_id: acp::RequestId },
     /// A `session/load` was initiated.
     LoadSubmit { request_id: acp::RequestId },
 }
@@ -54,8 +58,8 @@ pub(super) fn inbound_event_kind(event: &InboundEvent) -> &'static str {
         InboundEvent::LoadResponse => "load_response",
         InboundEvent::PromptStarted { .. } => "prompt_started",
         InboundEvent::PermissionRequest { .. } => "permission_request",
-        InboundEvent::PromptSubmit(_) => "prompt_submit",
-        InboundEvent::CancelSubmit => "cancel_submit",
+        InboundEvent::PromptSubmit(_) | InboundEvent::PromptSubmitIfIdle(_) => "prompt_submit",
+        InboundEvent::CancelSubmit | InboundEvent::CancelSubmitFor { .. } => "cancel_submit",
         InboundEvent::LoadSubmit { .. } => "load_submit",
     }
 }
@@ -85,6 +89,8 @@ pub enum SideEffect {
     SendCancel,
     /// Resolve a pending permission request as cancelled.
     ResolvePermissionCancelled { request_id: String },
+    /// Reject a prompt instead of adding it to the queue.
+    RejectPromptBusy { event_id: String },
 }
 
 /// The output of a single reduction step.
@@ -109,11 +115,23 @@ pub fn reduce(
         InboundEvent::PromptSubmit(prompt) => {
             reduce_prompt_submit(runtime, prompt, &mut out);
         }
+        InboundEvent::PromptSubmitIfIdle(prompt) => {
+            if runtime.phase == SessionPhase::Idle && runtime.queue.is_empty() {
+                start_prompt(runtime, prompt, &mut out);
+            } else {
+                out.side_effects.push(SideEffect::RejectPromptBusy {
+                    event_id: prompt.event_id,
+                });
+            }
+        }
         InboundEvent::PromptStarted { request_id } => {
             reduce_prompt_started(runtime, request_id, &mut out);
         }
         InboundEvent::CancelSubmit => {
-            reduce_cancel_submit(runtime, &mut out);
+            reduce_cancel_submit(runtime, None, &mut out);
+        }
+        InboundEvent::CancelSubmitFor { request_id } => {
+            reduce_cancel_submit(runtime, Some(&request_id), &mut out);
         }
         InboundEvent::LoadSubmit { request_id } => {
             reduce_load_submit(runtime, request_id, &mut out);
@@ -234,13 +252,20 @@ fn reduce_prompt_started(
 // Cancel submit
 // ---------------------------------------------------------------------------
 
-fn reduce_cancel_submit(runtime: &mut SessionRuntime, out: &mut ReduceOutput) {
+fn reduce_cancel_submit(
+    runtime: &mut SessionRuntime,
+    expected_request_id: Option<&acp::RequestId>,
+    out: &mut ReduceOutput,
+) {
     if let SessionPhase::Prompt {
         cancelling,
         request_id,
         ..
     } = &mut runtime.phase
     {
+        if expected_request_id.is_some_and(|expected| expected != request_id) {
+            return;
+        }
         if *cancelling {
             return; // double cancel is a no-op
         }
@@ -454,7 +479,10 @@ fn reduce_notification(
     }
 
     // Warn once for content that no local prompt or load owns.
-    if runtime.active.is_none() && !runtime.orphan_update_warning_emitted {
+    if runtime.active.is_none()
+        && !runtime.observer_turn_active
+        && !runtime.orphan_update_warning_emitted
+    {
         out.events.push(ClientEvent::Warning(WarningInfo {
             message: "Received update with no active local request".to_string(),
         }));
@@ -544,6 +572,23 @@ fn reduce_metadata_update(
             }
             if let Some(updated_at) = session_info.updated_at.as_opt_ref() {
                 runtime.persisted.session_info.updated_at = updated_at.cloned();
+            }
+            if runtime.active.is_none()
+                && let Some(status) = session_info
+                    .meta
+                    .as_ref()
+                    .and_then(|meta| meta.get("nori"))
+                    .and_then(|nori| nori.get("status"))
+                    .and_then(serde_json::Value::as_str)
+            {
+                match status {
+                    "working" => runtime.observer_turn_active = true,
+                    "idle" => {
+                        runtime.observer_turn_active = false;
+                        runtime.orphan_update_warning_emitted = false;
+                    }
+                    _ => {}
+                }
             }
         }
         acp::SessionUpdate::UsageUpdate(usage) => {

--- a/nori-rs/harness/src/backend/session_reducer/tests.rs
+++ b/nori-rs/harness/src/backend/session_reducer/tests.rs
@@ -289,6 +289,47 @@ fn cancel_sets_cancelling_but_does_not_end_turn() {
 }
 
 #[test]
+fn request_scoped_cancel_only_cancels_the_matching_turn() {
+    let mut rt = new_runtime();
+    let mut norm = new_normalizer();
+
+    reduce(
+        &mut rt,
+        InboundEvent::PromptSubmit(simple_prompt()),
+        &mut norm,
+    );
+    let active_request_id = rt
+        .active
+        .as_ref()
+        .expect("prompt should be active")
+        .request_id
+        .clone();
+    let stale = reduce(
+        &mut rt,
+        InboundEvent::CancelSubmitFor {
+            request_id: request_id("stale-turn"),
+        },
+        &mut norm,
+    );
+    assert!(stale.events.is_empty());
+    assert!(stale.side_effects.is_empty());
+    assert_eq!(rt.phase_view(), SessionPhaseView::Prompt);
+
+    let matching = reduce(
+        &mut rt,
+        InboundEvent::CancelSubmitFor {
+            request_id: active_request_id,
+        },
+        &mut norm,
+    );
+    assert!(has_side_effect(&matching.side_effects, |effect| matches!(
+        effect,
+        SideEffect::SendCancel
+    )));
+    assert_eq!(rt.phase_view(), SessionPhaseView::Cancelling);
+}
+
+#[test]
 fn double_cancel_is_noop() {
     let mut rt = new_runtime();
     let mut norm = new_normalizer();
@@ -393,6 +434,54 @@ fn notification_while_idle_warns_and_remains_unowned() {
     assert!(has_event(&out.events, |event| matches!(
         event,
         ClientEvent::MessageDelta(delta) if delta.delta == "proactive content"
+    )));
+    assert!(rt.active.is_none());
+    assert_eq!(rt.phase, SessionPhase::Idle);
+}
+
+#[test]
+fn nori_status_bounds_unowned_activity_without_claiming_the_turn() {
+    let mut rt = new_runtime();
+    let mut norm = new_normalizer();
+
+    reduce(
+        &mut rt,
+        notification(nori_status_update("working")),
+        &mut norm,
+    );
+    let bounded = reduce(
+        &mut rt,
+        notification(acp::SessionUpdate::AgentMessageChunk(
+            acp::ContentChunk::new(acp::ContentBlock::Text(acp::TextContent::new(
+                "observed response",
+            ))),
+        )),
+        &mut norm,
+    );
+    reduce(&mut rt, notification(nori_status_update("idle")), &mut norm);
+    let unbounded = reduce(
+        &mut rt,
+        notification(acp::SessionUpdate::AgentMessageChunk(
+            acp::ContentChunk::new(acp::ContentBlock::Text(acp::TextContent::new(
+                "truly unowned",
+            ))),
+        )),
+        &mut norm,
+    );
+
+    assert!(!has_event(&bounded.events, |event| matches!(
+        event,
+        ClientEvent::Warning(warning)
+            if warning.message == "Received update with no active local request"
+    )));
+    assert!(has_event(&bounded.events, |event| matches!(
+        event,
+        ClientEvent::MessageDelta(delta) if delta.delta == "observed response"
+    )));
+    assert!(has_event(&unbounded.events, |event| matches!(
+        event,
+        ClientEvent::Warning(warning)
+            if warning.message == "Received update with no active local request"
     )));
     assert!(rt.active.is_none());
     assert_eq!(rt.phase, SessionPhase::Idle);

--- a/nori-rs/harness/src/backend/session_runtime_driver.rs
+++ b/nori-rs/harness/src/backend/session_runtime_driver.rs
@@ -24,6 +24,9 @@ pub(crate) struct CompletedTurn {
 
 pub(crate) enum SessionRuntimeInput {
     Reducer(InboundEvent),
+    Barrier {
+        response_tx: tokio::sync::oneshot::Sender<()>,
+    },
     PermissionRequest {
         pending_request: Box<PendingApprovalRequest>,
         current_policy: AskForApproval,
@@ -118,6 +121,10 @@ impl SessionDriver {
 
     pub(crate) fn queue_len(&self) -> usize {
         self.runtime.queue.len()
+    }
+
+    pub(crate) fn prompt_is_busy(&self) -> bool {
+        self.runtime.phase != SessionPhase::Idle || !self.runtime.queue.is_empty()
     }
 
     pub(crate) fn owns_active_prompt_echo(&self, chunk: &acp::ContentChunk) -> bool {
@@ -320,6 +327,7 @@ impl AcpBackend {
     }
 
     async fn dispatch_reducer_actions(&self, actions: ReducerActions) {
+        let completed_prompt = actions.completed_turn.is_some();
         match actions.completed_turn.as_ref().map(|turn| turn.prompt.kind) {
             // Summarize-and-swap compaction defers `PromptCompleted` until after
             // the session swap, so the new session is active before the UI sees
@@ -352,6 +360,10 @@ impl AcpBackend {
             }
         }
 
+        if completed_prompt {
+            self.forward_observer_turn_status("idle").await;
+        }
+
         for side_effect in actions.side_effects {
             self.execute_side_effect(side_effect).await;
         }
@@ -361,6 +373,23 @@ impl AcpBackend {
         for client_event in client_events {
             self.forward_client_event(client_event.clone()).await;
         }
+    }
+
+    async fn forward_observer_turn_status(&self, status: &str) {
+        let mut meta = serde_json::Map::new();
+        meta.insert("nori".to_string(), serde_json::json!({ "status": status }));
+        let notification = acp::SessionNotification::new(
+            self.session_id.read().await.clone(),
+            acp::SessionUpdate::SessionInfoUpdate(acp::SessionInfoUpdate::new().meta(meta)),
+        );
+        let _ = self
+            .backend_event_tx
+            .send(BackendEvent::Public(SessionEvent::Acp(
+                nori_protocol::AcpEvent::Notification(acp::AgentNotification::SessionNotification(
+                    notification,
+                )),
+            )))
+            .await;
     }
 
     pub(super) async fn forward_client_event(&self, client_event: ClientEvent) {
@@ -764,6 +793,7 @@ impl AcpBackend {
                             debug_assert!(actions.side_effects.is_empty());
                             debug_assert!(actions.completed_turn.is_none());
                             self.forward_client_events(&actions.events).await;
+                            self.forward_observer_turn_status("working").await;
                             Ok(wire_request_id)
                         }
                         Ok(Err(error)) => Err(error),
@@ -860,6 +890,16 @@ impl AcpBackend {
                     }
                 });
                 *self.cancel_timeout_abort.lock().await = Some(watchdog.abort_handle());
+            }
+            SideEffect::RejectPromptBusy { event_id } => {
+                if let Some(response_tx) = self
+                    .pending_prompt_submissions
+                    .lock()
+                    .await
+                    .remove(&event_id)
+                {
+                    let _ = response_tx.send(Err(super::PromptBusy.into()));
+                }
             }
             SideEffect::ResolvePermissionCancelled { request_id } => {
                 self.resolve_cancelled_permission(&request_id).await;

--- a/nori-rs/harness/src/backend/spawn_and_relay.rs
+++ b/nori-rs/harness/src/backend/spawn_and_relay.rs
@@ -308,6 +308,9 @@ impl AcpBackend {
                     session_runtime_driver::SessionRuntimeInput::Reducer(event) => {
                         runtime_backend.apply_session_event(event).await;
                     }
+                    session_runtime_driver::SessionRuntimeInput::Barrier { response_tx } => {
+                        let _ = response_tx.send(());
+                    }
                     session_runtime_driver::SessionRuntimeInput::PermissionRequest {
                         pending_request,
                         current_policy,

--- a/nori-rs/harness/src/backend/submit_and_ops.rs
+++ b/nori-rs/harness/src/backend/submit_and_ops.rs
@@ -19,6 +19,15 @@ impl AcpBackend {
             .map_err(|_| anyhow::anyhow!("session runtime closed"))
     }
 
+    pub(crate) async fn cancel_request(&self, request_id: acp::RequestId) -> Result<()> {
+        self.session_event_tx
+            .send(session_runtime_driver::SessionRuntimeInput::Reducer(
+                session_reducer::InboundEvent::CancelSubmitFor { request_id },
+            ))
+            .await
+            .map_err(|_| anyhow::anyhow!("session runtime closed"))
+    }
+
     pub(crate) async fn shutdown(&self, child_grace: std::time::Duration) -> Result<()> {
         self.teardown(true, Some(child_grace)).await;
         let _ = self
@@ -207,6 +216,7 @@ impl AcpBackend {
         &self,
         content: Vec<acp::ContentBlock>,
         prompt_meta: Option<acp::Meta>,
+        admission: PromptAdmission,
         response_tx: oneshot::Sender<Result<acp::RequestId>>,
     ) {
         let has_content = content.iter().any(|block| match block {
@@ -218,12 +228,36 @@ impl AcpBackend {
             return;
         }
 
+        if admission == PromptAdmission::RejectIfBusy {
+            let (barrier_tx, barrier_rx) = oneshot::channel();
+            if self
+                .session_event_tx
+                .send(session_runtime_driver::SessionRuntimeInput::Barrier {
+                    response_tx: barrier_tx,
+                })
+                .await
+                .is_err()
+                || barrier_rx.await.is_err()
+            {
+                let _ = response_tx.send(Err(anyhow::anyhow!(
+                    "ACP session runtime closed before prompt admission"
+                )));
+                return;
+            }
+            if self.session_driver.lock().await.prompt_is_busy() {
+                let _ = response_tx.send(Err(PromptBusy.into()));
+                return;
+            }
+        }
+
         let id = generate_id();
         self.pending_prompt_submissions
             .lock()
             .await
             .insert(id.clone(), response_tx);
-        if let Err(error) = self.handle_prompt(content, &id, prompt_meta).await
+        if let Err(error) = self
+            .handle_prompt(content, &id, prompt_meta, admission)
+            .await
             && let Some(response_tx) = self.pending_prompt_submissions.lock().await.remove(&id)
         {
             let _ = response_tx.send(Err(error));

--- a/nori-rs/harness/src/backend/user_input.rs
+++ b/nori-rs/harness/src/backend/user_input.rs
@@ -7,6 +7,7 @@ impl AcpBackend {
         content: Vec<acp::ContentBlock>,
         id: &str,
         mut prompt_meta: Option<acp::Meta>,
+        admission: PromptAdmission,
     ) -> Result<()> {
         let prompt_text = content
             .iter()
@@ -199,22 +200,25 @@ impl AcpBackend {
             "Accepted user prompt into ACP backend"
         );
 
-        let _ = self
-            .session_event_tx
-            .send(session_runtime_driver::SessionRuntimeInput::Reducer(
-                session_reducer::InboundEvent::PromptSubmit(
-                    crate::normalized::session_runtime::QueuedPrompt {
-                        event_id: id.to_string(),
-                        kind: crate::normalized::session_runtime::QueuedPromptKind::User,
-                        text: final_prompt_text,
-                        prompt_meta,
-                        original_content,
-                        content: final_content,
-                        display_text: Some(prompt_text_for_hooks),
-                    },
-                ),
-            ))
-            .await;
+        let prompt = crate::normalized::session_runtime::QueuedPrompt {
+            event_id: id.to_string(),
+            kind: crate::normalized::session_runtime::QueuedPromptKind::User,
+            text: final_prompt_text,
+            prompt_meta,
+            original_content,
+            content: final_content,
+            display_text: Some(prompt_text_for_hooks),
+        };
+        let event = match admission {
+            PromptAdmission::Queue => session_reducer::InboundEvent::PromptSubmit(prompt),
+            PromptAdmission::RejectIfBusy => {
+                session_reducer::InboundEvent::PromptSubmitIfIdle(prompt)
+            }
+        };
+        self.session_event_tx
+            .send(session_runtime_driver::SessionRuntimeInput::Reducer(event))
+            .await
+            .map_err(|_| anyhow::anyhow!("ACP session runtime closed during prompt submission"))?;
 
         Ok(())
     }

--- a/nori-rs/harness/src/normalized/session_runtime.rs
+++ b/nori-rs/harness/src/normalized/session_runtime.rs
@@ -221,6 +221,9 @@ pub struct SessionRuntime {
     /// warning since the last time a request became active. Reset on each new
     /// prompt/load start so a later unowned burst can warn again.
     pub orphan_update_warning_emitted: bool,
+    /// Whether Nori lifecycle metadata bounds activity owned by another
+    /// frontend. This never claims the local ACP request slot.
+    pub observer_turn_active: bool,
 }
 
 impl SessionRuntime {
@@ -231,6 +234,7 @@ impl SessionRuntime {
             active: None,
             queue: VecDeque::new(),
             orphan_update_warning_emitted: false,
+            observer_turn_active: false,
         }
     }
 

--- a/nori-rs/harness/src/remote_agent.rs
+++ b/nori-rs/harness/src/remote_agent.rs
@@ -26,6 +26,7 @@ pub use nori_acp_host::remote::LoadedSession;
 pub use nori_acp_host::remote::RemoteAcpServer;
 pub use nori_acp_host::remote::parse_bind_addr;
 
+use crate::backend::PromptBusy;
 use crate::runtime::HarnessHandle;
 use crate::transcript::TranscriptLoader;
 
@@ -37,6 +38,7 @@ const REMOTE_SINK_EVENTS: usize = 256;
 /// event loop can observe a response before `prompt` finishes registering
 /// its request id). Local-frontend outcomes cycle through and are evicted.
 const UNCLAIMED_OUTCOME_LIMIT: usize = 8;
+const SESSION_BUSY_ERROR_CODE: i32 = -32015;
 
 /// The active harness session as seen by the remote surface.
 struct ActiveSession {
@@ -56,6 +58,12 @@ struct HostShared {
     subscription_seq: i64,
     /// Harness request ids of remote-submitted prompts awaiting completion.
     remote_turns: Vec<acp::RequestId>,
+    /// Monotonic identity for remote prompt-registration work.
+    remote_prompt_seq: u64,
+    /// A remote prompt is between host admission and request-id registration.
+    remote_prompt_pending: Option<u64>,
+    /// A cancel arrived while that remote prompt was still registering.
+    cancel_pending_prompt: bool,
     /// Turn outcomes (responses and failures) seen while no submitter had
     /// registered their request id; bounded, oldest evicted first.
     unclaimed_outcomes: Vec<SessionEvent>,
@@ -148,6 +156,8 @@ impl HarnessRemoteHost {
             cwd,
         });
         state.remote_turns.clear();
+        state.remote_prompt_pending = None;
+        state.cancel_pending_prompt = false;
         state.unclaimed_outcomes.clear();
         state.current_turn = None;
         state.event_task = Some(tokio::spawn(run_event_loop(self.state.clone(), events)));
@@ -179,6 +189,67 @@ fn unknown_session() -> acp::Error {
 
 fn internal_error(message: impl std::fmt::Display) -> acp::Error {
     acp::Error::new(-32000, message.to_string())
+}
+
+fn session_busy() -> acp::Error {
+    acp::Error::new(
+        SESSION_BUSY_ERROR_CODE,
+        "session already has an active turn",
+    )
+}
+
+async fn register_remote_prompt(
+    state: Arc<Mutex<HostShared>>,
+    handle: HarnessHandle,
+    submission_id: u64,
+    prompt: Vec<acp::ContentBlock>,
+    meta: Option<acp::Meta>,
+) -> Result<acp::RequestId, acp::Error> {
+    let request_id = match handle.prompt_with_meta_if_idle(prompt, meta).await {
+        Ok(request_id) => request_id,
+        Err(error) => {
+            let mut state = state.lock().await;
+            if state.remote_prompt_pending == Some(submission_id) {
+                state.remote_prompt_pending = None;
+                state.cancel_pending_prompt = false;
+            }
+            return if error.is::<PromptBusy>() {
+                Err(session_busy())
+            } else {
+                Err(internal_error(error))
+            };
+        }
+    };
+
+    let mut state = state.lock().await;
+    if state.remote_prompt_pending != Some(submission_id) {
+        return Err(internal_error(
+            "hosted session changed during remote prompt registration",
+        ));
+    }
+    state.remote_prompt_pending = None;
+    let cancel_pending = std::mem::take(&mut state.cancel_pending_prompt);
+    let raced = state
+        .unclaimed_outcomes
+        .iter()
+        .position(|event| outcome_request_id(event) == Some(&request_id));
+    match raced {
+        // The outcome was observed before this registration; deliver it now
+        // instead of registering a turn that already ended.
+        Some(position) => {
+            let event = state.unclaimed_outcomes.remove(position);
+            forward_to_sink(&mut state, event);
+        }
+        None => state.remote_turns.push(request_id.clone()),
+    }
+    drop(state);
+    if cancel_pending {
+        handle
+            .cancel_request(request_id.clone())
+            .await
+            .map_err(internal_error)?;
+    }
+    Ok(request_id)
 }
 
 /// Answer delegated permission requests the detached controller can no longer
@@ -270,6 +341,8 @@ async fn run_event_loop(state: Arc<Mutex<HostShared>>, mut events: mpsc::Receive
                     let mut shared = state.lock().await;
                     shared.session = None;
                     shared.remote_turns.clear();
+                    shared.remote_prompt_pending = None;
+                    shared.cancel_pending_prompt = false;
                     shared.unclaimed_outcomes.clear();
                     shared.current_turn = None;
                     return;
@@ -354,6 +427,8 @@ async fn run_event_loop(state: Arc<Mutex<HostShared>>, mut events: mpsc::Receive
                 );
                 shared.session = None;
                 shared.remote_turns.clear();
+                shared.remote_prompt_pending = None;
+                shared.cancel_pending_prompt = false;
                 shared.unclaimed_outcomes.clear();
                 shared.forwarded_requests.clear();
                 shared.current_turn = None;
@@ -467,36 +542,57 @@ impl HostedAgent for HarnessRemoteHost {
         prompt: Vec<acp::ContentBlock>,
         meta: Option<acp::Meta>,
     ) -> Result<acp::RequestId, acp::Error> {
-        // Do not hold the state lock across the submission: a prompt queued
-        // behind an active turn resolves only when it is issued, and holding
-        // the lock that long would freeze every other host method and the
-        // event loop.
-        let handle = self.checked_handle(session_id).await?;
-        let request_id = handle
-            .prompt_with_meta(prompt, meta)
-            .await
-            .map_err(internal_error)?;
-
-        let mut state = self.state.lock().await;
-        let raced = state
-            .unclaimed_outcomes
-            .iter()
-            .position(|event| outcome_request_id(event) == Some(&request_id));
-        match raced {
-            // The outcome was observed before this registration; deliver it
-            // now instead of registering a turn that already ended.
-            Some(position) => {
-                let event = state.unclaimed_outcomes.remove(position);
-                forward_to_sink(&mut state, event);
+        let (handle, submission_id) = {
+            let mut state = self.state.lock().await;
+            let Some(session) = state.session.as_ref() else {
+                return Err(unknown_session());
+            };
+            if session.conversation_id.as_deref() != Some(session_id.0.as_ref()) {
+                return Err(unknown_session());
             }
-            None => state.remote_turns.push(request_id.clone()),
-        }
-        Ok(request_id)
+            if state.remote_prompt_pending.is_some() {
+                return Err(session_busy());
+            }
+            let handle = session.handle.clone();
+            state.remote_prompt_seq += 1;
+            let submission_id = state.remote_prompt_seq;
+            state.remote_prompt_pending = Some(submission_id);
+            (handle, submission_id)
+        };
+        let registration = tokio::spawn(register_remote_prompt(
+            self.state.clone(),
+            handle,
+            submission_id,
+            prompt,
+            meta,
+        ));
+        registration.await.map_err(|error| {
+            internal_error(format!("remote prompt registration failed: {error}"))
+        })?
     }
 
     async fn cancel(&self, session_id: &acp::SessionId) -> Result<(), acp::Error> {
-        let handle = self.checked_handle(session_id).await?;
-        handle.cancel().await.map_err(internal_error)
+        let (handle, request_id) = {
+            let mut state = self.state.lock().await;
+            let Some(session) = state.session.as_ref() else {
+                return Err(unknown_session());
+            };
+            if session.conversation_id.as_deref() != Some(session_id.0.as_ref()) {
+                return Err(unknown_session());
+            }
+            let handle = session.handle.clone();
+            let Some(request_id) = state.remote_turns.last().cloned() else {
+                if state.remote_prompt_pending.is_some() {
+                    state.cancel_pending_prompt = true;
+                }
+                return Ok(());
+            };
+            (handle, request_id)
+        };
+        handle
+            .cancel_request(request_id)
+            .await
+            .map_err(internal_error)
     }
 
     async fn close_session(&self, session_id: &acp::SessionId) -> Result<(), acp::Error> {

--- a/nori-rs/harness/src/runtime.rs
+++ b/nori-rs/harness/src/runtime.rs
@@ -22,6 +22,7 @@ use tokio::sync::oneshot;
 use crate::backend::AcpBackend;
 use crate::backend::AcpBackendConfig;
 use crate::backend::BackendEvent;
+use crate::backend::PromptAdmission;
 use crate::backend::SessionContext;
 pub use crate::backend::prepared::PreparedAgent;
 pub use crate::backend::prepared::SessionCatalog;
@@ -77,6 +78,7 @@ enum HarnessCommand {
     Prompt {
         content: Vec<acp::v1::ContentBlock>,
         meta: Option<acp::v1::Meta>,
+        admission: PromptAdmission,
         response_tx: oneshot::Sender<anyhow::Result<acp::v1::RequestId>>,
     },
     /// Shut down the active harness session.
@@ -91,6 +93,10 @@ enum HarnessCommand {
         response_tx: oneshot::Sender<anyhow::Result<()>>,
     },
     Cancel {
+        response_tx: oneshot::Sender<anyhow::Result<()>>,
+    },
+    CancelRequest {
+        request_id: acp::v1::RequestId,
         response_tx: oneshot::Sender<anyhow::Result<()>>,
     },
     AddHistory {
@@ -197,11 +203,31 @@ impl HarnessHandle {
         content: Vec<acp::v1::ContentBlock>,
         meta: Option<acp::v1::Meta>,
     ) -> anyhow::Result<acp::v1::RequestId> {
+        self.prompt_with_meta_and_admission(content, meta, PromptAdmission::Queue)
+            .await
+    }
+
+    pub(crate) async fn prompt_with_meta_if_idle(
+        &self,
+        content: Vec<acp::v1::ContentBlock>,
+        meta: Option<acp::v1::Meta>,
+    ) -> anyhow::Result<acp::v1::RequestId> {
+        self.prompt_with_meta_and_admission(content, meta, PromptAdmission::RejectIfBusy)
+            .await
+    }
+
+    async fn prompt_with_meta_and_admission(
+        &self,
+        content: Vec<acp::v1::ContentBlock>,
+        meta: Option<acp::v1::Meta>,
+        admission: PromptAdmission,
+    ) -> anyhow::Result<acp::v1::RequestId> {
         let (response_tx, response_rx) = oneshot::channel();
         self.command_tx
             .send(HarnessCommand::Prompt {
                 content,
                 meta,
+                admission,
                 response_tx,
             })
             .map_err(|_| anyhow::anyhow!("ACP agent command channel closed"))?;
@@ -255,6 +281,17 @@ impl HarnessHandle {
     pub async fn cancel(&self) -> anyhow::Result<()> {
         self.request(|response_tx| HarnessCommand::Cancel { response_tx })
             .await
+    }
+
+    pub(crate) async fn cancel_request(
+        &self,
+        request_id: acp::v1::RequestId,
+    ) -> anyhow::Result<()> {
+        self.request(|response_tx| HarnessCommand::CancelRequest {
+            request_id,
+            response_tx,
+        })
+        .await
     }
 
     pub async fn add_history(&self, text: String) -> anyhow::Result<()> {
@@ -803,10 +840,11 @@ fn launch_session_from(source: SessionAgentSource, start: SessionStart) -> Launc
                     HarnessCommand::Prompt {
                         content,
                         meta,
+                        admission,
                         response_tx,
                     } => {
                         backend_for_agent
-                            .submit_prompt(content, meta, response_tx)
+                            .submit_prompt(content, meta, admission, response_tx)
                             .await;
                     }
                     HarnessCommand::Shutdown {
@@ -832,6 +870,13 @@ fn launch_session_from(source: SessionAgentSource, start: SessionStart) -> Launc
                     }
                     HarnessCommand::Cancel { response_tx } => {
                         let _ = response_tx.send(backend_for_agent.cancel().await);
+                    }
+                    HarnessCommand::CancelRequest {
+                        request_id,
+                        response_tx,
+                    } => {
+                        let _ =
+                            response_tx.send(backend_for_agent.cancel_request(request_id).await);
                     }
                     HarnessCommand::AddHistory { text, response_tx } => {
                         let _ = response_tx.send(backend_for_agent.add_history(text).await);

--- a/nori-rs/harness/tests/remote_host.rs
+++ b/nori-rs/harness/tests/remote_host.rs
@@ -3,7 +3,9 @@
 //! stream order, transcript-backed `session/load` replay, and delegated
 //! permission routing for remote-owned turns.
 
+use std::future::Future;
 use std::sync::Arc;
+use std::task::Poll;
 use std::time::Duration;
 
 use nori_config::NoriConfig;
@@ -21,6 +23,8 @@ use nori_protocol::SessionEvent;
 use nori_protocol::acp::v1 as acp;
 use pretty_assertions::assert_eq;
 use serial_test::serial;
+
+const SESSION_BUSY_ERROR_CODE: i32 = -32015;
 
 struct EnvGuard(&'static str);
 
@@ -108,6 +112,195 @@ fn notification_text(event: &SessionEvent) -> Option<(String, String)> {
         return None;
     };
     Some((notification.session_id.to_string(), text.text.clone()))
+}
+
+fn notification_nori_status(event: &SessionEvent) -> Option<(String, String)> {
+    let SessionEvent::Acp(AcpEvent::Notification(acp::AgentNotification::SessionNotification(
+        notification,
+    ))) = event
+    else {
+        return None;
+    };
+    let acp::SessionUpdate::SessionInfoUpdate(info) = &notification.update else {
+        return None;
+    };
+    let status = info.meta.as_ref()?.get("nori")?.get("status")?.as_str()?;
+    Some((notification.session_id.to_string(), status.to_string()))
+}
+
+#[tokio::test]
+#[serial]
+async fn local_prompt_broadcasts_a_complete_observer_turn_without_a_foreign_response() {
+    let fixture = launch_attached().await;
+    let info = wait_for_session(&fixture.host).await;
+    let session_id = info.session_id.clone();
+    let mut subscription = fixture.host.subscribe().await;
+
+    fixture
+        .session
+        .handle
+        .prompt(vec![acp::ContentBlock::Text(acp::TextContent::new(
+            "local turn",
+        ))])
+        .await
+        .expect("submit local prompt");
+
+    let observed = tokio::time::timeout(Duration::from_secs(10), async {
+        let mut sequence = Vec::new();
+        loop {
+            let event = subscription
+                .events
+                .recv()
+                .await
+                .ok_or_else(|| "subscription closed before observer turn ended".to_string())?;
+            if let Some((update_session_id, status)) = notification_nori_status(&event) {
+                assert_eq!(update_session_id, session_id.to_string());
+                sequence.push(format!("status:{status}"));
+                if status == "idle" {
+                    return Ok::<_, String>(sequence);
+                }
+                continue;
+            }
+            if let Some((update_session_id, text)) = notification_text(&event) {
+                assert_eq!(update_session_id, session_id.to_string());
+                sequence.push(format!("message:{text}"));
+                continue;
+            }
+            if matches!(event, SessionEvent::Acp(AcpEvent::Response { .. })) {
+                return Err(
+                    "observer received a response for a prompt it did not issue".to_string()
+                );
+            }
+        }
+    })
+    .await;
+
+    fixture.session.handle.shutdown().await.expect("shutdown");
+    let sequence = observed
+        .expect("observer turn should end")
+        .expect("observer stream should remain valid");
+    assert_eq!(
+        sequence,
+        vec![
+            "status:working".to_string(),
+            "message:local turn".to_string(),
+            "message:Test message 1".to_string(),
+            "message:Test message 2".to_string(),
+            "status:idle".to_string(),
+        ]
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn local_prompt_cancellation_still_ends_the_observer_turn() {
+    // SAFETY: tests that mutate the mock-agent environment run serially.
+    unsafe { std::env::set_var("MOCK_AGENT_STREAM_UNTIL_CANCEL", "1") };
+    let _guard = EnvGuard("MOCK_AGENT_STREAM_UNTIL_CANCEL");
+
+    let fixture = launch_attached().await;
+    let info = wait_for_session(&fixture.host).await;
+    let mut subscription = fixture.host.subscribe().await;
+
+    fixture
+        .session
+        .handle
+        .prompt(vec![acp::ContentBlock::Text(acp::TextContent::new(
+            "cancel locally",
+        ))])
+        .await
+        .expect("submit local prompt");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let event = subscription
+                .events
+                .recv()
+                .await
+                .expect("subscription closed before local output");
+            if notification_text(&event).is_some_and(|(_, text)| text == "Streaming...") {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("local output should start");
+    fixture
+        .session
+        .handle
+        .cancel()
+        .await
+        .expect("cancel locally");
+
+    let statuses = tokio::time::timeout(Duration::from_secs(5), async {
+        let mut statuses = Vec::new();
+        loop {
+            let event = subscription
+                .events
+                .recv()
+                .await
+                .expect("subscription closed before cancellation completed");
+            if let Some((update_session_id, status)) = notification_nori_status(&event) {
+                assert_eq!(update_session_id, info.session_id.to_string());
+                statuses.push(status.clone());
+                if status == "idle" {
+                    return statuses;
+                }
+            }
+        }
+    })
+    .await;
+
+    fixture.session.handle.shutdown().await.expect("shutdown");
+    assert_eq!(
+        statuses.expect("cancelled observer turn should end"),
+        vec!["idle".to_string()]
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn local_prompt_failure_still_ends_the_observer_turn() {
+    // SAFETY: tests that mutate the mock-agent environment run serially.
+    unsafe { std::env::set_var("MOCK_AGENT_PROMPT_FAIL", "1") };
+    let _guard = EnvGuard("MOCK_AGENT_PROMPT_FAIL");
+
+    let fixture = launch_attached().await;
+    let info = wait_for_session(&fixture.host).await;
+    let mut subscription = fixture.host.subscribe().await;
+
+    fixture
+        .session
+        .handle
+        .prompt(vec![acp::ContentBlock::Text(acp::TextContent::new(
+            "fail locally",
+        ))])
+        .await
+        .expect("submit local prompt");
+
+    let statuses = tokio::time::timeout(Duration::from_secs(5), async {
+        let mut statuses = Vec::new();
+        loop {
+            let event = subscription
+                .events
+                .recv()
+                .await
+                .expect("subscription closed before failure completed");
+            if let Some((update_session_id, status)) = notification_nori_status(&event) {
+                assert_eq!(update_session_id, info.session_id.to_string());
+                statuses.push(status.clone());
+                if status == "idle" {
+                    return statuses;
+                }
+            }
+        }
+    })
+    .await;
+
+    fixture.session.handle.shutdown().await.expect("shutdown");
+    assert_eq!(
+        statuses.expect("failed observer turn should end"),
+        vec!["working".to_string(), "idle".to_string()]
+    );
 }
 
 #[tokio::test]
@@ -329,14 +522,15 @@ async fn load_session_replays_the_previous_turn_from_the_transcript() {
     let texts: Vec<String> = loaded
         .replay
         .iter()
-        .map(|notification| {
+        .filter_map(|notification| {
             assert_eq!(notification.session_id, session_id);
             match &notification.update {
                 acp::SessionUpdate::UserMessageChunk(chunk)
                 | acp::SessionUpdate::AgentMessageChunk(chunk) => match &chunk.content {
-                    acp::ContentBlock::Text(text) => text.text.clone(),
+                    acp::ContentBlock::Text(text) => Some(text.text.clone()),
                     other => panic!("unexpected replay content: {other:?}"),
                 },
+                acp::SessionUpdate::SessionInfoUpdate(_) => None,
                 other => panic!("unexpected replay update: {other:?}"),
             }
         })
@@ -479,101 +673,361 @@ async fn delegated_permission_requests_reach_the_remote_controller_for_remote_tu
 
 #[tokio::test]
 #[serial]
-async fn queued_remote_prompt_does_not_freeze_the_host() {
+async fn remote_prompt_is_rejected_while_a_local_turn_is_active() {
     // SAFETY: tests that mutate the mock-agent environment run serially.
     unsafe { std::env::set_var("MOCK_AGENT_DELAY_MS", "3000") };
     let _guard = EnvGuard("MOCK_AGENT_DELAY_MS");
+
+    let mut fixture = launch_attached().await;
+    let info = wait_for_session(&fixture.host).await;
+    let session_id = info.session_id.clone();
+    let mut subscription = fixture.host.subscribe().await;
+    let local_request_id = fixture
+        .session
+        .handle
+        .prompt(vec![acp::ContentBlock::Text(acp::TextContent::new(
+            "first",
+        ))])
+        .await
+        .expect("submit local prompt");
+
+    let rejected = tokio::time::timeout(
+        Duration::from_secs(2),
+        fixture.host.prompt(
+            &session_id,
+            vec![acp::ContentBlock::Text(acp::TextContent::new("remote"))],
+            None,
+        ),
+    )
+    .await;
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let event = fixture
+                .session
+                .events
+                .recv()
+                .await
+                .expect("primary event stream closed before local turn ended");
+            if matches!(
+                event,
+                SessionEvent::Acp(AcpEvent::Response { request_id, .. })
+                    if request_id == local_request_id
+            ) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("local turn should end");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let rejected_prompt_was_later_broadcast =
+        std::iter::from_fn(|| subscription.events.try_recv().ok())
+            .filter_map(|event| notification_text(&event))
+            .any(|(_, text)| text == "remote");
+
+    fixture.session.handle.shutdown().await.expect("shutdown");
+    let error = rejected
+        .expect("remote prompt rejection should be immediate")
+        .expect_err("remote prompt must not queue behind local activity");
+    assert_eq!(i32::from(error.code), SESSION_BUSY_ERROR_CODE);
+    assert!(
+        !rejected_prompt_was_later_broadcast,
+        "a rejected remote prompt must never execute later"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn remote_cancel_does_not_cancel_a_local_turn() {
+    // SAFETY: tests that mutate the mock-agent environment run serially.
+    unsafe { std::env::set_var("MOCK_AGENT_STREAM_UNTIL_CANCEL", "1") };
+    let _guard = EnvGuard("MOCK_AGENT_STREAM_UNTIL_CANCEL");
 
     let fixture = launch_attached().await;
     let info = wait_for_session(&fixture.host).await;
     let session_id = info.session_id.clone();
     let mut subscription = fixture.host.subscribe().await;
 
-    // The first remote turn takes several seconds to finish.
-    let first_request_id = fixture
-        .host
-        .prompt(
-            &session_id,
-            vec![acp::ContentBlock::Text(acp::TextContent::new("first"))],
-            None,
-        )
+    fixture
+        .session
+        .handle
+        .prompt(vec![acp::ContentBlock::Text(acp::TextContent::new(
+            "local streaming turn",
+        ))])
         .await
-        .expect("submit the first prompt");
-
-    // A second prompt queues behind the active turn; its submission resolves
-    // only when the queue drains, so it must not hold the host hostage.
-    let queued = {
-        let host = fixture.host.clone();
-        let session_id = session_id.clone();
-        tokio::spawn(async move {
-            host.prompt(
-                &session_id,
-                vec![acp::ContentBlock::Text(acp::TextContent::new("second"))],
-                None,
-            )
-            .await
-        })
-    };
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
-    // Regression (H1): while the second prompt is queued, other host methods
-    // must stay responsive instead of blocking until the turn ends.
-    let sessions = tokio::time::timeout(Duration::from_secs(2), fixture.host.list_sessions())
-        .await
-        .expect("list_sessions must not block behind a queued prompt")
-        .expect("list sessions");
-    assert_eq!(sessions.len(), 1);
-
-    // Both turns then complete in order once the queue drains.
-    let second_request_id = tokio::time::timeout(Duration::from_secs(15), queued)
-        .await
-        .expect("the queued prompt should be issued when the first turn ends")
-        .expect("prompt task")
-        .expect("submit the second prompt");
-    let mut outcomes = Vec::new();
-    let mut sequence = Vec::new();
-    tokio::time::timeout(Duration::from_secs(15), async {
-        while outcomes.len() < 2 {
+        .expect("submit local prompt");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
             let event = subscription
                 .events
                 .recv()
                 .await
-                .expect("subscription closed before both turns ended");
-            match event {
-                SessionEvent::Acp(AcpEvent::Notification(
-                    acp::AgentNotification::SessionNotification(notification),
-                )) => {
-                    if let acp::SessionUpdate::UserMessageChunk(chunk) = notification.update
-                        && let acp::ContentBlock::Text(text) = chunk.content
-                    {
-                        sequence.push(format!("user:{}", text.text));
-                    }
-                }
-                SessionEvent::Acp(AcpEvent::Response { request_id, .. }) => {
-                    sequence.push(if request_id == first_request_id {
-                        "response:first".to_string()
-                    } else {
-                        "response:second".to_string()
-                    });
-                    outcomes.push(request_id);
-                }
-                SessionEvent::Acp(_) | SessionEvent::Nori(_) => {}
+                .expect("subscription closed before local output");
+            if notification_text(&event).is_some_and(|(_, text)| text == "Streaming...") {
+                break;
             }
         }
     })
     .await
-    .expect("both turns should complete");
-    assert_eq!(outcomes, vec![first_request_id, second_request_id]);
-    assert_eq!(
-        sequence,
-        vec![
-            "user:first".to_string(),
-            "response:first".to_string(),
-            "user:second".to_string(),
-            "response:second".to_string(),
-        ],
-        "a queued prompt must not enter the fan-out until it becomes active"
+    .expect("local output should start");
+    fixture
+        .host
+        .cancel(&session_id)
+        .await
+        .expect("ignore remote cancel for local turn");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    while subscription.events.try_recv().is_ok() {}
+    let output_continued = tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            let event = subscription
+                .events
+                .recv()
+                .await
+                .expect("subscription closed while local turn was active");
+            if notification_text(&event).is_some_and(|(_, text)| text == "Streaming...") {
+                return true;
+            }
+        }
+    })
+    .await
+    .unwrap_or(false);
+
+    fixture
+        .session
+        .handle
+        .cancel()
+        .await
+        .expect("cancel locally");
+    fixture.session.handle.shutdown().await.expect("shutdown");
+    assert!(
+        output_continued,
+        "local-owned agent output must continue after a remote cancel"
     );
+}
+
+#[tokio::test]
+#[serial]
+async fn remote_cancel_still_cancels_a_remote_owned_turn() {
+    // SAFETY: tests that mutate the mock-agent environment run serially.
+    unsafe { std::env::set_var("MOCK_AGENT_STREAM_UNTIL_CANCEL", "1") };
+    let _guard = EnvGuard("MOCK_AGENT_STREAM_UNTIL_CANCEL");
+
+    let fixture = launch_attached().await;
+    let info = wait_for_session(&fixture.host).await;
+    let session_id = info.session_id.clone();
+    let mut subscription = fixture.host.subscribe().await;
+    let request_id = fixture
+        .host
+        .prompt(
+            &session_id,
+            vec![acp::ContentBlock::Text(acp::TextContent::new(
+                "remote streaming turn",
+            ))],
+            None,
+        )
+        .await
+        .expect("submit remote prompt");
+    fixture
+        .host
+        .cancel(&session_id)
+        .await
+        .expect("cancel immediately after remote prompt admission");
+    let response = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let event = subscription
+                .events
+                .recv()
+                .await
+                .expect("subscription closed before remote cancellation completed");
+            if let SessionEvent::Acp(AcpEvent::Response {
+                request_id: response_id,
+                response,
+            }) = event
+                && response_id == request_id
+            {
+                return response;
+            }
+        }
+    })
+    .await
+    .expect("remote cancellation should complete");
+
+    fixture.session.handle.shutdown().await.expect("shutdown");
+    match response.expect("remote cancellation should be a successful ACP response") {
+        acp::AgentResponse::PromptResponse(response) => {
+            assert_eq!(response.stop_reason, acp::StopReason::Cancelled);
+        }
+        other => panic!("expected prompt response, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn immediate_remote_cancel_waits_for_remote_turn_registration() {
+    // SAFETY: tests that mutate the mock-agent environment run serially.
+    unsafe { std::env::set_var("MOCK_AGENT_STREAM_UNTIL_CANCEL", "1") };
+    let _guard = EnvGuard("MOCK_AGENT_STREAM_UNTIL_CANCEL");
+
+    let fixture = launch_attached().await;
+    let info = wait_for_session(&fixture.host).await;
+    let session_id = info.session_id.clone();
+    let mut subscription = fixture.host.subscribe().await;
+    let mut prompt = Box::pin(fixture.host.prompt(
+        &session_id,
+        vec![acp::ContentBlock::Text(acp::TextContent::new(
+            "cancel before registration",
+        ))],
+        None,
+    ));
+
+    let completed_on_first_poll = std::future::poll_fn(|cx| {
+        Poll::Ready(match prompt.as_mut().poll(cx) {
+            Poll::Ready(result) => Some(result),
+            Poll::Pending => None,
+        })
+    })
+    .await;
+    assert!(
+        completed_on_first_poll.is_none(),
+        "prompt should still be awaiting transport request registration"
+    );
+    fixture
+        .host
+        .cancel(&session_id)
+        .await
+        .expect("accept immediate remote cancel");
+    let request_id = tokio::time::timeout(Duration::from_secs(5), &mut prompt)
+        .await
+        .expect("remote prompt should finish registration")
+        .expect("submit remote prompt");
+
+    let response = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let event = subscription
+                .events
+                .recv()
+                .await
+                .expect("subscription closed before immediate cancellation completed");
+            if let SessionEvent::Acp(AcpEvent::Response {
+                request_id: response_id,
+                response,
+            }) = event
+                && response_id == request_id
+            {
+                return response;
+            }
+        }
+    })
+    .await
+    .expect("immediate remote cancellation should complete");
+
+    fixture.session.handle.shutdown().await.expect("shutdown");
+    match response.expect("remote cancellation should be a successful ACP response") {
+        acp::AgentResponse::PromptResponse(response) => {
+            assert_eq!(response.stop_reason, acp::StopReason::Cancelled);
+        }
+        other => panic!("expected prompt response, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn dropped_prompt_registration_does_not_wedge_a_reconnected_controller() {
+    // SAFETY: tests that mutate the mock-agent environment run serially.
+    unsafe { std::env::set_var("MOCK_AGENT_STREAM_UNTIL_CANCEL", "1") };
+    let _guard = EnvGuard("MOCK_AGENT_STREAM_UNTIL_CANCEL");
+
+    let fixture = launch_attached().await;
+    let info = wait_for_session(&fixture.host).await;
+    let session_id = info.session_id.clone();
+    let _first_controller = fixture.host.subscribe().await;
+    let mut abandoned_prompt = Box::pin(fixture.host.prompt(
+        &session_id,
+        vec![acp::ContentBlock::Text(acp::TextContent::new(
+            "disconnect during registration",
+        ))],
+        None,
+    ));
+    let completed_on_first_poll = std::future::poll_fn(|cx| {
+        Poll::Ready(match abandoned_prompt.as_mut().poll(cx) {
+            Poll::Ready(result) => Some(result),
+            Poll::Pending => None,
+        })
+    })
+    .await;
+    assert!(completed_on_first_poll.is_none());
+    drop(abandoned_prompt);
+
+    let mut replacement = fixture.host.subscribe().await;
+    fixture
+        .host
+        .cancel(&session_id)
+        .await
+        .expect("remember cancel across disconnected prompt registration");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let event = replacement
+                .events
+                .recv()
+                .await
+                .expect("replacement subscription closed before cancellation");
+            if matches!(
+                event,
+                SessionEvent::Acp(AcpEvent::Response {
+                    response: Ok(acp::AgentResponse::PromptResponse(acp::PromptResponse {
+                        stop_reason: acp::StopReason::Cancelled,
+                        ..
+                    })),
+                    ..
+                })
+            ) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("abandoned registration should still complete and consume its pending cancel");
+
+    let request_id = tokio::time::timeout(
+        Duration::from_secs(5),
+        fixture.host.prompt(
+            &session_id,
+            vec![acp::ContentBlock::Text(acp::TextContent::new(
+                "replacement controller turn",
+            ))],
+            None,
+        ),
+    )
+    .await
+    .expect("replacement prompt admission should not wedge")
+    .expect("replacement controller should not remain busy");
+    fixture
+        .host
+        .cancel(&session_id)
+        .await
+        .expect("cancel replacement turn");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let event = replacement
+                .events
+                .recv()
+                .await
+                .expect("replacement subscription closed before its response");
+            if matches!(
+                event,
+                SessionEvent::Acp(AcpEvent::Response {
+                    request_id: response_id,
+                    response: Ok(acp::AgentResponse::PromptResponse(_)),
+                }) if response_id == request_id
+            ) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("replacement controller turn should complete");
 
     fixture.session.handle.shutdown().await.expect("shutdown");
 }


### PR DESCRIPTION
## Summary

- bracket every admitted harness turn with shared `working` / `idle` ACP lifecycle updates
- reject busy remote prompts and scope remote cancellation to the exact remote-owned request
- preserve prompt/cancel wire order and reconnect safely during request registration
- document the observer and ownership contract

## Test plan

- `cargo test -p nori-acp-host` (102 passed)
- `MOCK_ACP_AGENT_BIN="$PWD/target/debug/mock_acp_agent" cargo test -p nori-harness` (366 passed)
- `cargo test -p nori-tui proactive_turn_status_bounds_unowned_output_and_owned_prompt_broadcast_renders_once`
- `cargo build --bin nori`
- `just fix -p nori-harness -p nori-acp-host`