### PR TITLE
fix(tui): bypass local startup flows in cloud mode

### DIFF
--- a/nori-rs/tui-pty-e2e/docs.md
+++ b/nori-rs/tui-pty-e2e/docs.md
@@ -60,6 +60,11 @@ before `SessionStarted`, and a later retry crosses ACP exactly once. A
 structured new-session failure also proves that the terminal shows the ACP
 message and string `data.detail` while excluding unrelated diagnostic fields.
 
+Cloud startup scenarios enable the local onboarding/trust, automatic-worktree,
+and per-session-skillset policies independently. Each must still reach the
+Handroll session picker without showing a local gate, creating a local
+worktree, or delaying agent preparation.
+
 The protocol hard cut did not introduce a test-only compatibility path. PTY
 tests exercise source-first `SessionEvent::{Acp, Nori}` dispatch and the same
 typed `HarnessHandle` methods available to headless embedders.

--- a/nori-rs/tui-pty-e2e/tests/cloud_mode.rs
+++ b/nori-rs/tui-pty-e2e/tests/cloud_mode.rs
@@ -321,6 +321,70 @@ fn test_cloud_mode_boots_into_session_picker_without_claiming() {
     );
 }
 
+/// Cloud startup owns its own Handroll-backed onboarding and must not be
+/// intercepted by the CLI's first-launch or directory-trust screens.
+#[test]
+fn test_cloud_mode_bypasses_local_onboarding_and_trust() {
+    let fake = FakeHandroll::new();
+    let config = cloud_lifecycle_config(&fake)
+        .with_skip_trust_directory(false)
+        .with_config_toml("");
+
+    let mut session =
+        TuiSession::spawn_with_config(24, 80, config).expect("Failed to spawn nori cloud");
+
+    session
+        .wait_for_text("Start a new session", TIMEOUT)
+        .expect("cloud entry should bypass local onboarding and open the session picker");
+
+    let contents = session.screen_contents();
+    assert!(
+        !contents.contains("Welcome to Nori") && !contents.contains("You are running Nori in"),
+        "cloud entry must not show local onboarding or directory trust, screen:\n{contents}"
+    );
+}
+
+/// Automatic worktrees configure local coding sessions. Cloud startup must
+/// neither create one nor switch its working directory before Handroll starts.
+#[test]
+fn test_cloud_mode_ignores_automatic_worktree() {
+    let fake = FakeHandroll::new();
+    let config = cloud_lifecycle_config(&fake)
+        .with_extra_config_toml("[tui]\nauto_worktree = \"automatic\"\n");
+
+    let mut session =
+        TuiSession::spawn_with_config(24, 80, config).expect("Failed to spawn nori cloud");
+    let local_repo = session.nori_home_path().expect("temporary local repo");
+
+    session
+        .wait_for_text("Start a new session", TIMEOUT)
+        .expect("cloud entry should open the session picker");
+
+    assert!(
+        !local_repo.join(".worktrees").exists(),
+        "cloud entry must not create a local auto-worktree"
+    );
+}
+
+/// Per-session skillset selection is a local-session concern and must not
+/// delay or replace the Handroll Cloud picker.
+#[test]
+fn test_cloud_mode_bypasses_per_session_skillset_picker() {
+    let fake = FakeHandroll::new();
+    let config = cloud_lifecycle_config(&fake)
+        .with_extra_config_toml("[tui]\nskillset_per_session = true\n");
+
+    let mut session =
+        TuiSession::spawn_with_config(24, 80, config).expect("Failed to spawn nori cloud");
+
+    session
+        .wait_for_text("Start a new session", TIMEOUT)
+        .expect("cloud entry should bypass skillset selection and open the session picker");
+    session
+        .wait_for_text("First mock session", TIMEOUT)
+        .expect("the Handroll Cloud picker should list its live session");
+}
+
 /// Picker-first entry must retain the CLI's positional prompt until the user
 /// explicitly starts a new session on the prepared connection.
 #[test]

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -583,14 +583,24 @@ Cloud sessions use standard ACP `session/list`, `session/resume`,
 `session/load`, and `session/close`. Capabilities describe what an initialized
 ACP facade supports; they are not a sound test for whether its process
 represents a remote VM. The top-level `nori cloud` launch supplies explicit
