### PR TITLE
fix(tui): write Codex OAuth login to the codex agent home

### DIFF
--- a/nori-rs/acp-host/docs.md
+++ b/nori-rs/acp-host/docs.md
@@ -154,6 +154,17 @@ The dependency direction stays `nori-harness -> nori-acp-host`.
   Codex configuration explicitly instead of silently discarding user settings.
   Codex model injection merges only the `model` key into that same object,
   preserving the goals-disabled flag.
+- The Codex agent subprocess is spawned with `CODEX_HOME` stripped
+  (`.env_remove("CODEX_HOME")` in `connection/acp_connection.rs`), so it resolves
+  its home to `$HOME/.codex` and reads its credentials from
+  `~/.codex/auth.json`, ignoring any `CODEX_HOME` override. The invariant this
+  enforces: whatever writes Codex credentials must target the same home the
+  subprocess reads. Nori's in-app OAuth `/login`
+  (`@/nori-rs/tui/src/chatwidget/login.rs`) therefore writes to `~/.codex` rather
+  than `nori_home`; writing anywhere else means a successful login never
+  authenticates the agent. Nori's own in-process `AuthManager` (which reads
+  `nori_home`) is not consumed by the ACP path, so the login flow's
+  `auth_manager.reload()` has no effect on the Codex agent.
 - Model injection does not validate the model id: an invalid model is accepted at
   spawn and only fails at the first prompt. For env-based channels, nori's
   injected value takes precedence over the agent's own configured model (e.g.

--- a/nori-rs/acp-host/src/connection/docs.md
+++ b/nori-rs/acp-host/src/connection/docs.md
@@ -79,5 +79,10 @@ remain unrestricted. Host-handled requests do not leak duplicate public
   respectively.
 - The connection uses `ProtocolVersion::LATEST` while enforcing ACP v1 as the
   minimum supported version.
+- Spawn strips `CODEX_HOME` (`.env_remove("CODEX_HOME")`), so a Codex agent
+  subprocess resolves its home to `$HOME/.codex` and reads credentials from
+  `~/.codex/auth.json`. Anything writing those credentials (notably the TUI's
+  in-app OAuth `/login`) must target that same home; see
+  `@/nori-rs/acp-host/docs.md`.
 
 Created and maintained by Nori.

--- a/nori-rs/login/docs.md
+++ b/nori-rs/login/docs.md
@@ -26,6 +26,9 @@ Used by `@/nori-rs/tui/` (via the `login` feature) to implement the `/login` sla
 - Serve the OAuth redirect endpoint
 - Receive authorization codes
 - Exchange codes for tokens
+- Persist tokens (`persist_tokens_async` → `save_auth`) into the `codex_home`
+  directory passed via `ServerOptions`, honoring the caller-selected
+  `AuthCredentialsStoreMode`.
 
 ### Things to Know
 
@@ -33,7 +36,12 @@ Used by `@/nori-rs/tui/` (via the `login` feature) to implement the `/login` sla
   login helpers from `codex-core::auth`; it has no app-server protocol
   dependency
 - Supports both API key login and OAuth flows
-- Tokens are stored in system keyring via `codex-keyring-store`
+- Storage backend is caller-selected via `AuthCredentialsStoreMode`
+  (`File`, `Keyring`, `Auto`); only `Keyring`/`Auto` touch
+  `codex-keyring-store`, while `File` writes `codex_home/auth.json`. The TUI's
+  in-app OAuth `/login` (`@/nori-rs/tui/src/chatwidget/login.rs`) uses `File`
+  mode and must target the Codex agent home (`~/.codex`), because the codex-acp
+  subprocess reads its `auth.json` from there — see `@/nori-rs/acp-host/docs.md`.
 - The `CLIENT_ID` constant identifies Nori to OAuth providers
 
 Created and maintained by Nori.

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -551,6 +551,13 @@ successful switch replaces the widget and returns bare `/login` to the active
 agent. The override affects login resolution only—prompts and lifecycle actions
 continue to target the current session unless a real candidate state exists.
 
+The Codex OAuth `/login` flow (`chatwidget/login.rs`) writes its credentials to
+the Codex agent home (`$HOME/.codex`, resolved by `codex_oauth_credentials_home`
+with a `nori_home` fallback), not `nori_home`. This matches where the codex-acp
+subprocess actually reads `auth.json`, since that subprocess is spawned with
+`CODEX_HOME` stripped (see `@/nori-rs/acp-host/docs.md`). The resolver
+deliberately ignores `$CODEX_HOME` because the subprocess ignores it too.
+
 The app-owned `HarnessRemoteHost` follows the same commit boundary. `App`
 attaches the stable host only after the active widget publishes
 `SessionStarted`, seeding identity from that observed event. During a switch it

--- a/nori-rs/tui/src/chatwidget/login.rs
+++ b/nori-rs/tui/src/chatwidget/login.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use std::path::Path;
+
 impl ChatWidget {
     /// Handle the /login slash command
     pub(super) fn handle_login_command(&mut self) {
@@ -98,8 +100,10 @@ impl ChatWidget {
         use codex_login::ServerOptions;
         use codex_login::run_login_server;
 
+        let credentials_home =
+            codex_oauth_credentials_home(&self.config.nori_home, dirs::home_dir());
         let opts = ServerOptions::new(
-            self.config.nori_home.clone(),
+            credentials_home,
             CLIENT_ID.to_string(),
             None, // No forced workspace ID
             codex_login::AuthCredentialsStoreMode::File,
@@ -282,5 +286,44 @@ impl ChatWidget {
             self.add_info_message(format!("{agent_name} login failed or was cancelled."), None);
         }
         self.request_redraw();
+    }
+}
+
+/// Directory the Codex OAuth login writes credentials to.
+///
+/// This must match the directory the codex-acp subprocess reads auth from. That
+/// subprocess is spawned with `CODEX_HOME` stripped (see the connection spawn in
+/// `nori-acp-host`), so it resolves its home to `$HOME/.codex`. Writing anywhere
+/// else (for example `nori_home`) means the agent never sees the credentials.
+/// Falls back to `nori_home` only when the home directory cannot be determined.
+fn codex_oauth_credentials_home(nori_home: &Path, home_dir: Option<PathBuf>) -> PathBuf {
+    home_dir
+        .map(|home| home.join(".codex"))
+        .unwrap_or_else(|| nori_home.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::codex_oauth_credentials_home;
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+
+    #[test]
+    fn oauth_login_targets_codex_agent_home_when_home_known() {
+        let nori_home = PathBuf::from("/example/home/.nori/cli");
+        let home_dir = PathBuf::from("/example/home");
+
+        let destination = codex_oauth_credentials_home(&nori_home, Some(home_dir));
+
+        assert_eq!(destination, PathBuf::from("/example/home/.codex"));
+    }
+
+    #[test]
+    fn oauth_login_falls_back_to_nori_home_when_home_unknown() {
+        let nori_home = PathBuf::from("/example/home/.nori/cli");
+
+        let destination = codex_oauth_credentials_home(&nori_home, None);
+
+        assert_eq!(destination, nori_home);
     }
 }


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://noriagentic.com/)

- Nori's in-app `/login` (OAuth for Codex) wrote credentials to `nori_home/auth.json` (default `~/.nori/cli`), but the codex-acp subprocess is spawned with `CODEX_HOME` stripped and reads `~/.codex/auth.json`. The two never matched, so a successful `/login` never authenticated Codex, and `/agent → Codex` kept failing with *"Authentication required for Codex ACP"*.
- Fix: the OAuth login now writes credentials to the codex agent home (`$HOME/.codex`) via a small `codex_oauth_credentials_home` resolver, so they land where the subprocess reads them. Store mode is unchanged (`File`); only the directory moves.
- The resolver deliberately ignores `$CODEX_HOME` (mirroring the subprocess strip) and falls back to `nori_home` only when the home dir is unresolvable. Docs updated across `login`, `acp-host`, `acp-host/connection`, and `tui` to record the invariant.

### Why it "worked before"
Not a recent code regression. The split has existed since the `CODEX_HOME` strip landed (early 2026); it only surfaced now because the credentials the subprocess actually reads (`~/.codex/auth.json`) went stale, and `/login` writes elsewhere so it couldn't refresh them.

### Known follow-ups (out of scope)
- Nori's in-process `AuthManager` (reads `nori_home`) is unused fork residue in the ACP path; `auth_manager.reload()` on the login path has no effect on Codex. Candidate for the slim-net cleanup.
- The subprocess ignores `$CODEX_HOME` entirely (pre-existing strip behavior), so a standalone `codex login` into a custom `$CODEX_HOME` still won't be seen by Nori's Codex agent.

## Test Plan
- [x] `cargo test -p nori-tui` (1394 pass; adds 2 unit tests for the credential-home resolver)
- [x] `cargo build --bin nori && cargo test -p tui-pty-e2e` (all pass)
- [x] `just fmt` + `just fix -p nori-tui` clean
- [x] Drove the real TUI (elizacp): launches, `›` prompt appears, accepts input, prompt returns
- [ ] Manual: run `/login` for Codex, confirm `~/.codex/auth.json` is written and `/agent → Codex` authenticates (real OpenAI OAuth cannot run in CI/sandbox)

Share Nori with your team: https://www.npmjs.com/package/nori-skillsets