### PR TITLE
feat(analytics): report authenticated Nori sessions

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -50,6 +50,17 @@ Configuration is resolved from `$NORI_HOME/config.toml` (default
 `~/.nori/cli/config.toml`) and injected into session launches. Transcripts live
 under the same Nori home and can be resumed through `nori resume`.
 
+Authenticated product activity is a separate, prompt-bound path. The CLI maps
+its interactive, cloud, plaintext-exec, and ACP-facade entrypoints to stable
+session modes; `nori-installed` attaches a one-shot reporter to the launched
+harness handle. The reporter reads Firebase credentials from the current nested
+`auth` object in `~/.nori-config.json`, with top-level `username` and
+`refreshToken` retained for legacy files, and posts the strict
+`nori_agent_session_started` envelope through the login-hosted analytics ingress
+only after the first user prompt reaches ACP. Nested auth is authoritative when
+both shapes exist. The ingress, rather than the distributed binary, owns
+canonical identity and organization fanout.
+
 ### Things to Know
 
 - The former `codex-protocol` and `codex-app-server-protocol` crates were
@@ -62,6 +73,11 @@ under the same Nori home and can be resumed through `nori resume`.
   their raw `RequestId`; `AskForApproval::Never` resolves them internally.
 - Cross-platform sandboxing uses Landlock on Linux, Seatbelt on macOS, and
   restricted tokens on Windows.
+- Analytics honors `NORI_NO_ANALYTICS` and durable install-state opt-out, skips
+  missing and service identities, and treats authentication, refresh, and
+  transport failures as best-effort background work with a bounded final
+  flush. Launch, help, version, and resume without a transported prompt are not
+  meaningful activity.
 - The crate-layering decision and the exact protocol contract are documented
   in `@/docs/specs/crate-layering.md` and
   `@/docs/specs/protocol-unification.md`.

--- a/nori-rs/Cargo.lock
+++ b/nori-rs/Cargo.lock
@@ -493,6 +493,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,11 +745,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
- "shlex",
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -848,6 +874,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cmp_any"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,13 +991,13 @@ dependencies = [
  "rand 0.9.4",
  "regex",
  "regex-lite",
- "reqwest",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "serial_test",
  "sha1",
  "sha2",
- "shlex",
+ "shlex 1.3.0",
  "similar",
  "tempfile",
  "thiserror 2.0.17",
@@ -993,7 +1028,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
- "shlex",
+ "shlex 1.3.0",
  "starlark",
  "thiserror 2.0.17",
 ]