-`cloud_mode` state through `TuiCli`, `App`, and `ChatWidget`. Cloud entry is
-normally picker-first: `App::run` prepares one connection and opens its session
-picker before any session directive can claim a VM, with "Start a new session"
-as an explicit pick. The prepared child remains alive behind that picker and
-the selection consumes it rather than spawning a second agent. The clap-skipped
-`cloud_onboard` flag (`nori cloud --onboard`, for customer onboarding) skips
-the picker but runs the same bounded connection preparation. The broker projects
-the config-pinned onboarding session as `_meta.nori.purpose = "onboarding"`;
+`cloud_mode` state through `TuiCli`, `App`, and `ChatWidget`. Before the TUI
+starts, [`run_main`](src/lib.rs) bypasses the local auto-worktree policy — its
+ask and blocked screens as well as automatic creation — and the local
+first-launch/directory-trust flow for this mode. During application
+construction, [`App`](src/app/mod.rs) also suppresses per-session skillset
+selection and its deferred agent preparation. These settings remain available
+to ordinary local sessions but cannot intercept, change the working directory
+for, or delay Handroll Cloud startup.
+
+Cloud entry is normally picker-first: `App::run` prepares one connection and
+opens its session picker before any session directive can claim a VM, with
+"Start a new session" as an explicit pick. The prepared child remains alive
+behind that picker and the selection consumes it rather than spawning a second
+agent. The clap-skipped `cloud_onboard` flag (`nori cloud --onboard`, for
+customer onboarding) skips the picker but runs the same bounded connection
+preparation. It remains a Handroll/ACP onboarding path and does not re-enable
+the suppressed local startup flows. The broker projects the config-pinned
+onboarding session as `_meta.nori.purpose = "onboarding"`;
 when that tag is present, the TUI emits the existing resume action and the
 harness uses `session/load`, including recorded-history replay. If no tagged
 session is present, or listing is unsupported, onboarding explicitly starts a

--- a/nori-rs/tui/src/app/mod.rs
+++ b/nori-rs/tui/src/app/mod.rs
@@ -292,7 +292,7 @@ impl App {
             Self::spawn_system_info_worker(system_info_rx, app_event_tx.clone());
         let footer_segment_config = config.footer_segment_config.clone();
         let footer_layout_config = config.footer_layout_config.clone();
-        let skillset_per_session = config.skillset_per_session;
+        let skillset_per_session = !cloud_mode && config.skillset_per_session;
 
         let mut app = Self {
             app_event_tx,
@@ -389,7 +389,7 @@ impl App {
         // write `.claude/CLAUDE.md` before the agent reads it. Applying or
         // dismissing the picker starts preparation without activating a
         // session.
-        if app.config.skillset_per_session {
+        if skillset_per_session {
             app.chat_widget.handle_switch_skillset_command();
         } else if app.pending_session_activation.is_some() {
             app.begin_agent_preparation(crate::app_event::AgentPrepareIntent::Idle);

--- a/nori-rs/tui/src/lib.rs
+++ b/nori-rs/tui/src/lib.rs
@@ -197,7 +197,7 @@ pub async fn run_main(
         use nori_config::AutoWorktree;
         let auto_worktree = config.auto_worktree;
 
-        if !auto_worktree.is_enabled() {
+        if cli.cloud_mode || !auto_worktree.is_enabled() {
             (false, None)
         } else {
             match cwd.clone().or_else(|| std::env::current_dir().ok()) {
@@ -358,8 +358,9 @@ async fn run_ratatui_app(
         codex_login::AuthCredentialsStoreMode::File,
     );
     let should_show_trust_screen = should_show_trust_screen(&initial_config);
-    let should_show_onboarding = should_show_trust_screen
-        || (!cli.skip_welcome && nori::onboarding::is_first_launch(&initial_config.nori_home));
+    let should_show_onboarding = !cli.cloud_mode
+        && (should_show_trust_screen
+            || (!cli.skip_welcome && nori::onboarding::is_first_launch(&initial_config.nori_home)));
 
     let (config, overrides) = if should_show_onboarding {
         // Use Nori-branded onboarding flow


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- bypass local onboarding and directory trust during Nori Cloud startup
- prevent auto-worktree creation and per-session skillset selection from intercepting Cloud
- cover each startup policy with PTY end-to-end regressions

## Test Plan
- [x] `cargo test -p nori-tui`
- [x] `cargo build --bin nori`
- [x] `cargo test -p tui-pty-e2e`
- [x] isolated tmux smoke: picker → new Cloud session → ready composer
- [x] `just fix -p nori-tui`
- [x] `just fmt`

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets