### PR TITLE
feat(tui): surface cloud connection progress

### DIFF
--- a/nori-rs/mock-acp-agent/docs.md
+++ b/nori-rs/mock-acp-agent/docs.md
@@ -37,6 +37,13 @@ count, image count, image MIME type, and image data through the
 error, allowing PTY lifecycle tests to verify that deferred positional or typed
 input reaches ACP exactly once without transforming text or attachments.
 
+Cloud readiness fixtures can hold a successful `session/new` response until a
+`MOCK_AGENT_NEW_SESSION_RELEASE_FILE` appears or return a structured
+broker-style failure. The handlers in [`main.rs`](src/main.rs) keep these
+controls on the real ACP request path, so PTY tests can observe the
+pre-`SessionStarted` UI state and user-facing ACP error projection without
+replacing Handroll or bypassing the stdio transport.
+
 The mock deliberately issues outbound client requests through the SDK rather
 than calling host internals. This makes the public `AcpEvent::Request` and
 `HarnessHandle::respond_to_agent` path observable end to end.

--- a/nori-rs/mock-acp-agent/src/main.rs
+++ b/nori-rs/mock-acp-agent/src/main.rs
@@ -1663,6 +1663,18 @@ async fn main() -> acp::Result<()> {
                             "Mock model-specific new_session failure for testing",
                         ));
                     }
+                    if std::env::var("MOCK_AGENT_FAIL_NEW_SESSION_JSON").is_ok() {
+                        eprintln!("Mock agent: simulating structured new_session failure");
+                        return responder.respond_with_error(
+                            acp::Error::new(-32010, "broker unreachable").data(
+                                serde_json::json!({
+                                    "detail": "connection reset by broker",
+                                    "retry_after_ms": 5000,
+                                    "trace_id": "mock-trace-new-session"
+                                }),
+                            ),
+                        );
+                    }
                     if let Ok(fail_from) = std::env::var("MOCK_AGENT_FAIL_NEW_SESSION_FROM")
                         && let Ok(fail_from) = fail_from.parse::<i64>()
                         && session_id >= fail_from
@@ -1674,7 +1686,14 @@ async fn main() -> acp::Result<()> {
                         ));
                     }
                     eprintln!("Mock agent: new_session id={session_id}");
-
+                    if let Ok(release_file) =
+                        std::env::var("MOCK_AGENT_NEW_SESSION_RELEASE_FILE")
+                    {
+                        let release_file = PathBuf::from(release_file);
+                        while !release_file.exists() {
+                            sleep(Duration::from_millis(10)).await;
+                        }
+                    }
                     let session_key = session_id.to_string();
                     let session_config = default_session_config();
                     state

--- a/nori-rs/tui-pty-e2e/docs.md
+++ b/nori-rs/tui-pty-e2e/docs.md
@@ -53,6 +53,13 @@ prompt reuse that child; and deferred text and images cross the configured
 session boundary exactly once. Sessionless slash/local commands, preparation
 timeout, and exit cover the corresponding no-activation and reaping paths.
 
+Cloud activation scenarios hold `session/new` behind a release-file barrier
+after the picker selection. They verify that connecting feedback remains in
+history, typing stays available, Enter preserves rather than queues the draft
+before `SessionStarted`, and a later retry crosses ACP exactly once. A
+structured new-session failure also proves that the terminal shows the ACP
+message and string `data.detail` while excluding unrelated diagnostic fields.
+
 The protocol hard cut did not introduce a test-only compatibility path. PTY
 tests exercise source-first `SessionEvent::{Acp, Nori}` dispatch and the same
 typed `HarnessHandle` methods available to headless embedders.
@@ -61,8 +68,10 @@ typed `HarnessHandle` methods available to headless embedders.
 
 - Build the mock agent before local runs when CI has not supplied its path.
 - Tests require the TUI `vt100-tests` feature.
-- Snapshot normalization removes dynamic session IDs, timestamps, and status
-  text while retaining meaningful terminal ordering and content.
+- Snapshot normalization removes dynamic session IDs, timestamps, status
+  text, and disposable Linux or macOS temp roots (`/tmp`, `/private/tmp`, and
+  `/private/var/folders`) while retaining meaningful terminal ordering and
+  content.
 - Transcript pickers treat a v3 transcript as non-empty only when it has at
   least one user turn; lifecycle records alone do not make it resumable.
 - Timing-sensitive scenarios use bounded waits, but assertions target visible