@@ -1059,7 +1094,7 @@ dependencies = [
  "codex-core",
  "core_test_support",
  "rand 0.9.4",
- "reqwest",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "sha2",
@@ -1093,7 +1128,7 @@ dependencies = [
  "mcp-types",
  "oauth2",
  "pretty_assertions",
- "reqwest",
+ "reqwest 0.12.24",
  "rmcp",
  "serde",
  "serde_json",
@@ -1344,7 +1379,7 @@ dependencies = [
  "nori-harness",
  "notify",
  "regex-lite",
- "shlex",
+ "shlex 1.3.0",
  "tempfile",
  "tokio",
  "walkdir",
@@ -2133,6 +2168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,6 +2245,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -2388,9 +2435,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -2930,16 +2988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3069,12 +3117,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.77"
+name = "jobserver"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "once_cell",
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -3482,14 +3541,14 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "6cdede44f9a69cab2899a2049e2c3bd49bf911a157f6a3353d4a91c61abbce44"
 dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
  "security-framework 2.11.1",
@@ -3642,6 +3701,7 @@ dependencies = [
  "nori-config",
  "nori-exec",
  "nori-harness",
+ "nori-installed",
  "nori-tui",
  "owo-colors",
  "predicates",
@@ -3680,6 +3740,7 @@ dependencies = [
  "futures",
  "nori-config",
  "nori-harness",
+ "nori-installed",
  "nori-protocol",
  "tokio",
  "tokio-util",
@@ -3712,7 +3773,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "shlex",
+ "shlex 1.3.0",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -3735,10 +3796,11 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "dirs",
  "libc",
  "nori-harness",
  "pretty_assertions",
- "reqwest",
+ "reqwest 0.13.4",
  "semver",
  "serde",
  "serde_json",
@@ -3805,11 +3867,11 @@ dependencies = [
  "ratatui",
  "ratatui-macros",
  "regex-lite",
- "reqwest",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "serial_test",
- "shlex",
+ "shlex 1.3.0",
  "strum 0.27.2",
  "strum_macros 0.27.2",
  "supports-color",
@@ -4036,7 +4098,7 @@ dependencies = [
  "getrandom 0.2.16",
  "http",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -4194,6 +4256,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
@@ -4786,6 +4854,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
@@ -4829,6 +4898,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radix_trie"
@@ -5152,6 +5227,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5184,7 +5297,7 @@ dependencies = [
  "pin-project-lite",
  "process-wrap",
  "rand 0.9.4",
- "reqwest",
+ "reqwest 0.12.24",
  "rmcp-macros",
  "schemars 1.0.4",
  "serde",
@@ -5272,6 +5385,7 @@ version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5279,6 +5393,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe 0.2.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.5.1",
 ]
 
 [[package]]
@@ -5292,11 +5418,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5815,6 +5969,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -6692,20 +6852,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -7236,48 +7396,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7285,22 +7429,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -7390,9 +7534,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7422,6 +7566,15 @@ dependencies = [
  "objc2-foundation",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/nori-rs/README.md
+++ b/nori-rs/README.md
@@ -21,7 +21,7 @@ progressively adopted or removed (see `docs/specs/crate-layering.md`).
 | `nori-config/` | Nori config layer (`~/.nori/cli/config.toml`) |
 | `nori-protocol/` | Session-runtime types over the ACP schema |
 | `sandbox/` (`codex-sandbox`) | Sandboxed exec engine: Seatbelt, Landlock/seccomp, Windows restricted tokens |
-| `installed/` (`nori-installed`) | Install detection and analytics |
+| `installed/` (`nori-installed`) | Local install state and prompt-bound authenticated analytics |
 | `mock-acp-agent/` | Mock ACP agent used by tests |
 | `tui-pty-e2e/` | End-to-end PTY tests driving the real binary |
 

--- a/nori-rs/cli/Cargo.toml
+++ b/nori-rs/cli/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 clap_complete = { workspace = true }
 nori-harness = { workspace = true }
+nori-installed = { workspace = true }
 nori-exec = { workspace = true }
 nori-config = { workspace = true }
 codex-arg0 = { workspace = true }

--- a/nori-rs/cli/docs.md
+++ b/nori-rs/cli/docs.md
@@ -13,8 +13,20 @@ This crate is the primary entry point that ties together the core crates:
 - **Always included:** `nori-tui`, `nori-exec`, `nori-harness`, `nori-config`, `codex-sandbox`
 - **Uses** `codex-arg0` for arg0-based dispatch (Linux sandbox embedding)
 - **Uses** `codex-sandbox` (`@/nori-rs/sandbox/`) for the `nori sandbox` debug subcommand's seatbelt/landlock/windows spawn helpers
+- Maps each agent-bearing entrypoint to the stable product analytics modes in
+  [`nori-installed`](../installed/docs.md): ordinary and resumed TUI sessions
+  are `interactive`, `nori cloud` is `cloud`, plaintext execution is `exec`, and
+  the stdio facade is `acp`.
 
 ### Core Implementation
+
+[`main.rs`](src/main.rs) constructs an `AnalyticsReporter` only for agent-bearing
+TUI, cloud, plaintext, and ACP-facade routes, then passes it into the owning
+frontend. Help, version, configuration-only, sandbox, and other sessionless
+commands do not create a reportable session. The reporter receives the resolved
+Nori home for durable opt-out state. Authenticated Firebase credentials come
+from the shared user-level `~/.nori-config.json`; the CLI does not derive
+PostHog identity or organization membership itself.
 
 **SeatbeltCommand**: macOS sandbox testing with options:
 - `--full-auto` - Network-disabled sandbox with cwd/TMPDIR write access

--- a/nori-rs/cli/src/main.rs
+++ b/nori-rs/cli/src/main.rs
@@ -11,6 +11,8 @@ use nori_config::NoriConfigOverrides;
 use nori_config::SandboxMode;
 use nori_config::find_nori_home;
 use nori_harness::init_rolling_file_tracing;
+use nori_installed::AnalyticsReporter;
+use nori_installed::SessionMode;
 
 use nori_tui::AppExitInfo;
 use nori_tui::Cli as TuiCli;
@@ -408,7 +410,12 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
             if consumed_stdin {
                 stdin_prompt::restore_stdin_from_terminal();
             }
-            let exit_info = nori_tui::run_main(interactive, codex_linux_sandbox_exe).await?;
+            let exit_info = nori_tui::run_main(
+                interactive,
+                codex_linux_sandbox_exe,
+                analytics_reporter(SessionMode::Interactive),
+            )
+            .await?;
             handle_app_exit(exit_info)?;
         }
         Some(Subcommand::Sandbox(sandbox_args)) => match sandbox_args.cmd {
@@ -463,7 +470,12 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
                 all,
                 config_overrides,
             );
-            let exit_info = nori_tui::run_main(interactive, codex_linux_sandbox_exe).await?;
+            let exit_info = nori_tui::run_main(
+                interactive,
+                codex_linux_sandbox_exe,
+                analytics_reporter(SessionMode::Interactive),
+            )
+            .await?;
             handle_app_exit(exit_info)?;
         }
         Some(Subcommand::Execpolicy(ExecpolicyCommand { sub })) => match sub {
@@ -505,7 +517,12 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
             interactive.cloud_mode = true;
             interactive.cloud_onboard = cloud_cmd.onboard;
 
-            let exit_info = nori_tui::run_main(interactive, codex_linux_sandbox_exe).await?;
+            let exit_info = nori_tui::run_main(
+                interactive,
+                codex_linux_sandbox_exe,
+                analytics_reporter(SessionMode::Cloud),
+            )
+            .await?;
             handle_app_exit(exit_info)?;
         }
         Some(Subcommand::Exec(cmd)) => {
@@ -577,10 +594,18 @@ async fn run_exec(
     let config = nori_config::NoriConfig::load_with_overrides(overrides)?;
     nori_harness::initialize_registry(config.agents.clone())
         .map_err(|error| anyhow::anyhow!("failed to initialize agent registry: {error}"))?;
+    let analytics = AnalyticsReporter::new(
+        if acp {
+            SessionMode::Acp
+        } else {
+            SessionMode::Exec
+        },
+        config.nori_home.clone(),
+    );
     let config = Arc::new(config);
 
     if acp {
-        return nori_exec::run_acp(config, cli_version).await;
+        return nori_exec::run_acp(config, cli_version, Some(analytics)).await;
     }
 
     // Read stdin only after the ACP facade has had its chance to claim it.
@@ -588,7 +613,7 @@ async fn run_exec(
     let Some(prompt) = prompt else {
         anyhow::bail!("a prompt argument or piped stdin is required");
     };
-    let outcome = nori_exec::run_plaintext(config, cli_version, prompt).await?;
+    let outcome = nori_exec::run_plaintext(config, cli_version, prompt, Some(analytics)).await?;
     {
         let mut stdout = std::io::stdout().lock();
         stdout.write_all(outcome.output.as_bytes())?;
@@ -601,6 +626,12 @@ async fn run_exec(
         anyhow::bail!("permission request was rejected during unattended execution");
     }
     Ok(())
+}
+
+fn analytics_reporter(mode: SessionMode) -> Option<AnalyticsReporter> {
+    find_nori_home()
+        .ok()
+        .map(|nori_home| AnalyticsReporter::new(mode, nori_home))
 }
 
 /// Prepend root-level overrides so they have lower precedence than

--- a/nori-rs/cli/tests/analytics.rs
+++ b/nori-rs/cli/tests/analytics.rs
@@ -1,0 +1,388 @@
+#![allow(clippy::expect_used)]
+
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::Read;
+use std::io::Write;
+use std::net::TcpListener;
+use std::net::TcpStream;
+use std::process::Child;
+use std::process::ChildStdin;
+use std::process::Command as StdCommand;
+use std::process::Stdio;
+use std::sync::mpsc;
+use std::time::Duration;
+use std::time::Instant;
+use std::time::SystemTime;
+
+use assert_cmd::Command;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use tempfile::TempDir;
+
+struct CapturedRequest {
+    request_line: String,
+    authorization: Option<String>,
+    body: Value,
+}
+
+fn read_request(mut stream: TcpStream) -> CapturedRequest {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set request timeout");
+    let mut bytes = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    let header_end = loop {
+        let count = stream.read(&mut buffer).expect("read analytics request");
+        assert!(count > 0, "analytics request closed before headers");
+        bytes.extend_from_slice(&buffer[..count]);
+        if let Some(index) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+            break index + 4;
+        }
+    };
+    let headers = String::from_utf8(bytes[..header_end].to_vec()).expect("UTF-8 headers");
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().expect("content length"))
+        })
+        .expect("content-length header");
+    while bytes.len() - header_end < content_length {
+        let count = stream.read(&mut buffer).expect("read analytics body");
+        assert!(count > 0, "analytics request closed before body");
+        bytes.extend_from_slice(&buffer[..count]);
+    }
+    let mut lines = headers.lines();
+    let request_line = lines.next().expect("request line").to_string();
+    let authorization = lines.find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case("authorization")
+            .then(|| value.trim().to_string())
+    });
+    let body = serde_json::from_slice(&bytes[header_end..header_end + content_length])
+        .expect("analytics JSON body");
+    stream
+        .write_all(
+            b"HTTP/1.1 202 Accepted\r\nContent-Type: application/json\r\nContent-Length: 17\r\nConnection: close\r\n\r\n{\"accepted\":true}",
+        )
+        .expect("write analytics response");
+    CapturedRequest {
+        request_line,
+        authorization,
+        body,
+    }
+}
+
+fn analytics_server() -> (String, mpsc::Receiver<CapturedRequest>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind analytics listener");
+    let address = listener.local_addr().expect("analytics listener address");
+    listener
+        .set_nonblocking(true)
+        .expect("nonblocking listener");
+    let (request_tx, request_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    if request_tx.send(read_request(stream)).is_err() {
+                        return;
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("accept analytics request: {error}"),
+            }
+        }
+    });
+    (
+        format!("http://{address}/api/analytics/v1/events"),
+        request_rx,
+    )
+}
+
+fn home_with_auth(username: Option<&str>) -> TempDir {
+    let home = TempDir::new().expect("temporary home");
+    let expires_at = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system clock")
+        .as_millis()
+        + 60_000;
+    if let Some(username) = username {
+        std::fs::write(
+            home.path().join(".nori-config.json"),
+            serde_json::json!({
+                "auth": {
+                    "username": username,
+                    "idToken": "firebase-id-token",
+                    "idTokenExpiresAt": expires_at,
+                }
+            })
+            .to_string(),
+        )
+        .expect("write authenticated config");
+    }
+    home
+}
+
+fn nori_command(home: &TempDir, analytics_url: &str) -> Command {
+    let mut command = Command::cargo_bin("nori").expect("built nori binary");
+    command
+        .env("HOME", home.path())
+        .env("NORI_HOME", home.path().join(".nori/cli"))
+        .env("NORI_ANALYTICS_URL", analytics_url)
+        .env(
+            "MOCK_ACP_AGENT_BIN",
+            std::env::var("MOCK_ACP_AGENT_BIN").expect("MOCK_ACP_AGENT_BIN"),
+        )
+        .env("MOCK_AGENT_ECHO_PROMPT", "1")
+        .args(["--agent", "mock-model"]);
+    command
+}
+
+#[test]
+fn exec_reports_one_authenticated_agent_session_without_changing_output() {
+    let home = home_with_auth(Some("human@example.com"));
+    let (analytics_url, requests) = analytics_server();
+    let output = nori_command(&home, &analytics_url)
+        .args(["exec", "meaningful work"])
+        .output()
+        .expect("run nori exec");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("UTF-8 output"),
+        "meaningful work\n"
+    );
+
+    let request = requests
+        .recv_timeout(Duration::from_secs(3))
+        .expect("authenticated analytics request");
+    assert_eq!(
+        request.request_line,
+        "POST /api/analytics/v1/events HTTP/1.1"
+    );
+    assert_eq!(
+        request.authorization.as_deref(),
+        Some("Bearer firebase-id-token")
+    );
+    assert_eq!(
+        request.body.get("event"),
+        Some(&Value::String("nori_agent_session_started".to_string()))
+    );
+    assert_eq!(
+        request.body.get("product"),
+        Some(&Value::String("nori".to_string()))
+    );
+    assert_eq!(
+        request.body.get("surface"),
+        Some(&Value::String("cli".to_string()))
+    );
+    assert_eq!(
+        request.body.get("properties"),
+        Some(&serde_json::json!({ "session_mode": "exec" }))
+    );
+    let object = request.body.as_object().expect("analytics envelope object");
+    assert_eq!(
+        object
+            .keys()
+            .map(String::as_str)
+            .collect::<std::collections::BTreeSet<_>>(),
+        std::collections::BTreeSet::from([
+            "activity_id",
+            "app_version",
+            "event",
+            "occurred_at",
+            "product",
+            "properties",
+            "schema_version",
+            "surface",
+        ])
+    );
+    assert_eq!(request.body.get("schema_version"), Some(&Value::from(1)));
+    let activity_id = request.body["activity_id"].as_str().expect("activity UUID");
+    assert_eq!(
+        activity_id.split('-').map(str::len).collect::<Vec<_>>(),
+        [8, 4, 4, 4, 12]
+    );
+    assert!(
+        request.body["occurred_at"]
+            .as_str()
+            .is_some_and(|value| value.ends_with('Z'))
+    );
+    assert!(
+        request.body["app_version"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty())
+    );
+    assert!(requests.recv_timeout(Duration::from_millis(400)).is_err());
+}
+
+#[test]
+fn analytics_opt_out_and_ineligible_identities_emit_nothing() {
+    for (username, opt_out) in [
+        (Some("human@example.com"), true),
+        (Some("nori-service:acme"), false),
+        (None, false),
+    ] {
+        let home = home_with_auth(username);
+        let (analytics_url, requests) = analytics_server();
+        let mut command = nori_command(&home, &analytics_url);
+        if opt_out {
+            command.env("NORI_NO_ANALYTICS", "1");
+        }
+        let output = command
+            .args(["exec", "meaningful work"])
+            .output()
+            .expect("run nori exec");
+
+        assert!(output.status.success());
+        assert_eq!(
+            String::from_utf8(output.stdout).expect("UTF-8 output"),
+            "meaningful work\n"
+        );
+        assert!(requests.recv_timeout(Duration::from_millis(400)).is_err());
+    }
+}
+
+#[test]
+fn unavailable_analytics_never_changes_exec_output_or_exit() {
+    let home = home_with_auth(Some("human@example.com"));
+    let started = Instant::now();
+    let output = nori_command(&home, "http://127.0.0.1:9/api/analytics/v1/events")
+        .args(["exec", "meaningful work"])
+        .output()
+        .expect("run nori exec");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("UTF-8 output"),
+        "meaningful work\n"
+    );
+    assert!(started.elapsed() < Duration::from_secs(2));
+}
+
+struct AcpProcess {
+    child: Child,
+    stdin: ChildStdin,
+    messages: mpsc::Receiver<Value>,
+}
+
+impl AcpProcess {
+    fn spawn(home: &TempDir, analytics_url: &str) -> Self {
+        let mut child = StdCommand::new(assert_cmd::cargo::cargo_bin("nori"))
+            .env("HOME", home.path())
+            .env("NORI_HOME", home.path().join(".nori/cli"))
+            .env("NORI_ANALYTICS_URL", analytics_url)
+            .env(
+                "MOCK_ACP_AGENT_BIN",
+                std::env::var("MOCK_ACP_AGENT_BIN").expect("MOCK_ACP_AGENT_BIN"),
+            )
+            .args(["--agent", "mock-model", "exec", "--acp"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn ACP facade");
+        let stdin = child.stdin.take().expect("ACP stdin");
+        let stdout = child.stdout.take().expect("ACP stdout");
+        let (message_tx, messages) = mpsc::channel();
+        std::thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                let value = line
+                    .ok()
+                    .and_then(|line| serde_json::from_str(&line).ok())
+                    .expect("ACP JSON response");
+                if message_tx.send(value).is_err() {
+                    break;
+                }
+            }
+        });
+        Self {
+            child,
+            stdin,
+            messages,
+        }
+    }
+
+    fn send(&mut self, value: Value) {
+        serde_json::to_writer(&mut self.stdin, &value).expect("write ACP request");
+        self.stdin.write_all(b"\n").expect("terminate ACP request");
+        self.stdin.flush().expect("flush ACP request");
+    }
+
+    fn response(&self, id: i64) -> Value {
+        loop {
+            let message = self
+                .messages
+                .recv_timeout(Duration::from_secs(10))
+                .expect("ACP response");
+            if message.get("id") == Some(&Value::from(id)) {
+                return message;
+            }
+        }
+    }
+}
+
+impl Drop for AcpProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn acp_facade_reports_activity_only_after_its_prompt_reaches_the_agent() {
+    let home = home_with_auth(Some("human@example.com"));
+    let (analytics_url, requests) = analytics_server();
+    let mut acp = AcpProcess::spawn(&home, &analytics_url);
+    acp.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": 1,
+            "clientCapabilities": {},
+            "clientInfo": {"name": "analytics-test", "version": "1"}
+        }
+    }));
+    assert_eq!(acp.response(1)["result"]["protocolVersion"], 1);
+    acp.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "session/new",
+        "params": {"cwd": std::env::current_dir().expect("cwd"), "mcpServers": []}
+    }));
+    let session = acp.response(2);
+    let session_id = session["result"]["sessionId"]
+        .as_str()
+        .expect("session id")
+        .to_string();
+    assert!(requests.recv_timeout(Duration::from_millis(300)).is_err());
+
+    acp.send(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "session/prompt",
+        "params": {
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": "meaningful work"}]
+        }
+    }));
+    assert_eq!(acp.response(3)["result"]["stopReason"], "end_turn");
+    let request = requests
+        .recv_timeout(Duration::from_secs(3))
+        .expect("ACP analytics request");
+    assert_eq!(
+        request.body["properties"],
+        serde_json::json!({"session_mode": "acp"})
+    );
+    assert!(requests.recv_timeout(Duration::from_millis(400)).is_err());
+}

--- a/nori-rs/docs.md
+++ b/nori-rs/docs.md
@@ -14,6 +14,7 @@ The production path is layered downward:
 
 ```text
 nori-cli / nori-tui / nori-exec
+        -> nori-installed -> authenticated analytics ingress
         -> nori-harness
         -> nori-acp-host
         -> ACP agent subprocess
@@ -47,6 +48,10 @@ used in production.
   `SessionEvent::{Acp, Nori}`.
 - `nori-config/` owns CLI configuration and the approval, sandbox, MCP, trust,
   and shell-policy types consumed at runtime.
+- `installed/` keeps local installation/launch state and owns the authenticated
+  `nori_agent_session_started` reporter. Frontends attach it to a harness
+  handle so one logical session is counted only after its first prompt reaches
+  ACP; identity and organization expansion remain server-owned.
 - `sandbox/` and the platform crates implement local sandbox debug execution;
   agent tool execution itself occurs in the external ACP agent.
 
@@ -70,6 +75,9 @@ product crates.
 - ACP capabilities describe an agent facade's operations, not whether the
   deployment is local or cloud. The top-level `nori cloud` launch carries that
   identity explicitly into the TUI.
+- Product analytics distinguishes `interactive`, `cloud`, `exec`, and `acp`
+  session modes. Resume is not a mode or event; a resumed interactive session
+  reports only if a new prompt reaches the transport.
 - There are two outward ACP agent surfaces: `nori exec --acp` (a bounded,
   one-session stdio facade) and the remote WebSocket transport (the long-lived
   interactive session, enabled at startup or runtime, loopback by default,

--- a/nori-rs/exec/Cargo.toml
+++ b/nori-rs/exec/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = { workspace = true }
 futures = { workspace = true }
 nori-config = { workspace = true }
 nori-harness = { workspace = true }
+nori-installed = { workspace = true }
 nori-protocol = { workspace = true }
 tokio = { workspace = true, features = ["io-std", "macros", "rt-multi-thread", "sync"] }
 tokio-util = { workspace = true, features = ["compat"] }

--- a/nori-rs/exec/docs.md
+++ b/nori-rs/exec/docs.md
@@ -14,6 +14,9 @@ Path: @/nori-rs/exec
 - Prompt ingestion is entirely a `nori-cli` concern: it composes the argument prompt and any piped stdin into one string and hands `run_plaintext` a fully resolved prompt. `nori-exec` never reads a prompt from the process itself.
 - `nori-exec` prepares and activates sessions through `nori-harness`; it does not spawn agents or reduce ACP state independently.
 - `nori-harness` supplies the ordered `SessionEvent` stream and preserves exact ACP request IDs used for prompt and permission correlation.
+- `nori-installed` supplies the optional authenticated activity reporter. Both
+  execution surfaces attach it to the downstream harness handle, so capture uses
+  the same first-prompt-on-ACP boundary as the interactive frontend.
 - Plaintext mode projects text `agent_message_chunk` updates into one final answer.
 - ACP mode uses the upstream ACP SDK to present an agent endpoint while acting as a client of the configured downstream ACP agent.
 
@@ -22,18 +25,26 @@ Path: @/nori-rs/exec
 - `run_plaintext` passes `AgentPrepareSpec` and the already-chosen
   `SessionStart::New` to `prepare_and_launch_session`, submits one text prompt,
   collects text chunks until the correlated prompt response, and shuts down the
-  session.
+  session. When supplied, its reporter emits `nori_agent_session_started` with
+  `session_mode = exec` after that prompt receives a downstream wire request ID,
+  then performs a bounded final flush without changing the plaintext outcome.
 - Unattended permission requests are rejected immediately using a schema-provided reject option, with cancellation as the safe fallback.
 - `run_acp` handles standard `initialize`, `session/new`,
   `session/set_config_option`, `session/prompt`, and `session/cancel` traffic
   over line-delimited JSON-RPC stdio. Its downstream `session/new` also uses
-  `prepare_and_launch_session` with the explicit New choice.
+  `prepare_and_launch_session` with the explicit New choice. The facade assigns
+  `session_mode = acp`; initialization and `session/new` alone are silent, and
+  the attached reporter fires only after the facade's accepted `session/prompt`
+  reaches the downstream ACP transport.
 - The ACP facade exposes the downstream session ID and effective configuration options, then emits one complete `agent_message_chunk` before the correlated prompt response.
 - Delegated permission requests are forwarded to the upstream ACP caller and their responses are returned to the downstream agent under the original downstream request ID.
 
 ### Things to Know
 
 - The facade is intentionally bounded to one downstream session and one prompt per process.
+- Analytics is optional at this crate boundary. The binary selects the mode and
+  constructs the reporter; embedders that pass `None` retain identical session
+  behavior without capture.
 - Both headless surfaces choose `SessionStart::New` before activation and use
   `prepare_and_launch_session`. Preparation and activation retain one
   downstream subprocess even though the API keeps those lifecycle phases

--- a/nori-rs/exec/src/lib.rs
+++ b/nori-rs/exec/src/lib.rs
@@ -20,6 +20,7 @@ use nori_harness::runtime::AgentPrepareSpec;
 use nori_harness::runtime::HarnessHandle;
 use nori_harness::runtime::SessionStart;
 use nori_harness::runtime::prepare_and_launch_session;
+use nori_installed::AnalyticsReporter;
 use nori_protocol::AcpEvent;
 use nori_protocol::NoriEvent;
 use nori_protocol::SessionEvent;
@@ -42,6 +43,7 @@ pub async fn run_plaintext(
     config: Arc<NoriConfig>,
     cli_version: String,
     prompt: String,
+    analytics: Option<AnalyticsReporter>,
 ) -> anyhow::Result<PlaintextOutcome> {
     let mut launched = prepare_and_launch_session(
         AgentPrepareSpec {
@@ -52,6 +54,9 @@ pub async fn run_plaintext(
         },
         SessionStart::New,
     );
+    if let Some(reporter) = analytics.as_ref() {
+        launched.handle = reporter.attach(launched.handle);
+    }
     let request_id = launched
         .handle
         .prompt(vec![acp::ContentBlock::Text(acp::TextContent::new(prompt))])
@@ -65,7 +70,7 @@ pub async fn run_plaintext(
     )
     .await;
     let shutdown_result = launched.handle.shutdown().await;
-    match result {
+    let outcome = match result {
         Ok(result) => {
             shutdown_result?;
             Ok(PlaintextOutcome {
@@ -74,7 +79,11 @@ pub async fn run_plaintext(
             })
         }
         Err(error) => Err(error),
+    };
+    if let Some(reporter) = analytics {
+        reporter.flush();
     }
+    outcome
 }
 
 #[derive(Clone, Copy)]
@@ -207,6 +216,7 @@ struct FacadeSession {
 struct FacadeState {
     base_config: Arc<NoriConfig>,
     cli_version: String,
+    analytics: Option<AnalyticsReporter>,
     session: Option<FacadeSession>,
 }
 
@@ -255,10 +265,15 @@ impl<R: AsyncRead + Unpin> AsyncRead for ErrorOnEof<R> {
 }
 
 /// Serve a bounded ACP agent facade over stdin/stdout.
-pub async fn run_acp(config: Arc<NoriConfig>, cli_version: String) -> anyhow::Result<()> {
+pub async fn run_acp(
+    config: Arc<NoriConfig>,
+    cli_version: String,
+    analytics: Option<AnalyticsReporter>,
+) -> anyhow::Result<()> {
     let state = Arc::new(Mutex::new(FacadeState {
         base_config: config,
         cli_version,
+        analytics: analytics.clone(),
         session: None,
     }));
 
@@ -287,12 +302,16 @@ pub async fn run_acp(config: Arc<NoriConfig>, cli_version: String) -> anyhow::Re
                     {
                         return responder.respond_with_error(acp::Error::invalid_params());
                     }
-                    let (mut config, cli_version) = {
+                    let (mut config, cli_version, analytics) = {
                         let state = state.lock().await;
                         if state.session.is_some() {
                             return responder.respond_with_error(acp::Error::invalid_params());
                         }
-                        ((*state.base_config).clone(), state.cli_version.clone())
+                        (
+                            (*state.base_config).clone(),
+                            state.cli_version.clone(),
+                            state.analytics.clone(),
+                        )
                     };
                     config.cwd = request.cwd;
                     let mut launched = prepare_and_launch_session(
@@ -304,6 +323,9 @@ pub async fn run_acp(config: Arc<NoriConfig>, cli_version: String) -> anyhow::Re
                         },
                         SessionStart::New,
                     );
+                    if let Some(reporter) = analytics.as_ref() {
+                        launched.handle = reporter.attach(launched.handle);
+                    }
                     let session_id = loop {
                         match launched.events.recv().await {
                             Some(SessionEvent::Nori(NoriEvent::SessionStarted(started))) => {
@@ -477,6 +499,9 @@ pub async fn run_acp(config: Arc<NoriConfig>, cli_version: String) -> anyhow::Re
     if let Some(handle) = handle {
         let _ = handle.cancel().await;
         let _ = handle.shutdown().await;
+    }
+    if let Some(reporter) = analytics {
+        reporter.flush();
     }
     if eof.load(Ordering::SeqCst) {
         Ok(())

--- a/nori-rs/harness/docs.md
+++ b/nori-rs/harness/docs.md
@@ -153,6 +153,16 @@ responses: a frontend that did not submit the turn can render and flush the
 complete stream without claiming the initiating request or receiving its stop
 reason.
 
+[`HarnessHandle::with_first_prompt_started_callback`](src/runtime.rs) exposes
+that same transport boundary to product infrastructure without adding an ACP or
+Nori protocol event. A decorated handle invokes its callback once, after its
+first successful [`prompt`](src/runtime.rs) call receives the real downstream
+wire request ID. Clones share the one-shot guard, so concurrent or repeated
+prompts cannot duplicate the callback. A prompt rejected before transport does
+not fire it. Nori's frontends use this hook for authenticated activity reporting
+through [`nori-installed`](../installed/docs.md); the harness remains unaware of
+identity, event schemas, and network delivery.
+
 The public event stream has two source-owned branches:
 
 ```rust

--- a/nori-rs/harness/src/runtime.rs
+++ b/nori-rs/harness/src/runtime.rs
@@ -184,12 +184,44 @@ enum HarnessCommand {
 }
 
 /// Typed handle for controlling one Nori harness session.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct HarnessHandle {
     command_tx: mpsc::UnboundedSender<HarnessCommand>,
+    first_prompt_started: Option<Arc<FirstPromptStarted>>,
+}
+
+struct FirstPromptStarted {
+    fired: std::sync::atomic::AtomicBool,
+    callback: Box<dyn Fn() + Send + Sync>,
+}
+
+impl std::fmt::Debug for HarnessHandle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("HarnessHandle")
+            .field("command_tx", &self.command_tx)
+            .field(
+                "has_first_prompt_started_callback",
+                &self.first_prompt_started.is_some(),
+            )
+            .finish()
+    }
 }
 
 impl HarnessHandle {
+    /// Attach a callback that fires once, after this session's first prompt
+    /// reaches the ACP transport and receives its wire request id.
+    pub fn with_first_prompt_started_callback(
+        mut self,
+        callback: impl Fn() + Send + Sync + 'static,
+    ) -> Self {
+        self.first_prompt_started = Some(Arc::new(FirstPromptStarted {
+            fired: std::sync::atomic::AtomicBool::new(false),
+            callback: Box::new(callback),
+        }));
+        self
+    }
+
     /// Submit a prompt and return the ACP request ID used on the wire.
     pub async fn prompt(
         &self,
@@ -231,9 +263,17 @@ impl HarnessHandle {
                 response_tx,
             })
             .map_err(|_| anyhow::anyhow!("ACP agent command channel closed"))?;
-        response_rx
+        let request_id = response_rx
             .await
-            .map_err(|_| anyhow::anyhow!("ACP agent did not accept the prompt"))?
+            .map_err(|_| anyhow::anyhow!("ACP agent did not accept the prompt"))??;
+        if let Some(first_prompt_started) = &self.first_prompt_started
+            && !first_prompt_started
+                .fired
+                .swap(true, std::sync::atomic::Ordering::AcqRel)
+        {
+            (first_prompt_started.callback)();
+        }
+        Ok(request_id)
     }
 
     /// Shut down the active harness session.
