### PR TITLE
fix(tui): preserve composer drafts across session activation

### DIFF
--- a/docs/specs/acp-connection-lifecycle.md
+++ b/docs/specs/acp-connection-lifecycle.md
@@ -211,10 +211,12 @@ anything claims one.
 The prepared connection is consumed through that pending New decision. Besides
 startup, `/new`, the first genuine user prompt, and initial positional prompts
 and images all record the same decision when a session is not yet active. Input
-typed while activation is still in flight is preserved: its text and image
-attachments are owned by the deferred widget, any in-flight paste burst is
-flushed at the handoff, and everything transfers to the activated widget to be
-submitted exactly once after the session-configured (`SessionStarted`) boundary.
+typed while activation is still in flight is preserved. Unsubmitted edits move
+as an owned `ComposerDraft`, retaining the cursor, undo/Vim state, image and
+large-paste placeholders and payloads, and any buffered input with its original
+flush deadline. A handoff must not round-trip an edit through plain text setters.
+Already-submitted activation input transfers separately and is submitted exactly
+once after the session-configured (`SessionStarted`) boundary.
 
 `/resume` uses the catalog gathered during preparation when the agent can load
 or resume listed sessions. Selecting a row consumes the prepared connection

--- a/nori-rs/tui-pty-e2e/docs.md
+++ b/nori-rs/tui-pty-e2e/docs.md
@@ -58,6 +58,11 @@ additionally proves that a session activates without input (the resolved model
 name appears), that `/model` lists the agent's advertised models before any
 prompt, and that per-session skillsets auto-activate once a skillset is applied.
 
+`startup_draft.rs` gates agent preparation on a file, renders the first draft
+character, releases preparation, and types the remaining text after activation.
+This deterministically checks cursor preservation across the widget handoff and
+then verifies that Ctrl-C clears the correctly ordered draft.
+
 Cloud activation scenarios hold `session/new` behind a release-file barrier
 after the picker selection. They verify that connecting feedback remains in
 history, typing stays available, Enter preserves rather than queues the draft

--- a/nori-rs/tui-pty-e2e/tests/snapshots/startup_draft__startup_draft_after_activation.snap
+++ b/nori-rs/tui-pty-e2e/tests/snapshots/startup_draft__startup_draft_after_activation.snap
@@ -1,0 +1,5 @@
+---
+source: tui-pty-e2e/tests/startup_draft.rs
+expression: composer
+---
+› draft message

--- a/nori-rs/tui-pty-e2e/tests/startup_draft.rs
+++ b/nori-rs/tui-pty-e2e/tests/startup_draft.rs
@@ -1,0 +1,64 @@
+#![cfg(unix)]
+
+//! Hold agent preparation behind a file gate to force a draft across activation.
+
+use pretty_assertions::assert_eq;
+use tui_pty_e2e::Key;
+use tui_pty_e2e::SessionConfig;
+use tui_pty_e2e::TIMEOUT;
+use tui_pty_e2e::TuiSession;
+
+#[test]
+fn startup_preserves_draft_cursor_across_activation() {
+    let dir = tempfile::tempdir().unwrap();
+    let gate = dir.path().join("activate");
+    let mock = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("mock_acp_agent");
+    assert!(mock.exists(), "missing mock agent: {}", mock.display());
+    let config = format!(
+        r#"agent = "gated-mock"
+[[agents]]
+name = "Gated Mock"
+slug = "gated-mock"
+[agents.distribution.local]
+command = "/bin/sh"
+args = ["-c", 'while [ ! -f "$1" ]; do sleep 0.01; done; exec "$2"', "gated-mock", {gate:?}, {mock:?}]
+"#,
+    );
+    let mut session = TuiSession::spawn_with_config(
+        24,
+        80,
+        SessionConfig::new()
+            .with_agent("gated-mock".to_string())
+            .with_config_toml(config),
+    )
+    .unwrap();
+    session.wait_for_text("›", TIMEOUT).unwrap();
+    session.send_key(Key::Char('d')).unwrap();
+    session.wait_for_text("› d", TIMEOUT).unwrap();
+    // The agent cannot prepare until the first character has rendered.
+    std::fs::write(&gate, "ready").unwrap();
+    session
+        .wait_for_text("Mock Default Model", TIMEOUT)
+        .unwrap();
+    session.type_input("raft message").unwrap();
+    let screen = session.screen_contents();
+    let composer = screen
+        .lines()
+        .rev()
+        .find(|line| line.contains('›'))
+        .unwrap()
+        .trim();
+    assert_eq!(composer, "› draft message");
+    insta::assert_snapshot!("startup_draft_after_activation", composer);
+
+    session.send_key(Key::Ctrl('c')).unwrap();
+    session
+        .wait_for(|screen| !screen.contains("draft message"), TIMEOUT)
+        .unwrap();
+}

--- a/nori-rs/tui/docs.md
+++ b/nori-rs/tui/docs.md
@@ -507,12 +507,15 @@ composer distinguishes activation input from local behavior. Any text or image
 prompt entered before the session is live remains in frontend state, requests
 New, and is transferred without rewriting to the activated widget, which submits
 it exactly once when `SessionStarted` establishes the configured session.
-Because activation rebuilds the composer widget, any in-flight paste burst is
-force-flushed before the handoff reads `composer_text`, so characters typed
-mid-burst are committed rather than dropped when the widget is rebuilt; this
-pass-through runs [`helpers.rs`](src/chatwidget/helpers.rs) ->
+Because activation rebuilds the composer widget, it transfers an owned
+`ComposerDraft` rather than restoring a plain text copy. The draft retains the
+cursor, undo/Vim state, atomic placeholders and their image/large-paste payloads,
+and buffered characters with their original paste deadline. This also preserves
+input that has not rendered yet. Ordinary `set_composer_text` replacement clears
+old buffered input and puts the cursor at the end; it is not a handoff API.
+The transfer runs [`helpers.rs`](src/chatwidget/helpers.rs) ->
 [`bottom_pane/mod.rs`](src/bottom_pane/mod.rs) ->
-[`chat_composer/paste_handling.rs`](src/bottom_pane/chat_composer/paste_handling.rs).
+[`chat_composer/draft.rs`](src/bottom_pane/chat_composer/draft.rs).
 Initial positional prompts use the same path. Activation replaces the
 sessionless widget, so `SessionStarted` first applies normal history metadata to
 the new widget, then records its queued launch prompt into composer-local

--- a/nori-rs/tui/src/app/event_handling.rs
+++ b/nori-rs/tui/src/app/event_handling.rs
@@ -219,11 +219,7 @@ impl App {
                     self.pending_session_activation = None;
                     self.deferred_spawn_pending = false;
                     let (initial_prompt, initial_images) = self.chat_widget.take_initial_input();
-                    // Commit any in-flight paste burst before reading the composer
-                    // so input typed while the session was activating is carried
-                    // over to the rebuilt widget instead of being dropped.
-                    self.chat_widget.flush_paste_burst();
-                    let composer_text = self.chat_widget.composer_text();
+                    let composer_draft = self.chat_widget.take_composer_draft();
                     let loop_state = self.chat_widget.loop_state();
                     self.shutdown_current_conversation();
                     let mut init = self.chat_widget_init(
@@ -237,9 +233,7 @@ impl App {
                     init.prepared_agent = Some(agent);
                     self.chat_widget = ChatWidget::new(init);
                     self.configure_new_chat_widget();
-                    if !composer_text.is_empty() {
-                        self.chat_widget.set_composer_text(composer_text);
-                    }
+                    self.chat_widget.restore_composer_draft(composer_draft);
                     if let Some((remaining, total)) = loop_state {
                         self.chat_widget.set_loop_state(remaining, total);
                     }

--- a/nori-rs/tui/src/bottom_pane/chat_composer/draft.rs
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/draft.rs
@@ -1,0 +1,43 @@
+//! Transfer an in-progress edit without flattening it into replacement text.
+
+use super::*;
+
+/// Owned editing state for a widget handoff. Moving the textarea preserves its
+/// cursor, atomic placeholders, undo history, and Vim editing state. Session
+/// metadata, agent commands, and popup results stay with their owning widget.
+#[must_use]
+pub(crate) struct ComposerDraft {
+    textarea: TextArea,
+    textarea_state: TextAreaState,
+    pending_pastes: Vec<(String, String)>,
+    attached_images: Vec<AttachedImage>,
+    is_shell_mode: bool,
+    paste_burst: PasteBurst,
+}
+
+impl ChatComposer {
+    /// Take the edit before discarding this composer. A buffered first character
+    /// or paste is part of the draft even when `current_text()` is still empty.
+    pub(crate) fn take_draft(&mut self) -> ComposerDraft {
+        ComposerDraft {
+            textarea: std::mem::replace(&mut self.textarea, TextArea::new()),
+            textarea_state: self.textarea_state.take(),
+            pending_pastes: std::mem::take(&mut self.pending_pastes),
+            attached_images: std::mem::take(&mut self.attached_images),
+            is_shell_mode: std::mem::take(&mut self.is_shell_mode),
+            paste_burst: std::mem::take(&mut self.paste_burst),
+        }
+    }
+
+    /// Restore an edit into a replacement widget, including the unflushed input
+    /// and its original deadline. The next paste tick continues the same burst.
+    pub(crate) fn restore_draft(&mut self, draft: ComposerDraft) {
+        self.textarea = draft.textarea;
+        self.textarea_state.replace(draft.textarea_state);
+        self.pending_pastes = draft.pending_pastes;
+        self.attached_images = draft.attached_images;
+        self.is_shell_mode = draft.is_shell_mode;
+        self.paste_burst = draft.paste_burst;
+        self.sync_selection_popups();
+    }
+}

--- a/nori-rs/tui/src/bottom_pane/chat_composer/mod.rs
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/mod.rs
@@ -173,6 +173,8 @@ const FOOTER_SPACING_HEIGHT: u16 = 0;
 /// below. The padding rows are where the textarea corner segments render.
 const MIN_COMPOSER_HEIGHT: u16 = 3;
 
+mod draft;
+pub(crate) use draft::ComposerDraft;
 mod key_handling;
 mod paste_handling;
 mod popup_management;
@@ -334,11 +336,13 @@ impl ChatComposer {
         self.input_enabled
     }
 
-    /// Replace the entire composer content with `text` and reset cursor.
+    /// Replace the draft with `text`, discard buffered input, and place the cursor
+    /// at the end. Widget handoffs must use `take_draft` / `restore_draft`.
     pub(crate) fn set_text_content(&mut self, text: String) {
         if !self.input_enabled {
             return;
         }
+        self.paste_burst = PasteBurst::default();
         // Clear any existing content, placeholders, and attachments first.
         self.textarea.set_text("");
         self.pending_pastes.clear();
@@ -350,7 +354,7 @@ impl ChatComposer {
             self.is_shell_mode = false;
             self.textarea.set_text(&text);
         }
-        self.textarea.set_cursor(0);
+        self.textarea.set_cursor(self.textarea.text().len());
         self.sync_selection_popups();
     }
 
@@ -370,7 +374,6 @@ impl ChatComposer {
             return;
         }
         self.set_text_content(text);
-        self.textarea.set_cursor(self.textarea.text().len());
     }
 
     pub(crate) fn clear_for_ctrl_c(&mut self) -> Option<String> {

--- a/nori-rs/tui/src/bottom_pane/chat_composer/paste_handling.rs
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/paste_handling.rs
@@ -113,15 +113,6 @@ impl ChatComposer {
         self.handle_paste_burst_flush(Instant::now())
     }
 
-    /// Force any in-flight paste burst into the textarea now, ignoring the burst
-    /// timer. Used before the composer contents are read for a session-activation
-    /// handoff so text typed mid-burst is not dropped when the widget is rebuilt.
-    pub(crate) fn flush_paste_burst(&mut self) {
-        if let Some(pasted) = self.paste_burst.flush_before_modified_input() {
-            self.handle_paste(pasted);
-        }
-    }
-
     pub(crate) fn is_in_paste_burst(&self) -> bool {
         self.paste_burst.is_active()
     }

--- a/nori-rs/tui/src/bottom_pane/chat_composer/tests/draft.rs
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/tests/draft.rs
@@ -1,0 +1,129 @@
+use super::*;
+use pretty_assertions::assert_eq;
+
+fn composer() -> ChatComposer {
+    let (tx, _rx) = unbounded_channel::<AppEvent>();
+    ChatComposer::new(true, AppEventSender::new(tx), false, String::new(), false)
+}
+
+#[test]
+fn replacement_text_appends_typing_and_discards_old_buffered_input() {
+    for replacement in ["draft", "héllo", "!echo hi", ""] {
+        let mut composer = composer();
+        composer.handle_key_event(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+        composer.set_text_content(replacement.to_string());
+        composer.handle_paste_burst_flush(Instant::now() + Duration::from_secs(1));
+        composer.insert_str(" suffix");
+        assert_eq!(composer.current_text(), format!("{replacement} suffix"));
+    }
+}
+
+#[test]
+fn handoff_preserves_cursor_at_every_input_boundary() {
+    let input = "draft message";
+    for split in 0..=input.len() {
+        let mut before = composer();
+        before.handle_paste(input[..split].to_string());
+        let mut after = composer();
+        after.restore_draft(before.take_draft());
+        after.handle_paste(input[split..].to_string());
+        assert_eq!(after.current_text(), input, "handoff at {split}");
+    }
+}
+
+#[test]
+fn handoff_preserves_pending_first_character_and_paste_burst() {
+    for input in ["d", "draft message"] {
+        let mut before = composer();
+        // Construct the burst at one logical instant, independent of scheduling.
+        let now = Instant::now();
+        for ch in input.chars() {
+            match before.paste_burst.on_plain_char(ch, now) {
+                CharDecision::RetainFirstChar => {}
+                CharDecision::BeginBufferFromPending | CharDecision::BufferAppend => {
+                    before.paste_burst.append_char_to_buffer(ch, now);
+                }
+                CharDecision::BeginBuffer { .. } => panic!("first character was held"),
+            }
+        }
+        assert_eq!(before.current_text(), "");
+        let mut after = composer();
+        after.restore_draft(before.take_draft());
+        after.handle_paste_burst_flush(now + Duration::from_secs(1));
+        assert_eq!(after.current_text(), input);
+        after.insert_str(" suffix");
+        assert_eq!(after.current_text(), format!("{input} suffix"));
+    }
+}
+
+#[test]
+fn handoff_preserves_mid_text_cursor_and_undo() {
+    let mut before = composer();
+    before.handle_paste("héllo world".to_string());
+    before.textarea.set_cursor("héllo".len());
+    let mut after = composer();
+    after.restore_draft(before.take_draft());
+    after.insert_str(" brave");
+    assert_eq!(after.current_text(), "héllo brave world");
+    after.textarea.undo();
+    assert_eq!(after.current_text(), "héllo world");
+    after.textarea.undo();
+    assert_eq!(after.current_text(), "");
+}
+
+#[test]
+fn handoff_preserves_vim_normal_mode() {
+    use crate::bottom_pane::textarea::VimModeState;
+
+    let mut before = composer();
+    before.set_vim_mode(nori_config::VimEnterBehavior::Submit);
+    before.insert_str("draft");
+    before.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+    let mut after = composer();
+    after.set_vim_mode(nori_config::VimEnterBehavior::Submit);
+    after.restore_draft(before.take_draft());
+    assert_eq!(after.vim_mode_state(), VimModeState::Normal);
+    after.handle_key_event(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+    assert_eq!(after.current_text(), "draf");
+    after.handle_key_event(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::NONE));
+    assert_eq!(after.current_text(), "draft");
+}
+
+#[test]
+fn handoff_preserves_shell_mode() {
+    let mut before = composer();
+    before.handle_paste("!echo".to_string());
+    let mut after = composer();
+    after.restore_draft(before.take_draft());
+    after.handle_paste(" hello".to_string());
+    assert_eq!(after.current_text(), "!echo hello");
+    let (result, _) = after.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    assert_eq!(result, InputResult::Submitted("!echo hello".to_string()));
+}
+
+#[test]
+fn handoff_preserves_large_paste_payload_and_attached_image() {
+    let mut before = composer();
+    let payload = "a".repeat(LARGE_PASTE_CHAR_THRESHOLD + 1);
+    let image = PathBuf::from("/tmp/draft.png");
+    before.handle_paste(payload.clone());
+    before.attach_image(image.clone(), 32, 16, "PNG");
+    let mut after = composer();
+    after.restore_draft(before.take_draft());
+    let (result, _) = after.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    assert_eq!(
+        result,
+        InputResult::Submitted(format!("{payload}[draft.png 32x16]"))
+    );
+    assert_eq!(after.take_recent_submission_images(), vec![image]);
+}
+
+#[test]
+fn handoff_preserves_atomic_placeholder_editing() {
+    let mut before = composer();
+    before.handle_paste("a".repeat(LARGE_PASTE_CHAR_THRESHOLD + 1));
+    let mut after = composer();
+    after.restore_draft(before.take_draft());
+    after.handle_key_event(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
+    assert_eq!(after.current_text(), "");
+}

--- a/nori-rs/tui/src/bottom_pane/chat_composer/tests/mod.rs
+++ b/nori-rs/tui/src/bottom_pane/chat_composer/tests/mod.rs
@@ -54,6 +54,7 @@ fn type_chars_humanlike(composer: &mut ChatComposer, chars: &[char]) {
     }
 }
 
+mod draft;
 mod part1;
 mod part2;
 mod part3;

--- a/nori-rs/tui/src/bottom_pane/mod.rs
+++ b/nori-rs/tui/src/bottom_pane/mod.rs
@@ -51,6 +51,7 @@ pub(crate) enum CancellationEvent {
 }
 
 pub(crate) use chat_composer::ChatComposer;
+pub(crate) use chat_composer::ComposerDraft;
 pub(crate) use chat_composer::InputResult;
 use nori_harness::custom_prompts::CustomPrompt;
 
@@ -307,9 +308,14 @@ impl BottomPane {
         self.composer.current_text()
     }
 
-    /// Force any in-flight paste burst into the composer text immediately.
-    pub(crate) fn flush_paste_burst(&mut self) {
-        self.composer.flush_paste_burst();
+    /// Move editing state out before replacing the widget.
+    pub(crate) fn take_composer_draft(&mut self) -> ComposerDraft {
+        self.composer.take_draft()
+    }
+
+    pub(crate) fn restore_composer_draft(&mut self, draft: ComposerDraft) {
+        self.composer.restore_draft(draft);
+        self.request_redraw();
     }
 
     /// Update the animated header shown to the left of the brackets in the

--- a/nori-rs/tui/src/chatwidget/helpers.rs
+++ b/nori-rs/tui/src/chatwidget/helpers.rs
@@ -209,11 +209,13 @@ impl ChatWidget {
         self.bottom_pane.composer_text()
     }
 
-    /// Force any in-flight paste burst into the composer text immediately, so a
-    /// session-activation handoff that reads `composer_text` does not drop input
-    /// typed while the burst was still buffering.
-    pub(crate) fn flush_paste_burst(&mut self) {
-        self.bottom_pane.flush_paste_burst();
+    /// Move the full edit, including buffered input, before replacing this widget.
+    pub(crate) fn take_composer_draft(&mut self) -> crate::bottom_pane::ComposerDraft {
+        self.bottom_pane.take_composer_draft()
+    }
+
+    pub(crate) fn restore_composer_draft(&mut self, draft: crate::bottom_pane::ComposerDraft) {
+        self.bottom_pane.restore_composer_draft(draft);
     }
 
     /// Returns the first prompt text for this session, used for transcript matching.
@@ -276,7 +278,8 @@ impl ChatWidget {
         self.bottom_pane.insert_str(text);
     }
 
-    /// Replace the composer content with the provided text and reset cursor.
+    /// Replace the composer content, placing the cursor at the end.
+    /// For widget handoffs, transfer a composer draft instead.
     pub(crate) fn set_composer_text(&mut self, text: String) {
         self.bottom_pane.set_composer_text(text);
     }

--- a/nori-rs/tui/src/chatwidget/tests/part10.rs
+++ b/nori-rs/tui/src/chatwidget/tests/part10.rs
@@ -114,7 +114,7 @@ fn follow_only_attachment_keeps_messages_in_the_composer_but_allows_agent_switch
 
     assert_eq!(
         chat.composer_text(),
-        "[follow-only-draft.png 32x16]This must stay local"
+        "This must stay local[follow-only-draft.png 32x16]"
     );
     assert!(
         std::iter::from_fn(|| rx.try_recv().ok())

--- a/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part10__follow_only_attachment_keeps_messages_in_the_composer_but_allows_agent_switching.snap
+++ b/nori-rs/tui/src/chatwidget/tests/snapshots/nori_tui__chatwidget__tests__part10__follow_only_attachment_keeps_messages_in_the_composer_but_allows_agent_switching.snap
@@ -1,6 +1,5 @@
 ---
 source: tui/src/chatwidget/tests/part10.rs
-assertion_line: 118
 expression: rendered
 ---
-› [follow-only-draft.png 32x16]This must stay local
+› This must stay local[follow-only-draft.png 32x16]


### PR DESCRIPTION
Automatic ACP activation can rebuild the composer between keystrokes: typing `draft message` can produce `raft messaged` when the handoff resets the cursor after the first character. This caused main's Linux CI failure after #626 even though the identical source tree passed PR CI.

Transfer an owned `ComposerDraft` across widget replacement, preserving cursor position, undo/Vim state, attachments, large-paste payloads, and buffered input with its original flush deadline. The shared text-replacement helper now clears stale buffered input and places the cursor at the end, so callers that prefill text get consistent editing behavior. Document the distinction between replacing text and transferring an edit.

Validation:
- A file-gated PTY regression reproduced `raft messaged` on the original binary and passes on the fixed binary.
- Eight helper regressions cover every split in the input, buffered characters, middle-of-text editing, undo/Vim state, shell mode, attachments, and atomic paste placeholders.
- Full `cargo test -p nori-tui`: 1,403 passed.
- Full `cargo test -p tui-pty-e2e`: 140 passed.
- `just fix -p nori-tui -p tui-pty-e2e` and `just fmt`.
- Real ElizACP/tmux smoke: type a draft, clear it with Ctrl-C, submit a prompt, and verify the agent response renders.