--- a/nori-rs/tui-pty-e2e/src/lib.rs
+++ b/nori-rs/tui-pty-e2e/src/lib.rs
@@ -989,9 +989,17 @@ fn strip_git_stats_segment(line: &str) -> String {
 pub fn normalize_for_snapshot(contents: String) -> String {
     let mut normalized = contents;
 
-    // Replace temp directories: /tmp/claude-*/.tmpXXXXXX, /tmp/claude/.tmpXXXXXX,
-    // or /tmp/.tmpXXXXXX -> [TMP_DIR]
-    for pattern in &["/tmp/claude-", "/tmp/claude/.tmp", "/tmp/.tmp"] {
+    // Replace temp directories. macOS canonicalizes /tmp to /private/tmp and
+    // may use /private/var/folders/... as its process temp root.
+    for pattern in &[
+        "/private/var/folders/",
+        "/private/tmp/claude-",
+        "/private/tmp/claude/.tmp",
+        "/private/tmp/.tmp",
+        "/tmp/claude-",
+        "/tmp/claude/.tmp",
+        "/tmp/.tmp",
+    ] {
         while let Some(start) = normalized.find(pattern) {
             let end = normalized[start..]
                 .find(|c: char| c.is_whitespace() || c == '│')
@@ -1235,6 +1243,16 @@ pub fn normalize_for_input_snapshot(contents: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalizes_canonical_macos_temp_directories() {
+        let input = "Directory  /private/tmp/.tmpAbCd12/project";
+
+        assert_eq!(
+            normalize_for_snapshot(input.to_string()),
+            "Directory  [TMP_DIR]"
+        );
+    }
 
     #[test]
     fn test_normalize_worked_for_line() {

--- a/nori-rs/tui-pty-e2e/tests/agent_switching.rs
+++ b/nori-rs/tui-pty-e2e/tests/agent_switching.rs
@@ -554,6 +554,16 @@ fn test_agent_candidate_activation_failure_keeps_current_session_promptable() {
     session
         .wait_for(|_| !process_exists(candidate_pid), Duration::from_secs(10))
         .expect("failed candidate should be reaped");
+    let contents = session.screen_contents();
+    assert_eq!(
+        contents.matches("Failed to start ACP session").count(),
+        1,
+        "candidate activation should render one actionable failure:\n{contents}"
+    );
+    assert!(
+        !contents.contains("Mock model-specific new_session failure for testing"),
+        "detail-less hidden ACP errors should yield to lifecycle guidance:\n{contents}"
+    );
     assert!(
         process_exists_and_not_zombie(current_pid),
         "current process must survive candidate activation failure"

--- a/nori-rs/tui-pty-e2e/tests/analytics.rs
+++ b/nori-rs/tui-pty-e2e/tests/analytics.rs
@@ -33,6 +33,9 @@ fn analytics_server() -> (String, mpsc::Receiver<Value>) {
                 Err(error) => panic!("accept analytics request: {error}"),
             };
             stream
+                .set_nonblocking(false)
+                .expect("make accepted analytics stream blocking");
+            stream
                 .set_read_timeout(Some(Duration::from_secs(5)))
                 .expect("set request timeout");
             let mut bytes = Vec::new();

--- a/nori-rs/tui-pty-e2e/tests/cloud_mode.rs
+++ b/nori-rs/tui-pty-e2e/tests/cloud_mode.rs
@@ -506,6 +506,98 @@ fn test_cloud_entry_picker_create_new_starts_fresh_session() {
         .expect("prompt should round-trip on the fresh session");
 }
 
+/// Claiming a fresh Cloud box can take several seconds. During that gap the
+/// TUI must explain what it is doing and keep an attempted prompt as a draft
+/// instead of silently queueing it before the session is ready.
+#[test]
+#[cfg(target_os = "linux")]
+fn test_cloud_create_new_shows_connection_progress_and_blocks_early_submit() {
+    let fake = FakeHandroll::new();
+    let release_file = fake.marker("release_new_session");
+    let config = cloud_lifecycle_config(&fake)
+        .with_agent_env(
+            "MOCK_AGENT_NEW_SESSION_RELEASE_FILE",
+            release_file.to_string_lossy(),
+        )
+        .with_mock_response("draft submitted after cloud connected");
+
+    let mut session =
+        TuiSession::spawn_with_config(24, 80, config).expect("Failed to spawn nori cloud");
+
+    session
+        .wait_for_text("Start a new session", TIMEOUT)
+        .expect("cloud entry should open the session picker");
+    session.send_key(Key::Enter).unwrap();
+    session
+        .wait_for_text("Connecting to Nori Cloud", TIMEOUT)
+        .expect("claiming a new cloud session should show connection progress");
+
+    session.send_str("draft while connecting").unwrap();
+    std::thread::sleep(TIMEOUT_INPUT);
+    session.send_key(Key::Enter).unwrap();
+    std::thread::sleep(Duration::from_millis(200));
+    assert!(
+        session.screen_contents().contains("draft while connecting"),
+        "an early Enter must keep the text in the composer"
+    );
+    let agent_stderr = std::fs::read_to_string(fake.marker("agent_stderr")).unwrap_or_default();
+    assert!(
+        !agent_stderr.contains("Mock agent: prompt"),
+        "the draft must not be queued during connection:\n{agent_stderr}"
+    );
+
+    std::fs::write(release_file, "ready").expect("release delayed session/new");
+
+    session
+        .wait_for_text("Directory", TIMEOUT)
+        .expect("the connected session should render its initial status card");
+    std::thread::sleep(Duration::from_millis(300));
+    assert!(
+        session
+            .screen_contents()
+            .contains("Connecting to Nori Cloud"),
+        "connection progress should remain in history after the status card appears"
+    );
+    session.send_key(Key::Enter).unwrap();
+    session
+        .wait_for_text("draft submitted after cloud connected", TIMEOUT)
+        .expect("the preserved draft should submit once the user retries after connection");
+    let agent_stderr = std::fs::read_to_string(fake.marker("agent_stderr")).unwrap_or_default();
+    assert_eq!(
+        agent_stderr.matches("Mock agent: prompt").count(),
+        1,
+        "the preserved draft should cross the ACP boundary exactly once:\n{agent_stderr}"
+    );
+}
+
+/// A structured ACP failure from Handroll must remain actionable in terminal
+/// history without exposing unrelated machine-readable error metadata.
+#[test]
+#[cfg(target_os = "linux")]
+fn test_cloud_create_new_error_shows_message_and_detail_without_json_noise() {
+    let fake = FakeHandroll::new();
+    let config =
+        cloud_lifecycle_config(&fake).with_agent_env("MOCK_AGENT_FAIL_NEW_SESSION_JSON", "1");
+
+    let mut session =
+        TuiSession::spawn_with_config(24, 80, config).expect("Failed to spawn nori cloud");
+
+    session
+        .wait_for_text("Start a new session", TIMEOUT)
+        .expect("cloud entry should open the session picker");
+    session.send_key(Key::Enter).unwrap();
+    session
+        .wait_for_text("broker unreachable", TIMEOUT)
+        .expect("the ACP error message should appear in history");
+    session
+        .wait_for_text("connection reset by broker", TIMEOUT)
+        .expect("the ACP error detail should appear in history");
+
+    let contents = session.screen_contents();
+    assert!(!contents.contains("retry_after_ms"), "{contents}");
+    assert!(!contents.contains("trace_id"), "{contents}");
+}
+
 /// /close releases the session and returns to the session picker — it must
 /// NOT auto-claim a fresh session ("swap" semantics are gone).
 #[test]

--- a/nori-rs/tui-pty-e2e/tests/cloud_mode.rs
+++ b/nori-rs/tui-pty-e2e/tests/cloud_mode.rs
@@ -521,11 +521,26 @@ fn test_cloud_create_new_shows_connection_progress_and_blocks_early_submit() {
         .expect("claiming a new cloud session should show connection progress");
 
     session.submit_input("draft while connecting").unwrap();
-    std::thread::sleep(Duration::from_millis(200));
+    session
+        .type_input("x")
+        .expect("input after Enter should prove the blocked submission was processed");
+    session
+        .wait_for_text("draft while connectingx", TIMEOUT)
+        .expect("the preserved draft should remain editable after blocked submission");
     assert!(
         session.screen_contents().contains("draft while connecting"),
         "an early Enter must keep the text in the composer"
     );
+    session.send_key(Key::Backspace).unwrap();
+    session
+        .wait_for(
+            |screen| {
+                screen.contains("draft while connecting")
+                    && !screen.contains("draft while connectingx")
+            },
+            TIMEOUT,
+        )
+        .expect("backspace should restore the original draft");
     let agent_stderr = std::fs::read_to_string(fake.marker("agent_stderr")).unwrap_or_default();
     assert!(
         !agent_stderr.contains("Mock agent: prompt"),
@@ -537,7 +552,6 @@ fn test_cloud_create_new_shows_connection_progress_and_blocks_early_submit() {
     session
         .wait_for_text("Directory", TIMEOUT)
         .expect("the connected session should render its initial status card");
-    std::thread::sleep(Duration::from_millis(300));
     assert!(
         session
             .screen_contents()
@@ -580,6 +594,16 @@ fn test_cloud_create_new_error_shows_message_and_detail_without_json_noise() {
         .expect("the ACP error detail should appear in history");
 
     let contents = session.screen_contents();
+    assert_eq!(
+        contents.matches("broker unreachable").count(),
+        1,
+        "{contents}"
+    );
+    assert_eq!(
+        contents.matches("connection reset by broker").count(),
+        1,
+        "{contents}"
+    );
     assert!(!contents.contains("retry_after_ms"), "{contents}");
     assert!(!contents.contains("trace_id"), "{contents}");
 }

--- a/nori-rs/tui-pty-e2e/tests/cloud_mode.rs
+++ b/nori-rs/tui-pty-e2e/tests/cloud_mode.rs
@@ -365,6 +365,9 @@ fn test_cloud_new_reuses_in_flight_entry_preparation() {
     session.submit_input("/new").unwrap();
 
     session
+        .wait_for_text("Nori Cloud · Mock Default Model", TIMEOUT)
+        .expect("the explicit new session should finish connecting");
+    session
         .submit_input("prove the explicit session won")
         .unwrap();
     session
@@ -550,7 +553,7 @@ fn test_cloud_create_new_shows_connection_progress_and_blocks_early_submit() {
     std::fs::write(release_file, "ready").expect("release delayed session/new");
 
     session
-        .wait_for_text("Directory", TIMEOUT)
+        .wait_for_text("Nori Cloud · Mock Default Model", TIMEOUT)
         .expect("the connected session should render its initial status card");
     assert!(
         session

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -65,11 +65,12 @@ first-prompt guard.
 
 The ordinary TUI uses `session_mode = interactive`; the explicit cloud route
 uses `session_mode = cloud`. Preparation, session listing, picker display,
-resume, and connection establishment are silent. Capture begins in the
-[harness](../harness/docs.md) only when the first user prompt receives its ACP
-wire request ID. Leaving the application performs one bounded reporter flush
-after [`App::run`](src/app/mod.rs) completes and before terminal restoration;
-analytics failures do not replace the application result.
+resume, and connection establishment do not emit authenticated activity;
+visible connection feedback is independent of analytics. Capture begins in
+the [harness](../harness/docs.md) only when the first user prompt receives its
+ACP wire request ID. Leaving the application performs one bounded reporter
+flush after [`App::run`](src/app/mod.rs) completes and before terminal
+restoration; analytics failures do not replace the application result.
 
 #### Source-first event dispatch
 
@@ -135,7 +136,12 @@ The application event loop matches `SessionEvent::Acp` and
   time. Failures unrelated to the active prompt do not complete it. Other typed
   operations complete through their
   `HarnessHandle` return values while their raw responses remain observable on
-  the stream.
+  the stream. [`event_handlers.rs`](src/chatwidget/event_handlers.rs) logs an
+  unpaired ACP error response with its code and safe diagnostic fields, then
+  renders its message plus a distinct, non-empty string `data.detail` when
+  present. Other machine-readable error data stays out of history, keeping the
+  user-facing failure actionable and screenshot-friendly without dumping
+  opaque metadata.
 - Nori events drive lifecycle, queue, replay, compaction, goals, undo,
   user-shell output, hooks, summaries, notices, and classified failures.
 
@@ -526,6 +532,13 @@ supersession, or application exit tears down only the candidate and leaves the
 current session promptable. Prompt submission always targets the current
 widget; there is no pending switch-on-next-prompt state.
 
+Candidate activation retains the safe, formatted ACP error received before a
+terminal `SessionEnded`. If activation fails, [`App`](src/app/event_handling.rs)
+prefers that precise message and detail over the lifecycle event's generic
+fallback, tears down the candidate, and renders the failure through the still
+active widget. Internal structured fields remain excluded by the shared error
+projection in [`event_handlers.rs`](src/chatwidget/event_handlers.rs).
+
 Bare `/login` has a narrow candidate-target override. Selecting a candidate
 sets it, and preparation or activation failure leaves it available so the user
 can authenticate that attempted agent without recreating pending-switch state.
@@ -591,6 +604,25 @@ attachments remain owned by the deferred widget. Choosing Start new transfers
 that input into the replacement widget before the deferred widget shuts down,
 so it auto-sends at the same `SessionStarted` boundary as every other entry
 path.
+
+Consuming a prepared Cloud connection for either New or Resume immediately
+adds a durable “Connecting to Nori Cloud…” history entry and shows the live
+connecting indicator. The constructors in
+[`constructors.rs`](src/chatwidget/constructors.rs) enter this state through
+the presentation helper in [`helpers.rs`](src/chatwidget/helpers.rs).
+`SessionStarted` is the readiness boundary: it hides the indicator, applies the
+connected session state, and renders the existing status card. The composer
+remains editable while activation is pending, but
+[`key_handling.rs`](src/chatwidget/key_handling.rs) restores the submitted text
+on Enter instead of passing it to the harness; the user must submit again after
+the status card appears. This prevents the harness's ordinary pre-activation
+command queue from accepting a Cloud prompt before the remote session is ready
+while preserving the user's draft. A pre-start `RequestFailed` or
+`SessionEnded` also clears the live indicator, so any failure output is not
+accompanied by stale connection state; the durable progress entry remains in
+history. Snapshots in [`chatwidget/tests`](src/chatwidget/tests/) pin the live
+indicator, durable connecting entry, stopped indicator with its preserved
+draft, and terminal failure history as separate presentation boundaries.
 
 The shared ACP resume picker treats session source as first-class presentation
 instead of requiring users to inspect raw metadata. Cloud rows with a typed

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -136,12 +136,12 @@ The application event loop matches `SessionEvent::Acp` and
   time. Failures unrelated to the active prompt do not complete it. Other typed
   operations complete through their
   `HarnessHandle` return values while their raw responses remain observable on
-  the stream. [`event_handlers.rs`](src/chatwidget/event_handlers.rs) logs an
-  unpaired ACP error response with its code and safe diagnostic fields, then
-  renders its message plus a distinct, non-empty string `data.detail` when
-  present. Other machine-readable error data stays out of history, keeping the
-  user-facing failure actionable and screenshot-friendly without dumping
-  opaque metadata.
+  the stream. When an unpaired ACP error reaches the active widget,
+  [`event_handlers.rs`](src/chatwidget/event_handlers.rs) logs its code and safe
+  diagnostic fields, then renders its message plus a distinct, non-empty string
+  `data.detail` when present. Other machine-readable error data stays out of
+  history, keeping the user-facing failure actionable and screenshot-friendly
+  without dumping opaque metadata.
 - Nori events drive lifecycle, queue, replay, compaction, goals, undo,
   user-shell output, hooks, summaries, notices, and classified failures.
 
@@ -532,12 +532,16 @@ supersession, or application exit tears down only the candidate and leaves the
 current session promptable. Prompt submission always targets the current
 widget; there is no pending switch-on-next-prompt state.
 
-Candidate activation retains the safe, formatted ACP error received before a
-terminal `SessionEnded`. If activation fails, [`App`](src/app/event_handling.rs)
-prefers that precise message and detail over the lifecycle event's generic
-fallback, tears down the candidate, and renders the failure through the still
-active widget. Internal structured fields remain excluded by the shared error
-projection in [`event_handlers.rs`](src/chatwidget/event_handlers.rs).
+Candidate activation classifies hidden candidate events in
+[`App`](src/app/event_handling.rs) before they reach the candidate widget. An
+ACP error or pre-start `RequestFailed` is logged and captured rather than
+forwarded into history. A safe ACP message is retained only when it has a
+distinct, non-empty string `data.detail`; otherwise the request-failure message
+becomes the retained fallback. On terminal `SessionEnded`, the TUI renders
+exactly one failure through the still-active widget, preferring detailed ACP
+context, then the request-failure message, then the terminal lifecycle message.
+This preserves useful broker detail without duplicating hidden candidate
+failures or exposing other structured fields.
 
 Bare `/login` has a narrow candidate-target override. Selecting a candidate
 sets it, and preparation or activation failure leaves it available so the user

--- a/nori-rs/tui/src/app/event_handling.rs
+++ b/nori-rs/tui/src/app/event_handling.rs
@@ -1,5 +1,29 @@
 use super::*;
 
+fn candidate_activation_failure_message(
+    event: &nori_protocol::SessionEvent,
+    raw_error: &mut Option<String>,
+) -> Option<String> {
+    match event {
+        nori_protocol::SessionEvent::Acp(nori_protocol::AcpEvent::Response {
+            response: Err(error),
+            ..
+        }) => {
+            *raw_error = Some(ChatWidget::acp_error_message(error));
+            None
+        }
+        nori_protocol::SessionEvent::Nori(nori_protocol::NoriEvent::SessionEnded(ended)) => {
+            Some(raw_error.take().unwrap_or_else(|| {
+                ended
+                    .message
+                    .clone()
+                    .unwrap_or_else(|| "Candidate session ended during activation".to_string())
+            }))
+        }
+        _ => None,
+    }
+}
+
 impl App {
     /// Clear and report a due deferred agent spawn.
     ///
@@ -139,6 +163,7 @@ impl App {
                         agent_name,
                         display_name,
                         widget: Box::new(widget),
+                        activation_error: None,
                     });
                     tui.frame_requester().schedule_frame();
                     return Ok(true);
@@ -667,25 +692,26 @@ impl App {
                         ) => Some(started.clone()),
                         _ => None,
                     };
-                    let ended_message = match &event {
-                        nori_protocol::SessionEvent::Nori(
-                            nori_protocol::NoriEvent::SessionEnded(ended),
-                        ) => Some(ended.message.clone().unwrap_or_else(|| {
-                            "Candidate session ended during activation".to_string()
-                        })),
-                        _ => None,
-                    };
-                    if let Some(CandidateAgent::Activating { widget, .. }) =
-                        self.candidate_agent.as_mut()
+                    let ended_message = if let Some(CandidateAgent::Activating {
+                        widget,
+                        activation_error,
+                        ..
+                    }) = self.candidate_agent.as_mut()
                     {
+                        let message =
+                            candidate_activation_failure_message(&event, activation_error);
                         widget.handle_session_event(generation, event);
-                    }
+                        message
+                    } else {
+                        None
+                    };
 
                     if let Some(started) = started {
                         let Some(CandidateAgent::Activating {
                             agent_name,
                             display_name,
                             widget,
+                            ..
                         }) = self.candidate_agent.take()
                         else {
                             unreachable!("candidate generation checked above")
@@ -1623,6 +1649,7 @@ impl App {
                         agent_name,
                         display_name,
                         widget: Box::new(widget),
+                        activation_error: None,
                     });
                     tui.frame_requester().schedule_frame();
                     return Ok(true);
@@ -1992,6 +2019,7 @@ pub(super) fn reattach_info_message(
 
 #[cfg(test)]
 mod tests {
+    use super::candidate_activation_failure_message;
     use super::reattach_info_message;
 
     #[test]
@@ -2000,5 +2028,42 @@ mod tests {
             "cloud_reattach_info_message",
             reattach_info_message("session-123", Some("Fix reconnect"), true, "Nori Cloud")
         );
+    }
+
+    #[test]
+    fn candidate_activation_prefers_structured_acp_error_detail() {
+        let request_id = nori_protocol::acp::v1::RequestId::Str("session-new".to_string());
+        let error = nori_protocol::acp::v1::Error::new(-32010, "broker unreachable").data(
+            serde_json::json!({
+                "detail": "connection reset by broker",
+                "trace_id": "internal-only"
+            }),
+        );
+        let mut raw_error = None;
+
+        let response = nori_protocol::SessionEvent::Acp(nori_protocol::AcpEvent::Response {
+            request_id,
+            response: Err(error),
+        });
+        assert_eq!(
+            candidate_activation_failure_message(&response, &mut raw_error),
+            None
+        );
+        assert_eq!(
+            raw_error.as_deref(),
+            Some("broker unreachable: connection reset by broker")
+        );
+
+        let ended = nori_protocol::SessionEvent::Nori(nori_protocol::NoriEvent::SessionEnded(
+            nori_protocol::SessionEnded {
+                reason: nori_protocol::SessionEndReason::SpawnFailed,
+                message: Some("Failed to create session".to_string()),
+            },
+        ));
+        assert_eq!(
+            candidate_activation_failure_message(&ended, &mut raw_error).as_deref(),
+            Some("broker unreachable: connection reset by broker")
+        );
+        assert_eq!(raw_error, None);
     }
 }

--- a/nori-rs/tui/src/app/event_handling.rs
+++ b/nori-rs/tui/src/app/event_handling.rs
@@ -1,26 +1,52 @@
 use super::*;
 
-fn candidate_activation_failure_message(
+#[derive(Debug, PartialEq, Eq)]
+enum CandidateActivationEvent {
+    Forward,
+    CapturedError,
+    Ended(String),
+}
+
+fn classify_candidate_activation_event(
     event: &nori_protocol::SessionEvent,
-    raw_error: &mut Option<String>,
-) -> Option<String> {
+    activation_error: &mut Option<String>,
+) -> CandidateActivationEvent {
     match event {
         nori_protocol::SessionEvent::Acp(nori_protocol::AcpEvent::Response {
             response: Err(error),
             ..
         }) => {
-            *raw_error = Some(ChatWidget::acp_error_message(error));
-            None
+            tracing::warn!(
+                code = i32::from(error.code),
+                message = %error.message,
+                detail = ChatWidget::acp_error_detail(error),
+                "ACP candidate activation request failed"
+            );
+            if let Some(message) = ChatWidget::acp_error_message_with_detail(error) {
+                *activation_error = Some(message);
+            }
+            CandidateActivationEvent::CapturedError
+        }
+        nori_protocol::SessionEvent::Nori(nori_protocol::NoriEvent::RequestFailed(failure)) => {
+            tracing::warn!(
+                message = %failure.message,
+                kind = ?failure.kind,
+                "candidate activation request failed"
+            );
+            if activation_error.is_none() {
+                *activation_error = Some(failure.message.clone());
+            }
+            CandidateActivationEvent::CapturedError
         }
         nori_protocol::SessionEvent::Nori(nori_protocol::NoriEvent::SessionEnded(ended)) => {
-            Some(raw_error.take().unwrap_or_else(|| {
+            CandidateActivationEvent::Ended(activation_error.take().unwrap_or_else(|| {
                 ended
                     .message
                     .clone()
                     .unwrap_or_else(|| "Candidate session ended during activation".to_string())
             }))
         }
-        _ => None,
+        _ => CandidateActivationEvent::Forward,
     }
 }
 
@@ -698,10 +724,17 @@ impl App {
                         ..
                     }) = self.candidate_agent.as_mut()
                     {
-                        let message =
-                            candidate_activation_failure_message(&event, activation_error);
-                        widget.handle_session_event(generation, event);
-                        message
+                        match classify_candidate_activation_event(&event, activation_error) {
+                            CandidateActivationEvent::Forward => {
+                                widget.handle_session_event(generation, event);
+                                None
+                            }
+                            CandidateActivationEvent::CapturedError => None,
+                            CandidateActivationEvent::Ended(message) => {
+                                widget.handle_session_event(generation, event);
+                                Some(message)
+                            }
+                        }
                     } else {
                         None
                     };
@@ -2019,7 +2052,8 @@ pub(super) fn reattach_info_message(
 
 #[cfg(test)]
 mod tests {
-    use super::candidate_activation_failure_message;
+    use super::CandidateActivationEvent;
+    use super::classify_candidate_activation_event;
     use super::reattach_info_message;
 
     #[test]
@@ -2046,8 +2080,8 @@ mod tests {
             response: Err(error),
         });
         assert_eq!(
-            candidate_activation_failure_message(&response, &mut raw_error),
-            None
+            classify_candidate_activation_event(&response, &mut raw_error),
+            CandidateActivationEvent::CapturedError
         );
         assert_eq!(
             raw_error.as_deref(),
@@ -2061,9 +2095,42 @@ mod tests {
             },
         ));
         assert_eq!(
-            candidate_activation_failure_message(&ended, &mut raw_error).as_deref(),
-            Some("broker unreachable: connection reset by broker")
+            classify_candidate_activation_event(&ended, &mut raw_error),
+            CandidateActivationEvent::Ended(
+                "broker unreachable: connection reset by broker".to_string()
+            )
         );
         assert_eq!(raw_error, None);
+    }
+
+    #[test]
+    fn candidate_activation_defers_request_failure_until_session_end() {
+        let mut activation_error = None;
+        let failure_message = "Connection timed out. The agent did not respond.";
+        let request_failed = nori_protocol::SessionEvent::Nori(
+            nori_protocol::NoriEvent::RequestFailed(nori_protocol::RequestFailure {
+                request_id: None,
+                message: failure_message.to_string(),
+                kind: nori_protocol::RequestFailureKind::Retryable,
+            }),
+        );
+
+        assert_eq!(
+            classify_candidate_activation_event(&request_failed, &mut activation_error),
+            CandidateActivationEvent::CapturedError
+        );
+        assert_eq!(activation_error.as_deref(), Some(failure_message));
+
+        let ended = nori_protocol::SessionEvent::Nori(nori_protocol::NoriEvent::SessionEnded(
+            nori_protocol::SessionEnded {
+                reason: nori_protocol::SessionEndReason::TimedOut,
+                message: Some(failure_message.to_string()),
+            },
+        ));
+        assert_eq!(
+            classify_candidate_activation_event(&ended, &mut activation_error),
+            CandidateActivationEvent::Ended(failure_message.to_string())
+        );
+        assert_eq!(activation_error, None);
     }
 }

--- a/nori-rs/tui/src/app/mod.rs
+++ b/nori-rs/tui/src/app/mod.rs
@@ -195,6 +195,7 @@ enum CandidateAgent {
         agent_name: String,
         display_name: String,
         widget: Box<ChatWidget>,
+        activation_error: Option<String>,
     },
 }
 

--- a/nori-rs/tui/src/chatwidget/constructors.rs
+++ b/nori-rs/tui/src/chatwidget/constructors.rs
@@ -31,6 +31,7 @@ impl ChatWidget {
             prepared_agent,
             analytics,
         } = common;
+        let activating_prepared_cloud_session = cloud_mode && prepared_agent.is_some();
         let mut rng = rand::rng();
         let placeholder = PROMPT_MODE_PLACEHOLDERS
             [rng.random_range(0..PROMPT_MODE_PLACEHOLDERS.len())]
@@ -154,6 +155,9 @@ impl ChatWidget {
         widget
             .bottom_pane
             .set_acp_wire_recording_enabled(acp_wire_recording_enabled);
+        if activating_prepared_cloud_session {
+            widget.show_connecting_status("Nori Cloud");
+        }
         widget
     }
 
@@ -201,6 +205,7 @@ impl ChatWidget {
             prepared_agent,
             analytics,
         } = common;
+        let activating_prepared_cloud_session = cloud_mode && prepared_agent.is_some();
         let mut rng = rand::rng();
         let placeholder = PROMPT_MODE_PLACEHOLDERS
             [rng.random_range(0..PROMPT_MODE_PLACEHOLDERS.len())]
@@ -326,6 +331,9 @@ impl ChatWidget {
         widget
             .bottom_pane
             .set_acp_wire_recording_enabled(acp_wire_recording_enabled);
+        if activating_prepared_cloud_session {
+            widget.show_connecting_status("Nori Cloud");
+        }
         widget
     }
 

--- a/nori-rs/tui/src/chatwidget/event_handlers.rs
+++ b/nori-rs/tui/src/chatwidget/event_handlers.rs
@@ -15,11 +15,18 @@ fn acp_error_detail(error: &nori_protocol::acp::v1::Error) -> Option<&str> {
 }
 
 impl ChatWidget {
+    pub(crate) fn acp_error_detail(error: &nori_protocol::acp::v1::Error) -> Option<&str> {
+        acp_error_detail(error)
+    }
+
+    pub(crate) fn acp_error_message_with_detail(
+        error: &nori_protocol::acp::v1::Error,
+    ) -> Option<String> {
+        acp_error_detail(error).map(|detail| format!("{}: {detail}", error.message))
+    }
+
     pub(crate) fn acp_error_message(error: &nori_protocol::acp::v1::Error) -> String {
-        match acp_error_detail(error) {
-            Some(detail) => format!("{}: {detail}", error.message),
-            None => error.message.clone(),
-        }
+        Self::acp_error_message_with_detail(error).unwrap_or_else(|| error.message.clone())
     }
 
     pub(crate) fn handle_session_event(

--- a/nori-rs/tui/src/chatwidget/event_handlers.rs
+++ b/nori-rs/tui/src/chatwidget/event_handlers.rs
@@ -4,7 +4,24 @@ use crate::ui_types::PlanItem;
 use crate::ui_types::PlanUpdate;
 use crate::ui_types::StepStatus;
 
+fn acp_error_detail(error: &nori_protocol::acp::v1::Error) -> Option<&str> {
+    error
+        .data
+        .as_ref()
+        .and_then(|data| data.get("detail"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|detail| !detail.is_empty() && *detail != error.message)
+}
+
 impl ChatWidget {
+    pub(crate) fn acp_error_message(error: &nori_protocol::acp::v1::Error) -> String {
+        match acp_error_detail(error) {
+            Some(detail) => format!("{}: {detail}", error.message),
+            None => error.message.clone(),
+        }
+    }
+
     pub(crate) fn handle_session_event(
         &mut self,
         generation: crate::app_event::SessionGeneration,
@@ -95,12 +112,19 @@ impl ChatWidget {
                 request_id,
                 response: Err(error),
             } => {
+                let message = Self::acp_error_message(&error);
+                tracing::warn!(
+                    code = i32::from(error.code),
+                    message = %error.message,
+                    detail = acp_error_detail(&error),
+                    "ACP request failed"
+                );
                 if self.owned_prompt_request_id.as_ref() == Some(&request_id) {
                     if !self.unpaired_prompt_error_ids.remove(&request_id) {
                         self.unpaired_prompt_error_ids.insert(request_id);
                     }
                 } else if !self.unpaired_prompt_error_ids.remove(&request_id) {
-                    self.on_error(error.to_string());
+                    self.on_error(message);
                 }
             }
             nori_protocol::AcpEvent::Request { .. }
@@ -204,17 +228,22 @@ impl ChatWidget {
                 };
                 self.handle_client_phase_changed(phase);
             }
-            nori_protocol::NoriEvent::SessionEnded(ended) => match ended.reason {
-                nori_protocol::SessionEndReason::Shutdown => {
-                    self.app_event_tx.send(AppEvent::ExitRequest);
+            nori_protocol::NoriEvent::SessionEnded(ended) => {
+                if !self.session_configured_received {
+                    self.bottom_pane.hide_status_indicator();
                 }
-                nori_protocol::SessionEndReason::Closed => {
-                    self.app_event_tx.send(AppEvent::SessionClosed);
+                match ended.reason {
+                    nori_protocol::SessionEndReason::Shutdown => {
+                        self.app_event_tx.send(AppEvent::ExitRequest);
+                    }
+                    nori_protocol::SessionEndReason::Closed => {
+                        self.app_event_tx.send(AppEvent::SessionClosed);
+                    }
+                    nori_protocol::SessionEndReason::ConnectionLost
+                    | nori_protocol::SessionEndReason::SpawnFailed
+                    | nori_protocol::SessionEndReason::TimedOut => {}
                 }
-                nori_protocol::SessionEndReason::ConnectionLost
-                | nori_protocol::SessionEndReason::SpawnFailed
-                | nori_protocol::SessionEndReason::TimedOut => {}
-            },
+            }
             nori_protocol::NoriEvent::QueueChanged(queue) => {
                 self.bottom_pane.set_queued_user_messages(queue.prompts);
                 self.request_redraw();
@@ -240,6 +269,9 @@ impl ChatWidget {
             }
             nori_protocol::NoriEvent::Notice(notice) => self.on_warning(notice.message),
             nori_protocol::NoriEvent::RequestFailed(failure) => {
+                if !self.session_configured_received {
+                    self.bottom_pane.hide_status_indicator();
+                }
                 let completes_active_prompt =
                     failure.request_id.as_ref().is_some_and(|request_id| {
                         self.owned_prompt_request_id.as_ref() == Some(request_id)

--- a/nori-rs/tui/src/chatwidget/helpers.rs
+++ b/nori-rs/tui/src/chatwidget/helpers.rs
@@ -142,6 +142,9 @@ impl ChatWidget {
     /// Called when an ACP agent is being spawned and may take time
     /// (e.g., npx/bunx resolving dependencies).
     pub(crate) fn show_connecting_status(&mut self, display_name: &str) {
+        if self.cloud_mode {
+            self.add_info_message(format!("Connecting to {display_name}…"), None);
+        }
         let header = format!("Connecting to {display_name}");
         self.bottom_pane.ensure_status_indicator();
         self.bottom_pane.set_interrupt_hint_visible(false); // Can't interrupt during connect

--- a/nori-rs/tui/src/chatwidget/key_handling.rs
+++ b/nori-rs/tui/src/chatwidget/key_handling.rs
@@ -53,6 +53,11 @@ impl ChatWidget {
         }
 
         match self.bottom_pane.handle_key_event(key_event) {
+            InputResult::Submitted(text)
+                if self.cloud_mode && !self.session_configured_received =>
+            {
+                self.bottom_pane.restore_composer_submission(text);
+            }
             InputResult::Submitted(text) if self.follow_only_attachment => {
                 self.bottom_pane.restore_composer_submission(text);
             }

--- a/nori-rs/tui/src/chatwidget/tests/part10.rs
+++ b/nori-rs/tui/src/chatwidget/tests/part10.rs
@@ -1,5 +1,25 @@
 use super::*;
 
+fn render_bottom_pane(chat: &mut ChatWidget, width: u16) -> String {
+    use crate::render::renderable::Renderable;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+
+    let area = Rect::new(0, 0, width, chat.bottom_pane.desired_height(width));
+    let mut buffer = Buffer::empty(area);
+    chat.bottom_pane.render(area, &mut buffer);
+    (0..area.height)
+        .map(|y| {
+            (0..area.width)
+                .map(|x| buffer[(x, y)].symbol().chars().next().unwrap_or(' '))
+                .collect::<String>()
+                .trim_end()
+                .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 #[test]
 fn candidate_login_target_survives_failure_and_clears_after_success() {
     let (mut chat, _rx, _unused_rx) = make_chatwidget_manual();
@@ -1583,6 +1603,58 @@ fn unrelated_request_failure_does_not_complete_the_active_prompt() {
     assert!(chat.bottom_pane.is_task_running());
     assert_eq!(chat.loop_remaining, Some(5));
     assert_eq!(next_loop_iteration(&mut rx), None);
+}
+
+#[test]
+fn startup_request_failure_stops_the_connecting_indicator() {
+    let (mut chat, mut rx, _op_rx) = make_cloud_chatwidget_manual();
+    let generation = chat.session_generation;
+    chat.set_composer_text("draft while connecting".to_string());
+    chat.show_connecting_status("Nori Cloud");
+    assert!(chat.bottom_pane.status_indicator_visible());
+    insta::assert_snapshot!(
+        "cloud_connecting_bottom_pane",
+        render_bottom_pane(&mut chat, 80)
+    );
+    insta::assert_snapshot!("cloud_connecting_history", history_text(&mut rx));
+
+    chat.handle_session_event(
+        generation,
+        nori_protocol::SessionEvent::Nori(nori_protocol::NoriEvent::RequestFailed(
+            nori_protocol::RequestFailure {
+                request_id: None,
+                message: "Connection timed out. The agent did not respond.".to_string(),
+                kind: nori_protocol::RequestFailureKind::Retryable,
+            },
+        )),
+    );
+
+    assert!(!chat.bottom_pane.status_indicator_visible());
+    insta::assert_snapshot!(
+        "cloud_connection_failure_bottom_pane",
+        render_bottom_pane(&mut chat, 80)
+    );
+    insta::assert_snapshot!("cloud_connection_failure_history", history_text(&mut rx));
+}
+
+#[test]
+fn startup_session_end_stops_the_connecting_indicator_without_a_request_failure() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual();
+    let generation = chat.session_generation;
+    chat.show_connecting_status("Nori Cloud");
+    assert!(chat.bottom_pane.status_indicator_visible());
+
+    chat.handle_session_event(
+        generation,
+        nori_protocol::SessionEvent::Nori(nori_protocol::NoriEvent::SessionEnded(
+            nori_protocol::SessionEnded {
+                reason: nori_protocol::SessionEndReason::SpawnFailed,
+                message: Some("Failed to create session".to_string()),
+            },
+        )),
+    );
+
+    assert!(!chat.bottom_pane.status_indicator_visible());
 }
 
 #[test]

--- a/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part10__cloud_connecting_bottom_pane.snap
+++ b/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part10__cloud_connecting_bottom_pane.snap
@@ -1,0 +1,8 @@
+---
+source: tui/src/chatwidget/tests/part10.rs
+expression: "render_bottom_pane(&mut chat, 80)"
+---
+• Connecting to Nori Cloud (0s)
+
+
+› draft while connecting

--- a/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part10__cloud_connecting_history.snap
+++ b/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part10__cloud_connecting_history.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/chatwidget/tests/part10.rs
+expression: history_text(&mut rx)
+---
+• Connecting to Nori Cloud…

--- a/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part10__cloud_connection_failure_bottom_pane.snap
+++ b/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part10__cloud_connection_failure_bottom_pane.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/chatwidget/tests/part10.rs
+expression: "render_bottom_pane(&mut chat, 80)"
+---
+› draft while connecting

--- a/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part10__cloud_connection_failure_history.snap
+++ b/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part10__cloud_connection_failure_history.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/chatwidget/tests/part10.rs
+expression: history_text(&mut rx)
+---
+■ Connection timed out. The agent did not respond.


### PR DESCRIPTION
## Summary

🤖 Generated with [Nori](https://noriagentic.com/)

- show live and durable connection progress while Handroll claims or resumes a Nori Cloud session
- preserve typed drafts and block prompt submission until `SessionStarted`
- render actionable ACP error message/detail in history, stop stale connection indicators, and preserve candidate activation failures
- add snapshot and PTY coverage, plus harden macOS PTY normalization/analytics test infrastructure

## Test plan

- [x] `cargo test -p nori-tui`
- [x] `cargo test -p tui-pty-e2e`
- [x] `cargo build --bin nori`
- [x] `cargo build -p mock-acp-agent`
- [x] `just clippy`
- [x] manual delayed-claim and structured-error TUI flows

Share Nori with your friends → [noriagentic.com](https://noriagentic.com/)