@@ -681,6 +721,7 @@ fn launch_session_from(source: SessionAgentSource, start: SessionStart) -> Launc
 
     let handle = HarnessHandle {
         command_tx: agent_cmd_tx,
+        first_prompt_started: None,
     };
 
     tokio::spawn(async move {
@@ -1049,7 +1090,10 @@ mod tests {
                 }
             }
         });
-        let handle = HarnessHandle { command_tx };
+        let handle = HarnessHandle {
+            command_tx,
+            first_prompt_started: None,
+        };
 
         let config_options = handle
             .set_session_config_option("mode".to_string(), "build".to_string())
@@ -1057,5 +1101,37 @@ mod tests {
             .unwrap();
 
         assert_eq!(config_options, vec![mode_option("build")]);
+    }
+
+    #[tokio::test]
+    async fn first_prompt_callback_fires_once_across_cloned_handles() {
+        let (command_tx, mut command_rx) = unbounded_channel::<HarnessCommand>();
+        tokio::spawn(async move {
+            let mut request_id = 0_i64;
+            while let Some(command) = command_rx.recv().await {
+                if let HarnessCommand::Prompt { response_tx, .. } = command {
+                    request_id += 1;
+                    let _ = response_tx.send(Ok(request_id.into()));
+                }
+            }
+        });
+        let callback_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let callback_count_for_handle = Arc::clone(&callback_count);
+        let handle = HarnessHandle {
+            command_tx,
+            first_prompt_started: None,
+        }
+        .with_first_prompt_started_callback(move || {
+            callback_count_for_handle.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        });
+        let cloned_handle = handle.clone();
+
+        handle.prompt(Vec::new()).await.expect("first prompt");
+        cloned_handle
+            .prompt(Vec::new())
+            .await
+            .expect("second prompt");
+
+        assert_eq!(callback_count.load(std::sync::atomic::Ordering::SeqCst), 1);
     }
 }

--- a/nori-rs/installed/Cargo.toml
+++ b/nori-rs/installed/Cargo.toml
@@ -16,15 +16,20 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
+dirs = { workspace = true }
 nori-harness = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest13 = { package = "reqwest", version = "0.13", default-features = false, features = [
+    "form",
+    "json",
+    "rustls",
+] }
 semver = "1"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true, features = ["fs", "rt", "time"] }
 tracing = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/nori-rs/installed/docs.md
+++ b/nori-rs/installed/docs.md
@@ -4,40 +4,99 @@ Path: @/nori-rs/installed
 
 ### Overview
 
-The installed crate tracks CLI lifecycle events for analytics purposes. It maintains a state file (`~/.nori/cli/.nori-install.json`) that records installation date, version history, and session information.
+- The installed crate persists local Nori CLI installation and launch state in
+  `$NORI_HOME/.nori-install.json` and exposes the authenticated product-analytics
+  reporter used by the CLI frontends.
+- Local launch classification and network analytics are separate paths:
+  [`track_launch`](src/lib.rs) updates installation state, while
+  [`AnalyticsReporter`](src/analytics.rs) reports meaningful agent activity only
+  after a prompt reaches the ACP transport.
 
 ### How it fits into the larger codebase
 
-Called early in `@/nori-rs/tui/` startup via `track_launch()`. This is a non-blocking, fire-and-forget operation that never delays CLI startup.
+```text
+nori-cli / nori-exec / nori-tui
+              │ SessionMode + AnalyticsReporter
+              v
+         nori-installed
+        /              \
+install-state JSON      authenticated v1 envelope
+                              │ Firebase bearer token
+                              v
+           login.norisessions.com/api/analytics/v1/events
+                              │
+                              v
+                 Sessions OAuth proxy -> PostHog
+```
+
+- [`@/nori-rs/cli`](../cli/docs.md) assigns the public session mode:
+  `interactive`, `cloud`, `exec`, or `acp`.
+- [`@/nori-rs/exec`](../exec/docs.md) and [`@/nori-rs/tui`](../tui/docs.md)
+  attach the reporter to each launched [`HarnessHandle`](../harness/docs.md).
+  A logical session therefore owns its own one-shot activity boundary even when
+  one TUI process launches more than one agent session.
+- The shared login configuration at `~/.nori-config.json` supplies Firebase
+  credentials. Current files use nested `auth.username`, `auth.idToken`,
+  `auth.idTokenExpiresAt`, and `auth.refreshToken`. Legacy files with top-level
+  `username` and `refreshToken` remain readable; when an `auth` object is
+  present it is authoritative and the flat values are ignored. Identity and
+  organization properties are not constructed in this crate; the authenticated
+  ingress owns canonical email identity and organization expansion.
+- The binding event contract and server-side identity rules live in the
+  [monorepo analytics specification](https://github.com/tilework-tech/nori-monorepo/blob/main/docs/analytics.md).
+- Existing Registrar support for older `noricli_*` payloads remains a server-side
+  compatibility boundary. New releases do not emit that legacy format.
 
 ### Core Implementation
 
-**State Management** (`state.rs`): The `InstallState` struct persists:
-- `client_id` - Anonymous UUID for analytics
-- `installed_version` - Current CLI version
-- `first_installed_at` - Original installation timestamp
-- `last_launched_at` - Most recent session timestamp
-- `opt_out` - Analytics opt-out flag
-
-**Launch Detection** (`lib.rs`): `track_launch_inner()` determines:
-- `AppInstall` - First time installation
-- `AppUpdate` - Version change (upgrade or downgrade)
-- `SessionStart` - Normal session
-- `UserResurrected` - User returned after 30+ day absence
-
-**Analytics** (`analytics.rs`): Sends events to analytics endpoint:
-- `InstallDetected`
-- `SessionStart`
-- `UserResurrected`
-
-**Install Source Detection** (`detection.rs`): Detects installation method (npm, binary, etc.) for analytics segmentation.
+- [`state.rs`](src/state.rs) persists the anonymous client UUID, installed
+  version, first-install time, last-launch time, install source, schema version,
+  and durable analytics opt-out. [`track_launch_inner`](src/lib.rs) classifies
+  first install, version change, ordinary session, and return after a long
+  absence, then writes the updated state. Those classifications remain local
+  lifecycle state and do not send network events.
+- [`AnalyticsReporter::attach`](src/analytics.rs) decorates one harness handle
+  with a callback. The harness invokes it once only after the first accepted user
+  prompt has acquired its real ACP wire request ID. Merely launching, preparing,
+  listing, or resuming a session does not report activity.
+- The reporter sends `nori_agent_session_started` with `product = "nori"`,
+  `surface = "cli"`, and the exact required `session_mode`. The v1 envelope also
+  carries the released application version, a per-activity UUID, and a UTC
+  timestamp. It does not carry prompts, paths, agent names, raw arguments,
+  client-selected identity, or organization data.
+- A currently valid nested `idToken` is used directly. When it is absent or
+  expired and a nested or legacy flat refresh token exists,
+  [`refresh_id_token`](src/analytics.rs) exchanges that token with Firebase
+  before posting the event. Missing configuration, malformed human identity,
+  and `nori-service:*` identities produce no request.
+- Production release builds default to
+  `https://login.norisessions.com/api/analytics/v1/events`. Debug builds send
+  only when `NORI_ANALYTICS_URL` supplies an explicit endpoint, which is also the
+  local test/development override.
+- Capture asks [`std::thread::Builder`](src/analytics.rs) for a named background
+  thread with its own current-thread Tokio runtime. Only a successfully spawned
+  worker is registered for the final flush; thread-creation failure is discarded
+  like every other analytics failure. The request and final
+  [`AnalyticsReporter::flush`](src/analytics.rs) share a 250 ms bound, so read,
+  refresh, serialization, transport, and response errors cannot change command
+  output or exit status.
 
 ### Things to Know
 
-- Analytics can be disabled via `NORI_ANALYTICS_OPT_OUT=1` environment variable
-- Analytics are automatically skipped in CI environments
-- The client ID is a UUID (legacy IDs like "nori-cli" are migrated)
-- State file uses JSON format with schema versioning
-- All errors are silently logged at debug level to avoid impacting CLI startup
+- `NORI_NO_ANALYTICS=1` and the durable `opt_out` value in
+  `$NORI_HOME/.nori-install.json` both disable authenticated capture. CI also
+  skips capture unless an explicit `NORI_ANALYTICS_URL` is supplied.
+- The event is once per logical agent session, not once per process and not once
+  per prompt. A second prompt on the same attached handle is silent; a newly
+  launched handle can report its own first transported prompt.
+- Resume is not a session mode or a separate event. A resumed session contributes
+  activity only when its first prompt in the current logical session reaches the
+  ACP transport, using the frontend's `interactive` mode.
+- [`analytics.rs`](src/analytics.rs) uses its explicitly named `reqwest` 0.13
+  dependency for the JSON ingress and Firebase form exchange. The workspace's
+  existing ACP/OAuth HTTP paths remain on `reqwest` 0.12.
+- The persisted anonymous client UUID remains for installation-state and legacy
+  compatibility purposes. It is not sent in the authenticated v1 envelope and
+  is not used as the authenticated PostHog identity.
 
 Created and maintained by Nori.

--- a/nori-rs/installed/src/analytics.rs
+++ b/nori-rs/installed/src/analytics.rs
@@ -1,145 +1,318 @@
-//! Analytics event sending
-//!
-//! Provides fire-and-forget analytics event sending for install tracking.
+//! Authenticated product analytics for meaningful Nori agent sessions.
 
-use crate::state::InstallSource;
-use crate::state::InstallState;
-use chrono::DateTime;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::mpsc;
+use std::time::Duration;
+use std::time::Instant;
+use std::time::SystemTime;
+
 use chrono::SecondsFormat;
 use chrono::Utc;
+use serde::Deserialize;
 use serde::Serialize;
+use uuid::Uuid;
 
-/// Default analytics endpoint URL (only used in release builds)
-#[cfg(not(debug_assertions))]
-const DEFAULT_ANALYTICS_URL: &str = "https://noriskillsets.dev/api/analytics/track";
+use crate::read_install_state;
 
-/// Environment variable to override the analytics URL (only used in release builds)
-#[cfg(not(debug_assertions))]
-const ANALYTICS_URL_ENV: &str = "NORI_ANALYTICS_URL";
-
-/// Environment variable to opt out of analytics
 pub const ANALYTICS_OPT_OUT_ENV: &str = "NORI_NO_ANALYTICS";
 
-const EXECUTABLE_NAME: &str = "nori-ai-cli";
+const ANALYTICS_URL_ENV: &str = "NORI_ANALYTICS_URL";
+const DEFAULT_ANALYTICS_URL: &str = "https://login.norisessions.com/api/analytics/v1/events";
+const FIREBASE_TOKEN_URL: &str =
+    "https://securetoken.googleapis.com/v1/token?key=AIzaSyC54HqlGrkyANVFKGDQi3LobO5moDOuafk";
+const REQUEST_DEADLINE: Duration = Duration::from_millis(250);
 
-/// Analytics event types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AnalyticsEventType {
-    InstallDetected,
-    SessionStart,
-    UserResurrected,
+pub enum SessionMode {
+    Interactive,
+    Cloud,
+    Exec,
+    Acp,
 }
 
-impl AnalyticsEventType {
-    pub fn as_str(self) -> &'static str {
+impl SessionMode {
+    fn as_str(self) -> &'static str {
         match self {
-            AnalyticsEventType::InstallDetected => "noricli_install_detected",
-            AnalyticsEventType::SessionStart => "noricli_session_started",
-            AnalyticsEventType::UserResurrected => "noricli_user_resurrected",
+            Self::Interactive => "interactive",
+            Self::Cloud => "cloud",
+            Self::Exec => "exec",
+            Self::Acp => "acp",
         }
     }
 }
 
-/// Analytics event request payload
-#[derive(Debug, Clone, Serialize)]
-pub struct TrackEventRequest {
-    pub client_id: String,
-    pub user_id: String,
-    pub event_name: String,
-    pub event_params: serde_json::Value,
+#[derive(Clone)]
+pub struct AnalyticsReporter {
+    inner: Arc<ReporterInner>,
 }
 
-pub fn create_event(
-    event_type: AnalyticsEventType,
-    state: &InstallState,
-    session_id: &str,
-    timestamp: DateTime<Utc>,
-    days_since_install: i64,
-    is_first_install: bool,
-    previous_version: Option<String>,
-) -> TrackEventRequest {
-    let mut params = base_event_params(state, session_id, timestamp, days_since_install);
-    if event_type == AnalyticsEventType::InstallDetected {
-        params["tilework_cli_is_first_install"] = serde_json::Value::Bool(is_first_install);
-        if let Some(prev) = previous_version {
-            params["tilework_cli_previous_version"] = serde_json::Value::String(prev);
+struct ReporterInner {
+    mode: SessionMode,
+    nori_home: PathBuf,
+    config_root: Option<PathBuf>,
+    pending: Mutex<Vec<mpsc::Receiver<()>>>,
+}
+
+impl std::fmt::Debug for AnalyticsReporter {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AnalyticsReporter")
+            .field("mode", &self.inner.mode)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AnalyticsReporter {
+    pub fn new(mode: SessionMode, nori_home: PathBuf) -> Self {
+        Self {
+            inner: Arc::new(ReporterInner {
+                mode,
+                nori_home,
+                config_root: dirs::home_dir(),
+                pending: Mutex::new(Vec::new()),
+            }),
         }
     }
 
-    TrackEventRequest {
-        client_id: state.client_id.clone(),
-        user_id: state.client_id.clone(),
-        event_name: event_type.as_str().to_string(),
-        event_params: params,
+    pub fn attach(
+        &self,
+        handle: nori_harness::runtime::HarnessHandle,
+    ) -> nori_harness::runtime::HarnessHandle {
+        let reporter = self.clone();
+        handle.with_first_prompt_started_callback(move || reporter.capture_session_started())
     }
-}
 
-fn base_event_params(
-    state: &InstallState,
-    session_id: &str,
-    timestamp: DateTime<Utc>,
-    days_since_install: i64,
-) -> serde_json::Value {
-    serde_json::json!({
-        // Required tilework_* fields (no cli_ prefix)
-        "tilework_source": "nori-cli",
-        "tilework_session_id": session_id,
-        "tilework_timestamp": timestamp.to_rfc3339_opts(SecondsFormat::Millis, true),
-        // CLI-specific fields (tilework_cli_* prefix)
-        "tilework_cli_executable_name": EXECUTABLE_NAME,
-        "tilework_cli_installed_version": state.installed_version.as_str(),
-        "tilework_cli_install_source": install_source_to_string(state.install_source),
-        "tilework_cli_days_since_install": days_since_install,
-        "tilework_cli_os": std::env::consts::OS,
-        "tilework_cli_arch": std::env::consts::ARCH,
-    })
-}
-
-fn install_source_to_string(source: InstallSource) -> &'static str {
-    match source {
-        InstallSource::Npm => "npm",
-        InstallSource::Bun => "bun",
-        InstallSource::Unknown => "unknown",
+    pub fn flush(&self) {
+        let receivers = self
+            .inner
+            .pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .drain(..)
+            .collect::<Vec<_>>();
+        let deadline = Instant::now() + REQUEST_DEADLINE;
+        for receiver in receivers {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() || receiver.recv_timeout(remaining).is_err() {
+                break;
+            }
+        }
     }
-}
 
-/// Send an analytics event to the backend (release builds only).
-///
-/// In release builds, sends the event via HTTP POST to the analytics endpoint.
-/// Failures are silently ignored (fire-and-forget).
-///
-/// In debug builds, this is a no-op to avoid noise from development and testing.
-#[cfg(not(debug_assertions))]
-pub async fn send_event(event: &TrackEventRequest) {
-    let url =
-        std::env::var(ANALYTICS_URL_ENV).unwrap_or_else(|_| DEFAULT_ANALYTICS_URL.to_string());
-
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build();
-
-    let client = match client {
-        Ok(c) => c,
-        Err(_) => {
+    fn capture_session_started(&self) {
+        let Some(endpoint) = analytics_endpoint() else {
             return;
+        };
+        let mode = self.inner.mode;
+        let nori_home = self.inner.nori_home.clone();
+        let config_root = self.inner.config_root.clone();
+        let (completion_tx, completion_rx) = mpsc::channel();
+        let spawned = std::thread::Builder::new()
+            .name("nori-analytics".to_string())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build();
+                if let Ok(runtime) = runtime {
+                    let _ = runtime.block_on(async {
+                        tokio::time::timeout(
+                            REQUEST_DEADLINE,
+                            send_session_started(
+                                mode,
+                                &nori_home,
+                                config_root.as_deref(),
+                                &endpoint,
+                            ),
+                        )
+                        .await
+                    });
+                }
+                let _ = completion_tx.send(());
+            });
+        if spawned.is_ok() {
+            self.inner
+                .pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(completion_rx);
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ConfigFile {
+    auth: Option<AuthSection>,
+    username: Option<String>,
+    #[serde(rename = "refreshToken")]
+    refresh_token: Option<String>,
+}
+
+impl ConfigFile {
+    fn effective_auth(self) -> Option<AuthSection> {
+        self.auth.or_else(|| {
+            (self.username.is_some() || self.refresh_token.is_some()).then_some(AuthSection {
+                username: self.username,
+                id_token: None,
+                id_token_expires_at: None,
+                refresh_token: self.refresh_token,
+            })
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AuthSection {
+    username: Option<String>,
+    #[serde(rename = "idToken")]
+    id_token: Option<String>,
+    #[serde(rename = "idTokenExpiresAt")]
+    id_token_expires_at: Option<i64>,
+    #[serde(rename = "refreshToken")]
+    refresh_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RefreshResponse {
+    id_token: String,
+}
+
+#[derive(Debug, Serialize)]
+struct AnalyticsEnvelope<'a> {
+    schema_version: i64,
+    event: &'static str,
+    activity_id: Uuid,
+    occurred_at: String,
+    product: &'static str,
+    surface: &'static str,
+    app_version: &'static str,
+    properties: SessionProperties<'a>,
+}
+
+#[derive(Debug, Serialize)]
+struct SessionProperties<'a> {
+    session_mode: &'a str,
+}
+
+async fn send_session_started(
+    mode: SessionMode,
+    nori_home: &Path,
+    config_root: Option<&Path>,
+    endpoint: &str,
+) -> anyhow::Result<()> {
+    if should_skip_analytics(nori_home) {
+        return Ok(());
+    }
+    let Some(config_root) = config_root else {
+        return Ok(());
+    };
+    let raw = tokio::fs::read_to_string(config_root.join(".nori-config.json")).await?;
+    let Some(auth) = serde_json::from_str::<ConfigFile>(&raw)?.effective_auth() else {
+        return Ok(());
+    };
+    let username = auth.username.as_deref().map(str::trim).unwrap_or_default();
+    if !is_human_username(username) {
+        return Ok(());
+    }
+
+    let client = reqwest13::Client::builder()
+        .timeout(REQUEST_DEADLINE)
+        .build()?;
+    let token = match fresh_id_token(&auth) {
+        Some(token) => token.to_string(),
+        None => {
+            let Some(refresh_token) = auth
+                .refresh_token
+                .as_deref()
+                .filter(|token| !token.is_empty())
+            else {
+                return Ok(());
+            };
+            refresh_id_token(&client, refresh_token, FIREBASE_TOKEN_URL).await?
         }
     };
-
-    let _ = client.post(&url).json(event).send().await;
+    let envelope = AnalyticsEnvelope {
+        schema_version: 1,
+        event: "nori_agent_session_started",
+        activity_id: Uuid::new_v4(),
+        occurred_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+        product: "nori",
+        surface: "cli",
+        app_version: crate::CLI_VERSION,
+        properties: SessionProperties {
+            session_mode: mode.as_str(),
+        },
+    };
+    let _ = client
+        .post(endpoint)
+        .bearer_auth(token)
+        .json(&envelope)
+        .send()
+        .await?;
+    Ok(())
 }
 
-/// No-op analytics sending for debug builds.
-#[cfg(debug_assertions)]
-pub async fn send_event(event: &TrackEventRequest) {
-    tracing::debug!(
-        "Analytics event skipped (debug build): {}",
-        event.event_name
-    );
+fn analytics_endpoint() -> Option<String> {
+    if let Ok(endpoint) = std::env::var(ANALYTICS_URL_ENV)
+        && !endpoint.is_empty()
+    {
+        return Some(endpoint);
+    }
+    if cfg!(debug_assertions) {
+        None
+    } else {
+        Some(DEFAULT_ANALYTICS_URL.to_string())
+    }
 }
 
-/// Check if running in a CI environment.
-///
-/// Returns true if CI environment variable is set to a truthy value.
+fn should_skip_analytics(nori_home: &Path) -> bool {
+    if std::env::var(ANALYTICS_OPT_OUT_ENV).as_deref() == Ok("1") {
+        return true;
+    }
+    if read_install_state(nori_home).is_some_and(|state| state.opt_out) {
+        return true;
+    }
+    is_ci_env() && std::env::var_os(ANALYTICS_URL_ENV).is_none()
+}
+
+fn is_human_username(username: &str) -> bool {
+    username.contains('@') && !username.to_ascii_lowercase().starts_with("nori-service:")
+}
+
+fn fresh_id_token(auth: &AuthSection) -> Option<&str> {
+    let expires_at = auth.id_token_expires_at?;
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .ok()?
+        .as_millis();
+    let now = i64::try_from(now).ok()?;
+    (expires_at > now)
+        .then_some(auth.id_token.as_deref())
+        .flatten()
+        .filter(|token| !token.is_empty())
+}
+
+async fn refresh_id_token(
+    client: &reqwest13::Client,
+    refresh_token: &str,
+    endpoint: &str,
+) -> anyhow::Result<String> {
+    let response = client
+        .post(endpoint)
+        .form(&[
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token),
+        ])
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<RefreshResponse>()
+        .await?;
+    Ok(response.id_token)
+}
+
 pub fn is_ci_env() -> bool {
     std::env::var("CI")
         .map(|value| value != "0" && !value.is_empty())
@@ -148,179 +321,75 @@ pub fn is_ci_env() -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Read;
+    use std::io::Write;
+    use std::net::TcpListener;
+
     use super::*;
-    use chrono::TimeZone;
     use pretty_assertions::assert_eq;
 
-    fn create_test_state() -> InstallState {
-        let now = Utc.with_ymd_and_hms(2025, 1, 15, 10, 30, 0).unwrap();
-        InstallState::new_first_install(
-            "c4f24cc9-acde-4d20-87e1-1d6bfa8e7a67".to_string(),
-            "1.0.0".to_string(),
-            InstallSource::Bun,
-            now,
-        )
+    #[test]
+    fn human_identity_gate_excludes_service_and_malformed_names() {
+        assert!(is_human_username("person@example.com"));
+        assert!(!is_human_username("nori-service:acme"));
+        assert!(!is_human_username("not-an-email"));
     }
 
     #[test]
-    fn test_create_install_detected_event_first_install() {
-        let state = create_test_state();
-        let now = Utc.with_ymd_and_hms(2025, 1, 15, 10, 30, 0).unwrap();
-        let event = create_event(
-            AnalyticsEventType::InstallDetected,
-            &state,
-            "1737373800",
-            now,
-            0,
-            true,
-            None,
-        );
+    fn config_prefers_nested_auth_credentials() {
+        let config = serde_json::from_value::<ConfigFile>(serde_json::json!({
+            "auth": {
+                "username": "nested@example.com",
+                "refreshToken": "nested-refresh"
+            },
+            "username": "legacy@example.com",
+            "refreshToken": "legacy-refresh"
+        }))
+        .expect("parse config");
 
-        assert_eq!(event.event_name, "noricli_install_detected");
-        assert_eq!(event.client_id, state.client_id);
-        assert_eq!(event.user_id, state.client_id);
-
-        let params = &event.event_params;
-        // Required tilework_* fields
-        assert_eq!(params["tilework_source"], "nori-cli");
-        assert_eq!(params["tilework_session_id"], "1737373800");
-        assert!(
-            params["tilework_timestamp"]
-                .as_str()
-                .unwrap()
-                .contains("2025-01-15")
-        );
-
-        // CLI-specific fields
-        assert_eq!(params["tilework_cli_install_source"], "bun");
-        assert_eq!(params["tilework_cli_installed_version"], "1.0.0");
-        assert_eq!(params["tilework_cli_is_first_install"], true);
-        assert_eq!(params["tilework_cli_days_since_install"], 0);
-        assert_eq!(params["tilework_cli_executable_name"], "nori-ai-cli");
-        assert!(params.get("tilework_cli_previous_version").is_none());
-
-        // Removed fields should NOT be present
-        assert!(params.get("tilework_cli_user_id").is_none());
+        let auth = config.effective_auth().expect("effective auth");
+        assert_eq!(auth.username.as_deref(), Some("nested@example.com"));
+        assert_eq!(auth.refresh_token.as_deref(), Some("nested-refresh"));
     }
 
     #[test]
-    fn test_create_install_detected_event_upgrade() {
-        let mut state = create_test_state();
-        state.installed_version = "2.0.0".to_string();
-        state.install_source = InstallSource::Npm;
+    fn config_accepts_legacy_top_level_credentials() {
+        let config = serde_json::from_value::<ConfigFile>(serde_json::json!({
+            "username": "legacy@example.com",
+            "refreshToken": "legacy-refresh"
+        }))
+        .expect("parse config");
 
-        let now = Utc.with_ymd_and_hms(2025, 1, 20, 10, 30, 0).unwrap();
-        let event = create_event(
-            AnalyticsEventType::InstallDetected,
-            &state,
-            "1737373800",
-            now,
-            5,
-            false,
-            Some("1.0.0".to_string()),
-        );
-
-        let params = &event.event_params;
-        // Required tilework_* fields
-        assert_eq!(params["tilework_source"], "nori-cli");
-        assert_eq!(params["tilework_session_id"], "1737373800");
-
-        // CLI-specific fields
-        assert_eq!(params["tilework_cli_install_source"], "npm");
-        assert_eq!(params["tilework_cli_installed_version"], "2.0.0");
-        assert_eq!(params["tilework_cli_is_first_install"], false);
-        assert_eq!(params["tilework_cli_previous_version"], "1.0.0");
-        assert_eq!(params["tilework_cli_days_since_install"], 5);
-
-        // Removed fields should NOT be present
-        assert!(params.get("tilework_cli_user_id").is_none());
+        let auth = config.effective_auth().expect("effective auth");
+        assert_eq!(auth.username.as_deref(), Some("legacy@example.com"));
+        assert_eq!(auth.refresh_token.as_deref(), Some("legacy-refresh"));
+        assert_eq!(auth.id_token.as_deref(), None);
+        assert_eq!(auth.id_token_expires_at, None);
     }
 
-    #[test]
-    fn test_create_session_start_event() {
-        let state = create_test_state();
-        let now = Utc.with_ymd_and_hms(2025, 1, 20, 10, 30, 0).unwrap();
-        let event = create_event(
-            AnalyticsEventType::SessionStart,
-            &state,
-            "1737373800",
-            now,
-            5,
-            false,
-            None,
-        );
+    #[tokio::test]
+    async fn refresh_token_exchange_returns_a_firebase_id_token() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind token endpoint");
+        let endpoint = format!("http://{}", listener.local_addr().expect("token address"));
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept token request");
+            let mut request = vec![0_u8; 4096];
+            let count = stream.read(&mut request).expect("read token request");
+            let request = String::from_utf8_lossy(&request[..count]);
+            assert!(request.starts_with("POST / HTTP/1.1"));
+            assert!(request.contains("grant_type=refresh_token&refresh_token=refresh-value"));
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 30\r\nConnection: close\r\n\r\n{\"id_token\":\"refreshed-token\"}",
+                )
+                .expect("write token response");
+        });
 
-        assert_eq!(event.event_name, "noricli_session_started");
-
-        let params = &event.event_params;
-        // Required tilework_* fields (no cli_ prefix)
-        assert_eq!(params["tilework_source"], "nori-cli");
-        assert_eq!(params["tilework_session_id"], "1737373800");
-        assert!(
-            params["tilework_timestamp"]
-                .as_str()
-                .unwrap()
-                .contains("2025-01-20")
-        );
-
-        // CLI-specific fields
-        assert_eq!(params["tilework_cli_installed_version"], "1.0.0");
-        assert_eq!(params["tilework_cli_install_source"], "bun");
-        assert_eq!(params["tilework_cli_days_since_install"], 5);
-        assert_eq!(params["tilework_cli_executable_name"], "nori-ai-cli");
-        assert_eq!(params["tilework_cli_os"], std::env::consts::OS);
-        assert_eq!(params["tilework_cli_arch"], std::env::consts::ARCH);
-
-        // Install-only fields should NOT be present
-        assert!(params.get("tilework_cli_is_first_install").is_none());
-        assert!(params.get("tilework_cli_previous_version").is_none());
-
-        // Removed fields should NOT be present
-        assert!(params.get("tilework_cli_user_id").is_none());
-        assert!(params.get("tilework_cli_session_id").is_none());
-        assert!(params.get("tilework_cli_timestamp").is_none());
-        assert!(params.get("tilework_cli_node_version").is_none());
-        assert!(params.get("tilework_cli_is_ci").is_none());
-    }
-
-    #[test]
-    fn test_track_event_request_uses_snake_case() {
-        let state = create_test_state();
-        let now = Utc.with_ymd_and_hms(2025, 1, 20, 10, 30, 0).unwrap();
-        let event = create_event(
-            AnalyticsEventType::SessionStart,
-            &state,
-            "1737373800",
-            now,
-            5,
-            false,
-            None,
-        );
-
-        let json = serde_json::to_string(&event).expect("serialization failed");
-
-        // Should use snake_case field names per API spec
-        assert!(json.contains("\"client_id\""), "should contain client_id");
-        assert!(json.contains("\"user_id\""), "should contain user_id");
-        assert!(json.contains("\"event_name\""), "should contain event_name");
-        assert!(
-            json.contains("\"event_params\""),
-            "should contain event_params"
-        );
-
-        // Should NOT use camelCase field names
-        assert!(
-            !json.contains("\"clientId\""),
-            "should not contain clientId"
-        );
-        assert!(!json.contains("\"userId\""), "should not contain userId");
-        assert!(
-            !json.contains("\"eventName\""),
-            "should not contain eventName"
-        );
-        assert!(
-            !json.contains("\"eventParams\""),
-            "should not contain eventParams"
-        );
+        let client = reqwest13::Client::new();
+        let token = refresh_id_token(&client, "refresh-value", &endpoint)
+            .await
+            .expect("refresh ID token");
+        assert_eq!(token, "refreshed-token");
+        server.join().expect("token server");
     }
 }

--- a/nori-rs/installed/src/lib.rs
+++ b/nori-rs/installed/src/lib.rs
@@ -1,10 +1,8 @@
 //! Install tracking for nori-cli
 //!
-//! This crate tracks CLI lifecycle events (first install, version updates, sessions)
-//! by maintaining a state file at `$NORI_HOME/.nori-install.json`.
-//!
-//! The tracker runs non-blocking on every CLI launch and can emit analytics events
-//! to help understand CLI usage patterns.
+//! This crate tracks CLI installation lifecycle state in
+//! `$NORI_HOME/.nori-install.json` and provides authenticated product analytics
+//! for meaningful agent sessions.
 //!
 //! # Usage
 //!
@@ -23,11 +21,9 @@ mod detection;
 mod state;
 
 pub use analytics::ANALYTICS_OPT_OUT_ENV;
-pub use analytics::AnalyticsEventType;
-pub use analytics::TrackEventRequest;
-pub use analytics::create_event;
+pub use analytics::AnalyticsReporter;
+pub use analytics::SessionMode;
 pub use analytics::is_ci_env;
-pub use analytics::send_event;
 pub use detection::detect_install_source;
 pub use detection::generate_client_id;
 pub use state::InstallSource;
@@ -65,7 +61,6 @@ pub enum LaunchEvent {
 /// 1. Read or create the install state file
 /// 2. Determine if this is a first install, upgrade, or normal session
 /// 3. Update the state file
-/// 4. Send analytics events (fire-and-forget)
 ///
 /// The function returns immediately and never blocks startup.
 /// All errors are silently logged at debug level.
@@ -84,7 +79,6 @@ async fn track_launch_inner(nori_home: &Path) -> anyhow::Result<Vec<LaunchEvent>
     let current_version = CLI_VERSION;
     let install_source = detect_install_source();
     let client_id = generate_client_id();
-    let session_id = now.timestamp().to_string();
 
     // Read existing state or treat missing/corrupt file as first install
     let existing_state = read_install_state(nori_home);
@@ -141,34 +135,6 @@ async fn track_launch_inner(nori_home: &Path) -> anyhow::Result<Vec<LaunchEvent>
     // Write updated state
     write_install_state(nori_home, &new_state).await?;
 
-    // Send analytics events (fire-and-forget)
-    if !should_skip_analytics(&new_state) {
-        let days_since_install = new_state.days_since_install(now);
-        for event in &events {
-            let (event_type, is_first_install, previous_version) = match event {
-                LaunchEvent::AppInstall => (AnalyticsEventType::InstallDetected, true, None),
-                LaunchEvent::AppUpdate { previous_version } => (
-                    AnalyticsEventType::InstallDetected,
-                    false,
-                    Some(previous_version.clone()),
-                ),
-                LaunchEvent::SessionStart => (AnalyticsEventType::SessionStart, false, None),
-                LaunchEvent::UserResurrected => (AnalyticsEventType::UserResurrected, false, None),
-            };
-
-            let analytics_event = create_event(
-                event_type,
-                &new_state,
-                &session_id,
-                now,
-                days_since_install,
-                is_first_install,
-                previous_version,
-            );
-            send_event(&analytics_event).await;
-        }
-    }
-
     debug!("Install tracking complete: {events:?}");
 
     Ok(events)
@@ -185,10 +151,6 @@ pub fn track_launch_sync(nori_home: &Path) -> anyhow::Result<LaunchEvent> {
         .build()?;
     let events = rt.block_on(track_launch_inner(nori_home))?;
     Ok(events.last().cloned().unwrap_or(LaunchEvent::SessionStart))
-}
-
-fn should_skip_analytics(state: &InstallState) -> bool {
-    std::env::var(ANALYTICS_OPT_OUT_ENV).as_deref() == Ok("1") || state.opt_out || is_ci_env()
 }
 
 fn is_valid_uuid(value: &str) -> bool {
@@ -448,39 +410,6 @@ mod tests {
         // Verify state was updated to current version
         let state = read_install_state(temp_home.path()).expect("state should exist");
         assert_eq!(state.installed_version, CLI_VERSION);
-    }
-
-    #[test]
-    fn test_analytics_skipped_in_ci_environment() {
-        // The should_skip_analytics function should return true when CI=true
-        let state = InstallState::new_first_install(
-            generate_client_id(),
-            "1.0.0".to_string(),
-            InstallSource::Npm,
-            Utc::now(),
-        );
-
-        // Save current CI value
-        let original_ci = std::env::var("CI").ok();
-
-        // Set CI=true
-        // SAFETY: This test runs single-threaded and restores the original value
-        unsafe {
-            std::env::set_var("CI", "true");
-        }
-
-        let should_skip = should_skip_analytics(&state);
-
-        // Restore original CI value
-        // SAFETY: This test runs single-threaded and restores the original value
-        unsafe {
-            match original_ci {
-                Some(val) => std::env::set_var("CI", val),
-                None => std::env::remove_var("CI"),
-            }
-        }
-
-        assert!(should_skip, "Analytics should be skipped when CI=true");
     }
 
     #[test]

--- a/nori-rs/tui-pty-e2e/docs.md
+++ b/nori-rs/tui-pty-e2e/docs.md
@@ -33,6 +33,12 @@ child PIDs to prove that the current and prepared candidate coexist, activation
 reuses the prepared child, and cancellation or activation failure leaves the
 current session usable.
 
+Authenticated analytics scenarios pair the real PTY workflow with a local HTTP
+sink. They prove interactive and cloud launches remain silent while merely
+connected, submit the first user prompt through the real ACP agent, observe the
+exact public `session_mode`, and verify a later prompt on the same logical
+session does not create another activity.
+
 The remote-control workflow drives startup and runtime listener management
 through a real WebSocket ACP client, then switches agents. It proves both entry
 paths share one listener owner, disabling listeners preserves the harness, and
@@ -67,5 +73,8 @@ typed `HarnessHandle` methods available to headless embedders.
 - Prompt-fidelity assertions use mock-agent validation rather than rendered
   output, so a duplicated or transformed deferred payload fails at the ACP
   boundary.
+- Analytics assertions use an explicit `NORI_ANALYTICS_URL` and disposable
+  Firebase-shaped user configuration. They never contact the production ingress
+  or PostHog.
 
 Created and maintained by Nori.

--- a/nori-rs/tui-pty-e2e/tests/analytics.rs
+++ b/nori-rs/tui-pty-e2e/tests/analytics.rs
@@ -1,0 +1,199 @@
+use std::io::Read;
+use std::io::Write;
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::time::Duration;
+use std::time::Instant;
+use std::time::SystemTime;
+
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use tui_pty_e2e::Key;
+use tui_pty_e2e::SessionConfig;
+use tui_pty_e2e::TIMEOUT;
+use tui_pty_e2e::TIMEOUT_INPUT;
+use tui_pty_e2e::TuiSession;
+
+fn analytics_server() -> (String, mpsc::Receiver<Value>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind analytics listener");
+    let address = listener.local_addr().expect("analytics listener address");
+    listener
+        .set_nonblocking(true)
+        .expect("nonblocking listener");
+    let (request_tx, request_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(8);
+        while Instant::now() < deadline {
+            let (mut stream, _) = match listener.accept() {
+                Ok(connection) => connection,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(10));
+                    continue;
+                }
+                Err(error) => panic!("accept analytics request: {error}"),
+            };
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .expect("set request timeout");
+            let mut bytes = Vec::new();
+            let mut buffer = [0_u8; 4096];
+            let header_end = loop {
+                let count = stream.read(&mut buffer).expect("read analytics request");
+                assert!(count > 0, "analytics request closed before headers");
+                bytes.extend_from_slice(&buffer[..count]);
+                if let Some(index) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+                    break index + 4;
+                }
+            };
+            let headers = String::from_utf8(bytes[..header_end].to_vec()).expect("UTF-8 headers");
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().expect("content length"))
+                })
+                .expect("content-length header");
+            while bytes.len() - header_end < content_length {
+                let count = stream.read(&mut buffer).expect("read analytics body");
+                assert!(count > 0, "analytics request closed before body");
+                bytes.extend_from_slice(&buffer[..count]);
+            }
+            request_tx
+                .send(
+                    serde_json::from_slice(&bytes[header_end..header_end + content_length])
+                        .expect("analytics JSON body"),
+                )
+                .expect("deliver request");
+            stream
+            .write_all(
+                b"HTTP/1.1 202 Accepted\r\nContent-Type: application/json\r\nContent-Length: 17\r\nConnection: close\r\n\r\n{\"accepted\":true}",
+            )
+            .expect("write analytics response");
+        }
+    });
+    (
+        format!("http://{address}/api/analytics/v1/events"),
+        request_rx,
+    )
+}
+
+fn fake_handroll() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("fake Handroll directory");
+    let mock = std::env::current_exe()
+        .expect("test executable")
+        .parent()
+        .and_then(|path| path.parent())
+        .expect("target directory")
+        .join("mock_acp_agent");
+    assert!(mock.exists(), "missing mock agent at {}", mock.display());
+    let script = dir.path().join("nori-handroll");
+    std::fs::write(&script, format!("#!/bin/sh\nexec '{}'\n", mock.display()))
+        .expect("write fake Handroll");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("make fake Handroll executable");
+    }
+    (dir, script)
+}
+
+fn authenticated_home() -> tempfile::TempDir {
+    let home = tempfile::tempdir().expect("temporary home");
+    let expires_at = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system clock")
+        .as_millis()
+        + 60_000;
+    std::fs::write(
+        home.path().join(".nori-config.json"),
+        serde_json::json!({
+            "auth": {
+                "username": "human@example.com",
+                "idToken": "interactive-id-token",
+                "idTokenExpiresAt": expires_at,
+            }
+        })
+        .to_string(),
+    )
+    .expect("write authenticated config");
+    home
+}
+
+#[test]
+fn interactive_prompt_reports_authenticated_agent_session() {
+    let home = authenticated_home();
+    let (analytics_url, requests) = analytics_server();
+    let config = SessionConfig::new()
+        .with_agent_env("HOME", home.path().to_string_lossy())
+        .with_agent_env("NORI_ANALYTICS_URL", analytics_url);
+    let mut session = TuiSession::spawn_with_config(18, 80, config).expect("spawn Nori TUI");
+
+    session.wait_for_text("›", TIMEOUT).expect("prompt ready");
+    assert!(requests.recv_timeout(Duration::from_millis(300)).is_err());
+    session.send_str("meaningful work").expect("type prompt");
+    std::thread::sleep(TIMEOUT_INPUT);
+    session.send_key(Key::Enter).expect("submit prompt");
+    session
+        .wait_for_text("Test message 2", TIMEOUT)
+        .expect("agent response");
+
+    let request = requests
+        .recv_timeout(Duration::from_secs(3))
+        .expect("authenticated analytics request");
+    assert_eq!(
+        request.get("event"),
+        Some(&Value::String("nori_agent_session_started".to_string()))
+    );
+    assert_eq!(
+        request.get("properties"),
+        Some(&serde_json::json!({ "session_mode": "interactive" }))
+    );
+    session
+        .send_str("second prompt")
+        .expect("type second prompt");
+    std::thread::sleep(TIMEOUT_INPUT);
+    session.send_key(Key::Enter).expect("submit second prompt");
+    session
+        .wait_for_text("Test message 2", TIMEOUT)
+        .expect("second agent response");
+    assert!(requests.recv_timeout(Duration::from_millis(400)).is_err());
+}
+
+#[test]
+fn cloud_prompt_reports_cloud_mode_after_the_agent_connects() {
+    let home = authenticated_home();
+    let (_handroll_dir, handroll) = fake_handroll();
+    let (analytics_url, requests) = analytics_server();
+    let config = SessionConfig::new()
+        .with_subcommand("cloud")
+        .with_arg("--onboard")
+        .with_agent_env("HOME", home.path().to_string_lossy())
+        .with_agent_env("NORI_ANALYTICS_URL", analytics_url)
+        .with_agent_env("NORI_HANDROLL_BIN", handroll.to_string_lossy());
+    let mut session = TuiSession::spawn_with_config(18, 80, config).expect("spawn Nori cloud");
+
+    session
+        .wait_for_text("›", TIMEOUT)
+        .expect("cloud prompt ready");
+    assert!(requests.recv_timeout(Duration::from_millis(300)).is_err());
+    session
+        .send_str("meaningful cloud work")
+        .expect("type prompt");
+    std::thread::sleep(TIMEOUT_INPUT);
+    session.send_key(Key::Enter).expect("submit prompt");
+    session
+        .wait_for_text("Test message 2", TIMEOUT)
+        .expect("cloud agent response");
+
+    let request = requests
+        .recv_timeout(Duration::from_secs(3))
+        .expect("cloud analytics request");
+    assert_eq!(
+        request.get("properties"),
+        Some(&serde_json::json!({ "session_mode": "cloud" }))
+    );
+    assert!(requests.recv_timeout(Duration::from_millis(400)).is_err());
+}

--- a/nori-rs/tui-pty-e2e/tests/markdown_table.rs
+++ b/nori-rs/tui-pty-e2e/tests/markdown_table.rs
@@ -43,6 +43,9 @@ fn test_streamed_markdown_table_renders_as_a_grid() {
     session
         .wait_for_text("Done.", TIMEOUT)
         .expect("Did not receive the streamed table");
+    session
+        .wait_for_text("Approvals: Agent", TIMEOUT)
+        .expect("Footer did not render after the streamed table");
     std::thread::sleep(TIMEOUT_PRESNAPSHOT);
 
     let screen = session.screen_contents();

--- a/nori-rs/tui/Cargo.toml
+++ b/nori-rs/tui/Cargo.toml
@@ -71,7 +71,7 @@ ratatui = { workspace = true, features = [
 ] }
 ratatui-macros = { workspace = true }
 regex-lite = { workspace = true }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -52,6 +52,25 @@ never to similarly named native agent tools.
 
 ### Core Implementation
 
+#### Prompt-bound authenticated analytics
+
+[`run_main`](src/lib.rs) receives an optional
+[`AnalyticsReporter`](../installed/docs.md) from the binary and carries one
+clone through [`App`](src/app/mod.rs) and each [`ChatWidgetInit`](src/chatwidget/mod.rs).
+Every new or resumed agent path in [`chatwidget/agent.rs`](src/chatwidget/agent.rs)
+attaches that reporter to the exact launched harness handle before exposing the
+handle to the widget. Agent replacement and `/new` therefore create a fresh
+logical-session boundary while cloned handles for one session share one
+first-prompt guard.
+
+The ordinary TUI uses `session_mode = interactive`; the explicit cloud route
+uses `session_mode = cloud`. Preparation, session listing, picker display,
+resume, and connection establishment are silent. Capture begins in the
+[harness](../harness/docs.md) only when the first user prompt receives its ACP
+wire request ID. Leaving the application performs one bounded reporter flush
+after [`App::run`](src/app/mod.rs) completes and before terminal restoration;
+analytics failures do not replace the application result.
+
 #### Source-first event dispatch
 
 The application event loop matches `SessionEvent::Acp` and

--- a/nori-rs/tui/src/app/mod.rs
+++ b/nori-rs/tui/src/app/mod.rs
@@ -91,6 +91,7 @@ pub(crate) struct App {
     pub(crate) config: NoriConfig,
     pub(crate) vertical_footer: bool,
     pub(crate) cloud_mode: bool,
+    pub(crate) analytics: Option<nori_installed::AnalyticsReporter>,
     pub(crate) footer_layout_config: nori_config::FooterLayoutConfig,
 
     pub(crate) file_search: FileSearchManager,
@@ -222,6 +223,7 @@ impl App {
         cloud_mode: bool,
         cloud_onboard: bool,
         startup_remote_addr: Option<std::net::SocketAddr>,
+        analytics: Option<nori_installed::AnalyticsReporter>,
     ) -> Result<AppExitInfo> {
         use tokio_stream::StreamExt;
 
@@ -250,6 +252,7 @@ impl App {
                 deferred_spawn: needs_deferred_spawn,
                 fork_context: None,
                 prepared_agent: None,
+                analytics: analytics.clone(),
             };
             match resume_selection {
                 ResumeSelection::Resume(target) => {
@@ -295,6 +298,7 @@ impl App {
             config,
             vertical_footer,
             cloud_mode,
+            analytics,
             file_search,
             enhanced_keys_supported,
             transcript_cells: Vec::new(),
@@ -478,6 +482,7 @@ impl App {
             deferred_spawn,
             fork_context,
             prepared_agent: None,
+            analytics: self.analytics.clone(),
         }
     }
 

--- a/nori-rs/tui/src/chatwidget/agent.rs
+++ b/nori-rs/tui/src/chatwidget/agent.rs
@@ -17,6 +17,7 @@ use nori_harness::runtime::SessionResume;
 use nori_harness::runtime::SessionStart;
 use nori_harness::runtime::launch_session;
 use nori_harness::runtime::prepare_and_launch_session;
+use nori_installed::AnalyticsReporter;
 use std::sync::Arc;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
@@ -44,6 +45,7 @@ pub(crate) fn spawn_agent(
     app_event_tx: AppEventSender,
     generation: crate::app_event::SessionGeneration,
     fork_context: Option<String>,
+    analytics: Option<AnalyticsReporter>,
 ) -> SpawnAgentResult {
     match nori_harness::get_agent_config(&config.active_agent) {
         Ok(_) => prepare_and_launch_acp_agent(
@@ -52,6 +54,7 @@ pub(crate) fn spawn_agent(
             generation,
             fork_context,
             SessionStart::New,
+            analytics,
         ),
         Err(_) => {
             let agent_name = config.active_agent;
@@ -80,6 +83,7 @@ pub(crate) fn spawn_acp_agent_resume(
     transcript: Option<nori_harness::transcript::Transcript>,
     app_event_tx: AppEventSender,
     generation: crate::app_event::SessionGeneration,
+    analytics: Option<AnalyticsReporter>,
 ) -> SpawnAgentResult {
     prepare_and_launch_acp_agent(
         config,
@@ -90,6 +94,7 @@ pub(crate) fn spawn_acp_agent_resume(
             acp_session_id,
             transcript,
         }),
+        analytics,
     )
 }
 
@@ -115,13 +120,14 @@ fn prepare_and_launch_acp_agent(
     generation: crate::app_event::SessionGeneration,
     fork_context: Option<String>,
     start: SessionStart,
+    analytics: Option<AnalyticsReporter>,
 ) -> SpawnAgentResult {
     let display_name = get_agent_display_name(&config.active_agent);
     app_event_tx.send(AppEvent::AgentConnecting { display_name });
 
     let prepare_spec = agent_prepare_spec(config, fork_context);
     let session = prepare_and_launch_session(prepare_spec, start);
-    forward_launched_session(session, app_event_tx, generation)
+    forward_launched_session(session, app_event_tx, generation, analytics)
 }
 
 pub(crate) fn agent_prepare_spec(
@@ -145,16 +151,21 @@ pub(crate) fn launch_prepared_agent(
     start: SessionStart,
     app_event_tx: AppEventSender,
     generation: crate::app_event::SessionGeneration,
+    analytics: Option<AnalyticsReporter>,
 ) -> SpawnAgentResult {
     let session = launch_session(SessionLaunchSpec { agent, start });
-    forward_launched_session(session, app_event_tx, generation)
+    forward_launched_session(session, app_event_tx, generation, analytics)
 }
 
 fn forward_launched_session(
     mut session: nori_harness::runtime::LaunchedSession,
     app_event_tx: AppEventSender,
     generation: crate::app_event::SessionGeneration,
+    analytics: Option<AnalyticsReporter>,
 ) -> SpawnAgentResult {
+    if let Some(reporter) = analytics.as_ref() {
+        session.handle = reporter.attach(session.handle);
+    }
     let handle = Some(session.handle.clone());
 
     tokio::spawn(async move {

--- a/nori-rs/tui/src/chatwidget/constructors.rs
+++ b/nori-rs/tui/src/chatwidget/constructors.rs
@@ -29,6 +29,7 @@ impl ChatWidget {
             deferred_spawn,
             fork_context,
             prepared_agent,
+            analytics,
         } = common;
         let mut rng = rand::rng();
         let placeholder = PROMPT_MODE_PLACEHOLDERS
@@ -41,6 +42,7 @@ impl ChatWidget {
                 nori_harness::runtime::SessionStart::New,
                 app_event_tx.clone(),
                 session_generation,
+                analytics,
             )
         } else if deferred_spawn {
             SpawnAgentResult { handle: None }
@@ -50,6 +52,7 @@ impl ChatWidget {
                 app_event_tx.clone(),
                 session_generation,
                 fork_context,
+                analytics,
             )
         };
 
@@ -192,6 +195,7 @@ impl ChatWidget {
             deferred_spawn: _,
             fork_context: _,
             prepared_agent,
+            analytics,
         } = common;
         let mut rng = rand::rng();
         let placeholder = PROMPT_MODE_PLACEHOLDERS
@@ -207,6 +211,7 @@ impl ChatWidget {
                 }),
                 app_event_tx.clone(),
                 session_generation,
+                analytics,
             )
         } else {
             spawn_acp_agent_resume(
@@ -215,6 +220,7 @@ impl ChatWidget {
                 transcript,
                 app_event_tx.clone(),
                 session_generation,
+                analytics,
             )
         };
 

--- a/nori-rs/tui/src/chatwidget/mod.rs
+++ b/nori-rs/tui/src/chatwidget/mod.rs
@@ -156,6 +156,8 @@ pub(crate) struct ChatWidgetInit {
     pub(crate) fork_context: Option<String>,
     /// A live initialized connection to consume instead of spawning one.
     pub(crate) prepared_agent: Option<nori_harness::runtime::PreparedAgent>,
+    /// Emits one authenticated activity after this session's first prompt reaches ACP.
+    pub(crate) analytics: Option<nori_installed::AnalyticsReporter>,
 }
 
 /// Controls the pinned plan drawer visibility and display mode.

--- a/nori-rs/tui/src/chatwidget/tests/mod.rs
+++ b/nori-rs/tui/src/chatwidget/tests/mod.rs
@@ -116,6 +116,7 @@ fn make_chatwidget_manual_for_mode(
         fork_context: None,
         prepared_agent: None,
         cloud_mode,
+        analytics: None,
     });
     let (_unused_tx, unused_rx) = unbounded_channel();
     (widget, event_rx, unused_rx)

--- a/nori-rs/tui/src/lib.rs
+++ b/nori-rs/tui/src/lib.rs
@@ -122,6 +122,7 @@ use std::io::Write as _;
 pub async fn run_main(
     cli: Cli,
     _codex_linux_sandbox_exe: Option<PathBuf>,
+    analytics: Option<nori_installed::AnalyticsReporter>,
 ) -> std::io::Result<AppExitInfo> {
     // Pre-warm the ACP agent installation cache in a background thread.
     // This runs `which` commands early so the agent picker opens quickly.
@@ -296,6 +297,7 @@ pub async fn run_main(
         overrides,
         pending_worktree_ask,
         worktree_blocked_reason,
+        analytics,
     )
     .await
     .map_err(|err| std::io::Error::other(err.to_string()))
@@ -308,6 +310,7 @@ async fn run_ratatui_app(
     overrides: NoriConfigOverrides,
     pending_worktree_ask: bool,
     worktree_blocked_reason: Option<String>,
+    analytics: Option<nori_installed::AnalyticsReporter>,
 ) -> color_eyre::Result<AppExitInfo> {
     color_eyre::install()?;
 
@@ -529,8 +532,13 @@ async fn run_ratatui_app(
         cloud_mode,
         cloud_onboard,
         startup_remote_addr,
+        analytics.clone(),
     )
     .await;
+
+    if let Some(reporter) = analytics {
+        reporter.flush();
+    }
 
     restore();
     // Mark the end of the recorded session.

--- a/nori-rs/tui/src/main.rs
+++ b/nori-rs/tui/src/main.rs
@@ -21,7 +21,7 @@ fn main() -> anyhow::Result<()> {
             .config_overrides
             .raw_overrides
             .splice(0..0, top_cli.config_overrides.raw_overrides);
-        let exit_info = run_main(inner, codex_linux_sandbox_exe).await?;
+        let exit_info = run_main(inner, codex_linux_sandbox_exe, None).await?;
 
         let token_usage = exit_info.token_usage;
         if !token_usage.is_zero() {


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- Reports one meaningful `nori_agent_session_started` event after the first prompt reaches ACP transport.
- Covers interactive, cloud, exec, and ACP modes without treating resume itself as activity.
- Uses Firebase credentials from current or legacy Nori config, honors opt-out and service exclusions, and remains fail-open.

## Test Plan
- [x] Broad Rust unit, integration, PTY, and doc-test suite
- [x] Authenticated analytics black-box tests for exec, ACP, interactive, and cloud
- [x] `just fix`, `just fmt`, and `just clippy`
- [x] Isolated manual TUI prompt/response smoke test
- [x] Independent code and test-hygiene review

Specification: https://github.com/tilework-tech/nori-monorepo/pull/109
Ingress: https://github.com/tilework-tech/nori-sessions/pull/1704

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets